### PR TITLE
Bunch of GL fixes

### DIFF
--- a/cmake/Modules/FindLibEpoxy.cmake
+++ b/cmake/Modules/FindLibEpoxy.cmake
@@ -25,5 +25,6 @@ find_library(LibEpoxy_LIBRARY
 
 set(LibEpoxy_PROCESS_INCLUDES LibEpoxy_INCLUDE_DIR)
 set(LibEpoxy_PROCESS_LIBS LibEpoxy_LIBRARY)
+set(LibEpoxy_VERSION ${LibEpoxy_PKGCONF_VERSION})
 libfind_process(LibEpoxy)
 

--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -64,8 +64,12 @@ find_package(Boost 1.36 REQUIRED COMPONENTS thread date_time program_options reg
 include_directories(${Boost_INCLUDE_DIRS})
 list(APPEND LIBS ${Boost_LIBRARIES})
 
+find_package(LibEpoxy 1.2 REQUIRED)
+include_directories(${LibEpoxy_INCLUDE_DIRS})
+list(APPEND LIBS ${LibEpoxy_LIBRARIES})
+
 # Find all the libs that don't require extra parameters
-foreach(lib ${OUR_LIBS} SDL2 PangoCairo LibRSVG LibXML++ LibEpoxy AVFormat AVResample SWScale Z Jpeg Png PortAudio Fontconfig)
+foreach(lib ${OUR_LIBS} SDL2 PangoCairo LibRSVG LibXML++ AVFormat AVResample SWScale Z Jpeg Png PortAudio Fontconfig)
 	find_package(${lib} REQUIRED)
 	message(STATUS "${lib} includes: ${${lib}_INCLUDE_DIRS}")
 	include_directories(${${lib}_INCLUDE_DIRS})

--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -64,6 +64,8 @@ find_package(Boost 1.36 REQUIRED COMPONENTS thread date_time program_options reg
 include_directories(${Boost_INCLUDE_DIRS})
 list(APPEND LIBS ${Boost_LIBRARIES})
 
+# LibEpoxy < 1.2 crashes with binary drivers (nvidia & fglrx) when creating shaders
+# (see https://github.com/anholt/libepoxy/issues/23 for the exact problem)
 find_package(LibEpoxy 1.2 REQUIRED)
 include_directories(${LibEpoxy_INCLUDE_DIRS})
 list(APPEND LIBS ${LibEpoxy_LIBRARIES})

--- a/game/main.cc
+++ b/game/main.cc
@@ -410,3 +410,13 @@ void outputOptionalFeatureStatus() {
 	  << "\n  Webcam support:       " << (Webcam::enabled() ? "Enabled" : "Disabled")
 	  << std::endl;
 }
+
+#if defined(_WIN32)
+// Force high-performance graphics on dual-GPU systems
+extern "C" {
+	// http://developer.download.nvidia.com/devzone/devcenter/gamegraphics/files/OptimusRenderingPolicies.pdf
+	__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+	// https://community.amd.com/thread/169965
+	__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+}
+#endif

--- a/game/video_driver.cc
+++ b/game/video_driver.cc
@@ -93,7 +93,7 @@ Window::Window(unsigned int width, unsigned int height, bool fs): m_windowW(widt
 
 	if (epoxy_gl_version() < 21) throw std::runtime_error("OpenGL 2.1 is required but not available");
 
-	if (epoxy_gl_version() >= 33) {
+	if (epoxy_has_gl_extension("GL_ARB_viewport_array")) {
 		// Compile geometry shaders when stereo is requested
 		shader("color").compileFile(findFile("shaders/stereo3d.geom"));
 		shader("surface").compileFile(findFile("shaders/stereo3d.geom"));

--- a/game/video_driver.cc
+++ b/game/video_driver.cc
@@ -93,6 +93,8 @@ Window::Window(unsigned int width, unsigned int height, bool fs): m_windowW(widt
 
 	if (epoxy_gl_version() < 21) throw std::runtime_error("OpenGL 2.1 is required but not available");
 
+	// The Stereo3D shader needs OpenGL 3.3 and GL_ARB_viewport_array, some Intel drivers support GL 3.3,
+	// but not GL_ARB_viewport_array, so we just check for the extension here.
 	if (epoxy_has_gl_extension("GL_ARB_viewport_array")) {
 		// Compile geometry shaders when stereo is requested
 		shader("color").compileFile(findFile("shaders/stereo3d.geom"));


### PR DESCRIPTION
Some small GL fixes (mostly in respons to issues raised in #148):

- Check for GL extension for 3D stero shader instead of checking for the GL version. It seems some Intel cards say they are OpenGL 3.3 an still are missing this extension. The opposite should never happen (GL < 3.3 and support for this extension)
- This might be a bit controversial: Force high-performance GPU on dual-GPU-systems (Nvidia Optimus & AMD PowerExpress) - If anyone is interested, I can go into detail why I think this is a good idea.
- Do a compile check to only compile against libepoxy >= 1.2 - There is a nasty bug in libepoxy < 1.2 that makes Performous crash on Linux with nvidia or fglrx.