### PR TITLE
Mingw build fix

### DIFF
--- a/game/guitargraph.cc
+++ b/game/guitargraph.cc
@@ -1166,7 +1166,7 @@ void GuitarGraph::updateChords() {
 		// Quit processing if none were left
 		if (t == getInf()) break;
 		// Construct a chord
-		Chord c;
+		GuitarChord c;
 		c.begin = t;
 		int tapfret = -1;
 		for (unsigned fret = 0; fret < m_pads; ++fret) {

--- a/game/guitargraph.hh
+++ b/game/guitargraph.hh
@@ -7,7 +7,7 @@
 
 class Song;
 
-struct Chord {
+struct GuitarChord {
 	double begin, end;
 	bool fret[5];
 	bool fret_cymbal[5];
@@ -19,7 +19,7 @@ struct Chord {
 	int score;
 	AnimValue hitAnim[5];
 	double releaseTimes[5];
-	Chord(): begin(), end(), polyphony(), tappable(), passed(), status(), score() {
+	GuitarChord(): begin(), end(), polyphony(), tappable(), passed(), status(), score() {
 		std::fill(fret, fret + 5, false);
 		std::fill(fret_cymbal, fret_cymbal + 5, false);
 		std::fill(dur, dur + 5, static_cast<Duration const*>(NULL));
@@ -39,7 +39,7 @@ struct Chord {
 	}
 };
 
-static inline bool operator==(Chord const& a, Chord const& b) {
+static inline bool operator==(GuitarChord const& a, GuitarChord const& b) {
 	return std::equal(a.fret, a.fret + 5, b.fret);
 }
 
@@ -132,7 +132,7 @@ class GuitarGraph: public InstrumentGraph {
 	void updateChords();
 	bool updateTom(unsigned int tomTrack, unsigned int fretId); // returns true if this tom track exists
 	double getNotesBeginTime() const { return m_chords.front().begin; }
-	typedef std::vector<Chord> Chords;
+	typedef std::vector<GuitarChord> Chords;
 	Chords m_chords;
 	Chords::iterator m_chordIt;
 	typedef std::map<Duration const*, unsigned> NoteStatus; // Note in song to m_events[unsigned - 1] or 0 for not played

--- a/game/menu.cc
+++ b/game/menu.cc
@@ -74,7 +74,7 @@ void Menu::action(int dir) {
 			else gm->activateScreen(screen);
 			break;
 		}
-		case MenuOption::CALLBACK: {
+		case MenuOption::CALLBACK_FUNCTION: {
 			if (current().callback) current().callback();
 			break;
 		}

--- a/game/menu.hh
+++ b/game/menu.hh
@@ -20,7 +20,7 @@ typedef boost::shared_ptr<Surface> MenuImage;
 /// Struct for menu options
 class MenuOption {
 public:
-	enum Type { CLOSE_SUBMENU, OPEN_SUBMENU, CHANGE_VALUE, SET_AND_CLOSE, ACTIVATE_SCREEN, CALLBACK } type;
+	enum Type { CLOSE_SUBMENU, OPEN_SUBMENU, CHANGE_VALUE, SET_AND_CLOSE, ACTIVATE_SCREEN, CALLBACK_FUNCTION } type;
 
 	/// Construct a menu option. Default function is to close the menu.
 	/// @param nm Name (menu item title)
@@ -37,7 +37,7 @@ public:
 	/// Make the option activate a screeen
 	MenuOption& screen(std::string const& scrn) { type = ACTIVATE_SCREEN; newValue = scrn; return *this; }
 	/// Make the option call a callback
-	MenuOption& call(MenuOptionCallback f) { type = CALLBACK; callback = f; return *this; }
+	MenuOption& call(MenuOptionCallback f) { type = CALLBACK_FUNCTION; callback = f; return *this; }
 	/// Sets name to follow a reference
 	MenuOption& setDynamicName(std::string& nm) { namePtr = &nm; return *this; }
 	/// Sets comment to follow a reference


### PR DESCRIPTION
Recently, building with MXE fails, because of name conflicts. I really don't know why this only surfaced recently:

* CALLBACK is a define deep in some windows includes, so you eventually get bitten by it
* Chord is an age-old Windows GDI function, don't know why this didn't triggered earlier (https://technet.microsoft.com/en-us/scriptcenter/dd183428%28v=vs.105%29.aspx)

I just renamed the symbols, there might be a better way (namespaces?) - Any thoughts?