### PR TITLE
More robust tempo handling in midi files.

### DIFF
--- a/game/midifile.cc
+++ b/game/midifile.cc
@@ -265,6 +265,8 @@ void MidiFileParser::add_tempo_change(uint32_t miditime, uint32_t tempo) {
 	if (tempochanges.empty()) {
 		if (miditime > 0) throw std::runtime_error("Invalid MIDI file (tempo not set at the beginning)");
 	} else {
+		// Ignore duplicate (identical) tempo changes.
+		if (tempochanges.back().miditime == miditime && tempochanges.back().value == tempo) return;
 		if (tempochanges.back().miditime >= miditime) throw std::runtime_error("Invalid MIDI file (unexpected tempo change)");
 	}
 #if MIDI_DEBUG_LEVEL > 2


### PR DESCRIPTION
Added a check to ignore multiple identical tempo changes in a midi file.

Theoretically, more than one tempo change can not occur at the exact same time. However, if there are multiple tempo changes at the exact same time _but with the same target tempo_ there is not really any reason to bail out.

I had some songs that were being ignored because of two identical tempo changes near the end of the song, these songs play just fine with this patch.
