### PR TITLE
Path to libboost_thread_win32-mt.dll fixed ~Windows Build

### DIFF
--- a/win32/mxe/make-performous.sh
+++ b/win32/mxe/make-performous.sh
@@ -7,6 +7,6 @@ mkdir -p stage
 cd build
 cmake ../../.. -DPKG_CONFIG_EXECUTABLE="$MXE_PREFIX/usr/bin/$MXE_TARGET-pkg-config" \
   -DCMAKE_TOOLCHAIN_FILE="$MXE_PREFIX/usr/$MXE_TARGET/share/cmake/mxe-conf.cmake" \
-  -DBoost_THREAD_LIBRARY_RELEASE="$MXE_PREFIX/usr/$MXE_TARGET/lib/libboost_thread_win32-mt.dll" \
+  -DBoost_THREAD_LIBRARY_RELEASE="$MXE_PREFIX/usr/$MXE_TARGET/bin/libboost_thread_win32-mt.dll" \
   -DENABLE_WEBCAM=OFF -DCMAKE_INSTALL_PREFIX="$here/stage"
 make install


### PR DESCRIPTION
When running make-performous.sh it was looking in the wrong folder. Changed it to look into the right folder where the file actually exists