### PR TITLE
Fix font loading

### DIFF
--- a/game/fs.cc
+++ b/game/fs.cc
@@ -226,11 +226,14 @@ fs::path findFile(fs::path const& filename) {
 }
 
 Paths listFiles(fs::path const& dir) {
-	if (dir.is_absolute()) throw std::logic_error("findFile expects a folder name without path.");
+	if (dir.is_absolute()) throw std::logic_error("listFiles expects a folder name without path.");
 	std::set<fs::path> found;  // Filenames already found
 	Paths files;  // Full paths of files found
 	for (fs::path path: getThemePaths()) {
-		for (fs::recursive_directory_iterator dirIt(path), dirEnd; dirIt != dirEnd; ++dirIt) {
+		fs::path subdir = path / dir;
+		if (!fs::is_directory(subdir))
+			continue;
+		for (fs::recursive_directory_iterator dirIt(subdir), dirEnd; dirIt != dirEnd; ++dirIt) {
 			fs::path name = dirIt->path().filename();  // FIXME: Extract full path from current folder, not just the filename
 			// If successfully inserted to "found", it wasn't found before, so add to paths.
 			if (found.insert(name).second) files.push_back(*dirIt);

--- a/game/main.cc
+++ b/game/main.cc
@@ -144,6 +144,7 @@ void mainLoop(std::string const& songlist) {
 	Backgrounds backgrounds;
 	Database database(getConfigDir() / "database.xml");
 	Songs songs(database, songlist);
+	loadFonts();
 	Game gm(window);
 	try {
 		// Load audio samples

--- a/game/opengl_text.cc
+++ b/game/opengl_text.cc
@@ -159,7 +159,12 @@ namespace {
 		while (std::getline(iss, token, ';')) {
 			std::istringstream iss2(token);
 			std::getline(iss2, token, ':');
-			if (token == "font-size") iss2 >> _theme.fontsize;
+			if (token == "font-size") {
+				// Parse as int because https://llvm.org/bugs/show_bug.cgi?id=17782
+				int value;
+				iss2 >> value;
+				_theme.fontsize = value;
+			}
 			else if (token == "font-family") std::getline(iss2, _theme.fontfamily);
 			else if (token == "font-style") std::getline(iss2, _theme.fontstyle);
 			else if (token == "font-weight") std::getline(iss2, _theme.fontweight);

--- a/game/opengl_text.cc
+++ b/game/opengl_text.cc
@@ -9,6 +9,17 @@
 #include <sstream>
 #include "fs.hh"
 
+void loadFonts() {
+	/* Disabled on Windows due to not working and producing weird cache directory in the wrong place
+#ifndef _WIN32
+	FcConfig *config = FcInitLoadConfigAndFonts();
+	for (fs::path const& font: listFiles("fonts")) {
+		FcConfigAppFontAddFile(config, reinterpret_cast<const FcChar8*>(font.string().c_str()));
+	}
+	FcConfigSetCurrent(config);
+#endif
+*/
+}
 
 namespace {
 	PangoAlignment parseAlignment(std::string const& fontalign) {

--- a/game/opengl_text.cc
+++ b/game/opengl_text.cc
@@ -60,7 +60,7 @@ OpenGLText::OpenGLText(TextStyle& _text, double m) {
 	m *= 2.0;  // HACK to improve text quality without affecting compatibility with old versions
 	// Setup font settings
 	PangoAlignment alignment = parseAlignment(_text.fontalign);
-	boost::shared_ptr<PangoFontDescription> desc(
+	std::shared_ptr<PangoFontDescription> desc(
 	  pango_font_description_new(),
 	  pango_font_description_free);
 	pango_font_description_set_weight(desc.get(), parseWeight(_text.fontweight));
@@ -69,10 +69,10 @@ OpenGLText::OpenGLText(TextStyle& _text, double m) {
 	pango_font_description_set_absolute_size(desc.get(), _text.fontsize * PANGO_SCALE * m);
 	double border = _text.stroke_width * m;
 	// Setup Pango context and layout
-	boost::shared_ptr<PangoContext> ctx(
+	std::shared_ptr<PangoContext> ctx(
 	  pango_font_map_create_context(pango_cairo_font_map_get_default()),
 	  g_object_unref);
-	boost::shared_ptr<PangoLayout> layout(
+	std::shared_ptr<PangoLayout> layout(
 	  pango_layout_new(ctx.get()),
 	  g_object_unref);
 	pango_layout_set_alignment(layout.get(), alignment);
@@ -88,10 +88,10 @@ OpenGLText::OpenGLText(TextStyle& _text, double m) {
 		m_y_advance = rec1.y;
 	}
 	// Create Cairo surface and drawing context
-	boost::shared_ptr<cairo_surface_t> surface(
+	std::shared_ptr<cairo_surface_t> surface(
 	  cairo_image_surface_create(CAIRO_FORMAT_ARGB32, m_x, m_y),
 	  cairo_surface_destroy);
-	boost::shared_ptr<cairo_t> dc(
+	std::shared_ptr<cairo_t> dc(
 	  cairo_create(surface.get()),
 	  cairo_destroy);
 	// Keep things sharp and fast, we scale with OpenGL anyway...

--- a/game/opengl_text.cc
+++ b/game/opengl_text.cc
@@ -10,15 +10,12 @@
 #include "fs.hh"
 
 void loadFonts() {
-	/* Disabled on Windows due to not working and producing weird cache directory in the wrong place
-#ifndef _WIN32
 	FcConfig *config = FcInitLoadConfigAndFonts();
 	for (fs::path const& font: listFiles("fonts")) {
-		FcConfigAppFontAddFile(config, reinterpret_cast<const FcChar8*>(font.string().c_str()));
+		FcBool err = FcConfigAppFontAddFile(config, reinterpret_cast<const FcChar8*>(font.string().c_str()));
+		std::clog << "font/info: Loading font " << font << ": " << ((err == FcTrue)?"ok":"error") << std::endl;
 	}
 	FcConfigSetCurrent(config);
-#endif
-*/
 }
 
 namespace {

--- a/game/opengl_text.cc
+++ b/game/opengl_text.cc
@@ -80,12 +80,10 @@ OpenGLText::OpenGLText(TextStyle& _text, double m) {
 	pango_layout_set_text(layout.get(), _text.text.c_str(), -1);
 	// Compute text extents
 	{
-		PangoRectangle rec1, rec2;
-		pango_layout_get_pixel_extents(layout.get(), &rec1, &rec2);
-		m_x = rec2.width + border;  // Add twice half a border for margins
-		m_y = rec2.height + border;
-		m_x_advance = rec1.x;
-		m_y_advance = rec1.y;
+		PangoRectangle rec;
+		pango_layout_get_pixel_extents(layout.get(), NULL, &rec);
+		m_x = rec.width + border;  // Add twice half a border for margins
+		m_y = rec.height + border;
 	}
 	// Create Cairo surface and drawing context
 	std::shared_ptr<cairo_surface_t> surface(
@@ -120,8 +118,6 @@ OpenGLText::OpenGLText(TextStyle& _text, double m) {
 	// We don't want text quality multiplier m to affect rendering size...
 	m_x /= m;
 	m_y /= m;
-	m_x_advance /= m;
-	m_y_advance /= m;
 }
 
 void OpenGLText::draw() {

--- a/game/opengl_text.hh
+++ b/game/opengl_text.hh
@@ -55,10 +55,6 @@ public:
 	double x() const { return m_x; }
 	/// @return y
 	double y() const { return m_y; }
-	/// @return x_advance
-	double x_advance() const { return m_x_advance; }
-	/// @return y_advance
-	double y_advance() const { return m_y_advance; }
 	/// @returns dimension of texture
 	Dimensions& dimensions() { return m_surface.dimensions; }
 


### PR DESCRIPTION
These fixes different font issues:

 - Restores loadFonts so all fonts from themes are loaded
 - Makes sure to use the freetype/fontconfig backend on all platforms (and not native rendering on Win32 and Mac OS X), so our "private" fonts are really used.
 - Fixes listFiles (which didn't do what it's docstring suggested)
 - Parse font-size from SVG CSS as integer instead of double, since the double parsing rules are bonkers.
 - Does some code cleanup and adds some logging to the font loading.