### PR TITLE
fix imagemagick detection on Debian

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -8,26 +8,31 @@ include_directories(${Boost_INCLUDE_DIRS})
 # Find all the libs that don't require extra parameters
 
 if (APPLE)
-    foreach(lib LibXML++ Z Jpeg Tiff Png Freetype Z)
+	foreach(lib LibXML++ Z Jpeg Tiff Png Freetype Z)
 	find_package(${lib})
-    	if (${lib}_FOUND)
-	    	include_directories(${${lib}_INCLUDE_DIRS})
-		    add_definitions(${${lib}_DEFINITIONS})
-    	endif (${lib}_FOUND)
-    endforeach(lib)
+		if (${lib}_FOUND)
+		include_directories(${${lib}_INCLUDE_DIRS})
+			add_definitions(${${lib}_DEFINITIONS})
+		endif (${lib}_FOUND)
+	endforeach(lib)
 
-    # CMake cannot properly detect Magick++ on Mac the other way.
+# CMake cannot properly detect Magick++ on Mac the other way.
 
-    find_package(ImageMagick COMPONENTS Magick++)
-    include_directories(${ImageMagick_INCLUDE_DIRS})
+	find_package(ImageMagick COMPONENTS Magick++)
+	include_directories(${ImageMagick_INCLUDE_DIRS})
 else (APPLE)
-    foreach(lib LibXML++ Z Magick++ Jpeg Tiff Png Freetype Z)
-	    find_package(${lib})
-    	if (${lib}_FOUND)
-	    	include_directories(${${lib}_INCLUDE_DIRS})
-		    add_definitions(${${lib}_DEFINITIONS})
-    	endif (${lib}_FOUND)
-    endforeach(lib)
+	foreach(lib LibXML++ Z Jpeg Tiff Png Freetype Z)
+		find_package(${lib})
+		if (${lib}_FOUND)
+			include_directories(${${lib}_INCLUDE_DIRS})
+			add_definitions(${${lib}_DEFINITIONS})
+		endif (${lib}_FOUND)
+	endforeach(lib)
+
+	find_package(ImageMagick COMPONENTS Magick++)
+	find_package(PkgConfig)
+	PKG_CHECK_MODULES(IMAGEMAGICK Magick++ MagickWand MagickCore)
+	include_directories(${ImageMagick_INCLUDE_DIRS})
 endif (APPLE)
 
 # Set default compile flags for GCC


### PR DESCRIPTION
Currently the detection of Imagemagick libraries on Debian and probably other UNIX systems is broken. We need to do something similar here as we do already for APPLE. Try to detect whether the package ImageMagick with its component Magick++ exists but then also try to check with PkgConfig whether the library is installed in Multiarch directories like /usr/lib/x86_64_linux-gnu/ or /usr/lib/i386-linux-gnu/.

I can confirm this works for Debian, ImageMagick is detetected and the ss_extract and ss_cover_conv binaries are built again. I took the liberty to use TABS more consistently. The relevant part is

find_package(ImageMagick COMPONENTS Magick++)
find_package(PkgConfig)
PKG_CHECK_MODULES(IMAGEMAGICK Magick++ MagickWand MagickCore)

This shouldn't cause any build failures because these libraries are not required.
