### PR TITLE
Use duet headers for earlier duet detection in TXT

### DIFF
--- a/game/songparser-txt.cc
+++ b/game/songparser-txt.cc
@@ -80,6 +80,7 @@ bool SongParser::txtParseField(std::string const& line) {
 	else if (key == "VIDEOGAP") assign(m_song.videoGap, value);
 	else if (key == "PREVIEWSTART") assign(m_song.preview_start, value);
 	else if (key == "LANGUAGE") m_song.language= value.substr(value.find_first_not_of(" "));
+	else if (key == "DUETSINGERP2") m_song.insertVocalTrack(DUET_P2, VocalTrack(DUET_P2)); // Strong hint that this is a duet, so it will be readily displayed with two singers in browser and properly filtered
 	return true;
 }
 


### PR DESCRIPTION
This way songs are correctly displayed and filtered as duets from the start
