### PR TITLE
Switch to epoxy

### DIFF
--- a/cmake/Modules/FindLibEpoxy.cmake
+++ b/cmake/Modules/FindLibEpoxy.cmake
@@ -1,0 +1,29 @@
+# - Try to find LibEpoxy
+# Once done, this will define
+#
+#  LibEpoxy_FOUND - system has LibEpoxy
+#  LibEpoxy_INCLUDE_DIRS - the LibEpoxy include directories
+#  LibEpoxy_LIBRARIES - link these to use LibEpoxy
+#
+# See documentation on how to write CMake scripts at
+# http://www.cmake.org/Wiki/CMake:How_To_Find_Libraries
+
+include(LibFindMacros)
+
+libfind_pkg_check_modules(LibEpoxy_PKGCONF epoxy)
+
+find_path(LibEpoxy_INCLUDE_DIR
+  NAMES epoxy/gl.h
+  PATHS ${LibEpoxy_PKGCONF_INCLUDE_DIRS}
+  PATH_SUFFIXES LibEpoxy
+)
+
+find_library(LibEpoxy_LIBRARY
+  NAMES epoxy
+  PATHS ${LibEpoxy_PKGCONF_LIBRARY_DIRS}
+)
+
+set(LibEpoxy_PROCESS_INCLUDES LibEpoxy_INCLUDE_DIR)
+set(LibEpoxy_PROCESS_LIBS LibEpoxy_LIBRARY)
+libfind_process(LibEpoxy)
+

--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -65,7 +65,7 @@ include_directories(${Boost_INCLUDE_DIRS})
 list(APPEND LIBS ${Boost_LIBRARIES})
 
 # Find all the libs that don't require extra parameters
-foreach(lib ${OUR_LIBS} SDL2 PangoCairo LibRSVG LibXML++ GLEW AVFormat AVResample SWScale OpenGL Z Jpeg Png PortAudio Fontconfig)
+foreach(lib ${OUR_LIBS} SDL2 PangoCairo LibRSVG LibXML++ LibEpoxy AVFormat AVResample SWScale OpenGL Z Jpeg Png PortAudio Fontconfig)
 	find_package(${lib} REQUIRED)
 	message(STATUS "${lib} includes: ${${lib}_INCLUDE_DIRS}")
 	include_directories(${${lib}_INCLUDE_DIRS})
@@ -133,7 +133,7 @@ if(WIN32)
 			OUTPUT_VARIABLE MXE_HACK_STRING
 		)
 		set(CMAKE_CXX_LINK_EXECUTABLE ${CMAKE_CXX_LINK_EXECUTABLE}${MXE_HACK_STRING})
-		add_definitions(-DBOOST_THREAD_USE_LIB -DGLEW_STATIC)
+		add_definitions(-DBOOST_THREAD_USE_LIB)
 	endif()
 	set(BIN_INSTALL .)  # Straight to Program Files/Performous with no bin subfolder.
 	set(SUBSYSTEM_WIN32 WIN32)

--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -65,7 +65,7 @@ include_directories(${Boost_INCLUDE_DIRS})
 list(APPEND LIBS ${Boost_LIBRARIES})
 
 # Find all the libs that don't require extra parameters
-foreach(lib ${OUR_LIBS} SDL2 PangoCairo LibRSVG LibXML++ LibEpoxy AVFormat AVResample SWScale OpenGL Z Jpeg Png PortAudio Fontconfig)
+foreach(lib ${OUR_LIBS} SDL2 PangoCairo LibRSVG LibXML++ LibEpoxy AVFormat AVResample SWScale Z Jpeg Png PortAudio Fontconfig)
 	find_package(${lib} REQUIRED)
 	message(STATUS "${lib} includes: ${${lib}_INCLUDE_DIRS}")
 	include_directories(${${lib}_INCLUDE_DIRS})

--- a/game/glmath.hh
+++ b/game/glmath.hh
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 #include <algorithm>
 #include <cmath>
 #include <iomanip>

--- a/game/glshader.hh
+++ b/game/glshader.hh
@@ -6,7 +6,7 @@
 #include <string>
 #include <map>
 #include <vector>
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 #include <boost/noncopyable.hpp>
 
 struct Uniform {

--- a/game/glutil.hh
+++ b/game/glutil.hh
@@ -3,7 +3,7 @@
 
 #include "color.hh"
 #include "glmath.hh"
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 #include <string>
 #include <iostream>
 #include <vector>

--- a/game/surface.cc
+++ b/game/surface.cc
@@ -186,8 +186,10 @@ void Surface::load(Bitmap const& bitmap) {
 	glerror.check("glTexParameterf");
 
 	// Anisotropy is potential trouble maker
-	if (GLEW_EXT_texture_filter_anisotropic) glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, 16.0f);
-	glerror.check("MAX_ANISOTROPY_EXT");
+	if (epoxy_has_gl_extension("GL_EXT_texture_filter_anisotropic")) {
+		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, 16.0f);
+		glerror.check("MAX_ANISOTROPY_EXT");
+	}
 
 	// Load the data into texture
 	PixFmt const& f = getPixFmt(bitmap.fmt);

--- a/win32/mxe/settings.mk
+++ b/win32/mxe/settings.mk
@@ -1,5 +1,5 @@
 JOBS := 1
 MXE_TARGETS :=  i686-w64-mingw32.shared
-LOCAL_PKG_LIST := gettext sdl sdl2 boost portaudio ffmpeg portmidi pango gdk-pixbuf librsvg libsigc++ libxml++ glew libcdio opencv
+LOCAL_PKG_LIST := gettext sdl sdl2 boost portaudio ffmpeg portmidi pango gdk-pixbuf librsvg libsigc++ libxml++ glew libcdio opencv libepoxy
 .DEFAULT local-pkg-list:
 local-pkg-list: $(LOCAL_PKG_LIST)


### PR DESCRIPTION
This replaces GLEW with libepoxy (https://github.com/anholt/libepoxy#why-not-use-libglew).

This was quite simple and I think startup is faster :+1: 

Reasons why we want libepoxy over GLEW: Basically everything on https://github.com/anholt/libepoxy#why-not-use-libglew - which means for us:
- Easier to port to OpenGL ES and EGL (Android, Raspberry Pi, Wayland, etc.)
- Support for newer OpenGL extensions(?)
- Faster startup ;)

Platform support of libepoxy:
- MXE: Pending addition
- Debian: In jessie, so in stable in about 1-3 months
- Ubuntu: Included since Trusty (14.04)
- Mac OS X: Not in homebrew :-1: 
- Fedora: Since F20

PS: Should I remove now unused cmake Find modules?