### PR TITLE
Fix osx build script to work with macports libs

### DIFF
--- a/osx-utils/performous-app-build.sh
+++ b/osx-utils/performous-app-build.sh
@@ -30,11 +30,11 @@ ETCDIR="$RESDIR/etc"
 rm -rf "$TEMPDIR"
 mkdir -p "$TEMPDIR"
 
-rm -rd ./build
+rm -rf ./build
 mkdir build
 cd build
 
-cmake -DCMAKE_INSTALL_PREFIX=$TEMPDIR -DENABLE_TOOLS=OFF -DCMAKE_BUILD_TYPE=Debug -DCMAKE_VERBOSE_MAKEFILE=1 -DFreetype_INCLUDE_DIR=/opt/local/include/freetype2 -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 -DFontconfig_INCLUDE_DIR=/opt/local/include/fontconfig -DPng_INCLUDE_DIR=/opt/local/include/libpng -DAVCodec_INCLUDE_DIR=/opt/local/include/libavcodec -DGLEW_LIBRARY=/Library/Frameworks/GLEW.framework -DGLEW_INCLUDE_DIR=/Library/Frameworks/GLEW.framework/Headers -DOpenGL_GL_LIBRARY=/System/Library/Frameworks/OpenGL.framework -DOpenGL_GLU_LIBRARY=/System/Library/Frameworks/OpenGL.framework -DOpenGL_INCLUDE_DIR=/System/Library/Frameworks/OpenGL.framework/Headers -DAVFormat_INCLUDE_DIR=/opt/local/include/libavformat -DSWScale_INCLUDE_DIR=/opt/local/include/libswscale  -DSDL2_INCLUDE_DIR=/Library/Frameworks/SDL2.Framework/Headers -DSDL2_LIBRARY=/Library/Frameworks/SDL2.framework -DFreetype_INCLUDE_DIR=/opt/local/include/freetype2/ -DLibXML2_LIBRARY=/opt/local/lib/libxml2.dylib -DLibXML2_INCLUDE_DIR=/opt/local/include/libxml2 -DLibXML++Config_INCLUDE_DIR=/opt/local/lib/libxml++-2.6/include -DGettext_LIBRARY=/opt/local/lib/libgettextlib.dylib  -DGettext_INCLUDE_DIR=/opt/local/include/ -DGlibmmConfig_INCLUDE_DIR=/opt/local/lib/glibmm-2.4/include -DGlibConfig_INCLUDE_DIR=/opt/local/lib/glib-2.0/include -DCMAKE_C_COMPILER=/opt/local/bin/gcc-mp-4.8 -DCMAKE_CXX_COMPILER=/opt/local/bin/g++-mp-4.8 -DCMAKE_C_FLAGS="-arch x86_64" -DSHARE_INSTALL=Resources -DLOCALE_DIR=Resources/Locales -DCMAKE_CXX_FLAGS="-Wno-unused-function -Wno-unused-local-typedefs -Wno-ignored-qualifiers -lstdc++ -arch x86_64 -L/opt/local/lib -lintl -Wl,-framework -Wl,CoreFoundation,-headerpad_max_install_names" -DCMAKE_EXE_LINKER_FLAGS="-ldl -lstdc++ -arch x86_64" -DCMAKE_MODULE_LINKER_FLAGS="-ldl -lstdc++ -arch x86_64" -DCMAKE_OSX_ARCHITECTURES="x86_64" -DCMAKE_SHARED_LINKER_FLAGS="-ldl -lstdc++ -arch x86_64" -DCMAKE_STATIC_LINKER_FLAGS="-ldl -lstdc++ -arch x86_64" ../..
+cmake -DCMAKE_INSTALL_PREFIX=$TEMPDIR -DENABLE_TOOLS=OFF -DCMAKE_BUILD_TYPE=Debug -DCMAKE_VERBOSE_MAKEFILE=1 -DFreetype_INCLUDE_DIR=/opt/local/include/freetype2 -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 -DFontconfig_INCLUDE_DIR=/opt/local/include/fontconfig -DPng_INCLUDE_DIR=/opt/local/include/libpng -DAVCodec_INCLUDE_DIR=/opt/local/include/libavcodec -DOpenGL_GL_LIBRARY=/System/Library/Frameworks/OpenGL.framework -DOpenGL_GLU_LIBRARY=/System/Library/Frameworks/OpenGL.framework -DOpenGL_INCLUDE_DIR=/System/Library/Frameworks/OpenGL.framework/Headers -DAVFormat_INCLUDE_DIR=/opt/local/include/libavformat -DSWScale_INCLUDE_DIR=/opt/local/include/libswscale -DFreetype_INCLUDE_DIR=/opt/local/include/freetype2/ -DLibXML2_LIBRARY=/opt/local/lib/libxml2.dylib -DLibXML2_INCLUDE_DIR=/opt/local/include/libxml2 -DLibXML++Config_INCLUDE_DIR=/opt/local/lib/libxml++-2.6/include -DGettext_LIBRARY=/opt/local/lib/libgettextlib.dylib  -DGettext_INCLUDE_DIR=/opt/local/include/ -DGlibmmConfig_INCLUDE_DIR=/opt/local/lib/glibmm-2.4/include -DGlibConfig_INCLUDE_DIR=/opt/local/lib/glib-2.0/include -DCMAKE_C_COMPILER=/opt/local/bin/gcc-mp-4.8 -DCMAKE_CXX_COMPILER=/opt/local/bin/g++-mp-4.8 -DCMAKE_C_FLAGS="-arch x86_64" -DSHARE_INSTALL=Resources -DLOCALE_DIR=Resources/Locales -DCMAKE_CXX_FLAGS="-Wno-unused-function -Wno-unused-local-typedefs -Wno-ignored-qualifiers -lstdc++ -arch x86_64 -L/opt/local/lib -lintl -Wl,-framework -Wl,CoreFoundation,-headerpad_max_install_names" -DCMAKE_EXE_LINKER_FLAGS="-ldl -lstdc++ -arch x86_64" -DCMAKE_MODULE_LINKER_FLAGS="-ldl -lstdc++ -arch x86_64" -DCMAKE_OSX_ARCHITECTURES="x86_64" -DCMAKE_SHARED_LINKER_FLAGS="-ldl -lstdc++ -arch x86_64" -DCMAKE_STATIC_LINKER_FLAGS="-ldl -lstdc++ -arch x86_64" ../..
 make -j2 install
 
 # then create the rest of the app bundle
@@ -46,7 +46,6 @@ cp ../resources/performous.icns "$RESDIR"
 cp ../resources/Info.plist "$TEMPDIR"
 
 mkdir -p $FRAMEWORKDIR
-cp -R /Library/Frameworks/SDL2.framework "$FRAMEWORKDIR/SDL2.framework"
 mkdir -p $LIBDIR
 
 dylibbundler -od -b -x "$BINDIR/performous" -d "$LIBDIR" -p @executable_path/../Resources/lib/


### PR DESCRIPTION
Remove references to SDL2 and GLEW from cmake to let autodetection find
the libraries from macports. Remove copying SDL2 framework because
dylibbundler will handle that for us with macports lib.

Also change rm -rd to -rf, otherwise the script will fail if build dir
doesn't exist yet.
