### PR TITLE
check for UTF8-BOM while guessing if type == TXT

### DIFF
--- a/game/songparser-txt.cc
+++ b/game/songparser-txt.cc
@@ -15,7 +15,11 @@ namespace {
 
 /// 'Magick' to check if this file looks like correct format
 bool SongParser::txtCheck(std::vector<char> const& data) const {
-	return data[0] == '#' && data[1] >= 'A' && data[1] <= 'Z';
+	if (data[0] == '#' && data[1] >= 'A' && data[1] <= 'Z') return true;
+	// ignore UTF-8 BOM while checking
+	else if (data[0] == '\xEF' && data[1] == '\xBB' && data[2] == '\xBF' &&
+				data[3] == '#' && data[4] >= 'A' && data[4] <= 'Z') return true;
+	else return false;
 }
 
 /// Parse header data for Songs screen


### PR DESCRIPTION
This patch fixes an issue where a TXT-song-file with UTF-8 BOM will be ignored, because the check (type == TXT) fails.

Now there is a dedicated check for the UTF-8 BOM while guessing the type.