### PR TITLE
Add menu option to enable game controllers during band (karaoke) playing...

### DIFF
--- a/data/config/schema.xml
+++ b/data/config/schema.xml
@@ -62,6 +62,10 @@ to save the current settings to XML.
 		<short>Theme</short>
 		<long>Name of the theme to use.</long>
 	</entry>
+	<entry name="game/band_controllers_enabled" type="bool" value="false">
+		<short>Enable Controllers</short>
+		<long>Enable controllers during band (karaoke) song.</long>
+	</entry>
 	<entry name="game/keyboard_guitar" type="bool" value="true">
 		<short>Keyboard as guitar</short>
 		<long>Enable keyboard as guitar (Frets on Fire mode).</long>

--- a/game/screen_sing.cc
+++ b/game/screen_sing.cc
@@ -257,7 +257,7 @@ void ScreenSing::manageEvent(input::NavEvent const& event) {
 	}
 	// Only pause or esc opens the global menu (instruments have their own menus)
 	// TODO: This should probably check if the source is participating as an instrument or not rather than check for its type
-	if (event.source.isKeyboard() && (nav == input::NAV_PAUSE || nav == input::NAV_CANCEL) && !m_audio.isPaused() && !m_menu.isOpen()) {
+	if ((event.source.isKeyboard() || config["game/band_controllers_enabled"].b()) && (nav == input::NAV_PAUSE || nav == input::NAV_CANCEL) && !m_audio.isPaused() && !m_menu.isOpen()) {
 		m_menu.open();
 		m_audio.togglePause();
 	}


### PR DESCRIPTION
Hi, wrote a quick patch to allow users to quit a playing band (karaoke) song using a controller.

This enables the user to quit a playing song without a keyboard connected.

If it's OK, can you please pull.

Cheers, Ian
