### PR TITLE
Songloading refactor

### DIFF
--- a/game/songparser-ini.cc
+++ b/game/songparser-ini.cc
@@ -11,7 +11,7 @@
 using namespace SongParserUtil;
 
 /// 'Magick' to check if this file looks like correct format
-bool SongParser::iniCheck(std::vector<char> const& data) const {
+bool SongParser::iniCheck(std::string const& data) const {
 	static const std::string header = "[song]";
 	return std::equal(header.begin(), header.end(), data.begin());
 }

--- a/game/songparser-sm.cc
+++ b/game/songparser-sm.cc
@@ -11,7 +11,7 @@
 using namespace SongParserUtil;
 
 /// 'Magick' to check if this file looks like correct format
-bool SongParser::smCheck(std::vector<char> const& data) const {
+bool SongParser::smCheck(std::string const& data) const {
 	if (data[0] != '#' || data[1] < 'A' || data[1] > 'Z') return false;
 	for (char ch: data) {
 		if (ch == '\n') return false;

--- a/game/songparser-txt.cc
+++ b/game/songparser-txt.cc
@@ -14,7 +14,7 @@ namespace {
 }
 
 /// 'Magick' to check if this file looks like correct format
-bool SongParser::txtCheck(std::vector<char> const& data) const {
+bool SongParser::txtCheck(std::string const& data) const {
 	return data[0] == '#' && data[1] >= 'A' && data[1] <= 'Z';
 }
 

--- a/game/songparser-xml.cc
+++ b/game/songparser-xml.cc
@@ -11,7 +11,7 @@
 using namespace SongParserUtil;
 
 /// 'Magick' to check if this file looks like correct format
-bool SongParser::xmlCheck(std::vector<char> const& data) const {
+bool SongParser::xmlCheck(std::string const& data) const {
 	static const std::string header = "<?";
 	return std::equal(header.begin(), header.end(), data.begin());
 }
@@ -33,18 +33,13 @@ struct SSDom: public xmlpp::DomParser {
 	}
 	void load(std::string const& buf) {
 		set_substitute_entities();
-		try {
-			/*
-			struct DisableLogger {
-				DisableLogger() { disableXMLLogger(); }
-				~DisableLogger() { enableXMLLogger(); }
-			} disabler;
-			*/
-			parse_memory(buf);
-		} catch (...) {
-			std::string buf2 = Glib::convert(buf, "UTF-8", "ISO-8859-1"); // Convert to UTF-8
-			parse_memory(buf2);
-		}
+		/*
+		struct DisableLogger {
+			DisableLogger() { disableXMLLogger(); }
+			~DisableLogger() { enableXMLLogger(); }
+		} disabler;
+		*/
+		parse_memory(buf);
 		nsmap["ss"] = get_document()->get_root_node()->get_namespace_uri();
 	}
 	bool find(xmlpp::Element const& elem, std::string xpath, xmlpp::NodeSet& n) {

--- a/game/songparser.cc
+++ b/game/songparser.cc
@@ -58,21 +58,18 @@ SongParser::SongParser(Song& s) try:
 	{
 		fs::ifstream f(s.filename, std::ios::binary);
 		if (!f.is_open()) throw SongParserException(s, "Could not open song file", 0);
-		f.seekg(0, std::ios::end);
-		size_t size = f.tellg();
+		m_ss << f.rdbuf();
+		int size = m_ss.str().length();
 		if (size < 10 || size > 100000) throw SongParserException(s, "Does not look like a song file (wrong size)", 1, true);
-		f.seekg(0);
-		std::vector<char> data(size);
-		if (!f.read(&data[0], size)) throw SongParserException(s, "Unexpected I/O error", 0);
-		if (smCheck(data)) type = SM;
-		else if (txtCheck(data)) type = TXT;
-		else if (iniCheck(data)) type = INI;
-		else if (xmlCheck(data)) type = XML;
+		// Convert m_ss; filename supplied for possible warning messages
+		convertToUTF8(m_ss, s.filename.string());
+
+		if (smCheck(m_ss.str())) type = SM;
+		else if (txtCheck(m_ss.str())) type = TXT;
+		else if (iniCheck(m_ss.str())) type = INI;
+		else if (xmlCheck(m_ss.str())) type = XML;
 		else throw SongParserException(s, "Does not look like a song file (wrong header)", 1, true);
-		m_ss.write(&data[0], size);
 	}
-	// Convert m_ss; filename supplied for possible warning messages
-	convertToUTF8(m_ss, s.filename.string());
 	// Header already parsed?
 	if (s.loadStatus == Song::HEADER) {
 		if (type == TXT) txtParse();

--- a/game/songparser.hh
+++ b/game/songparser.hh
@@ -38,21 +38,21 @@ class SongParser {
 	double m_gap;
 	double m_bpm;
 
-	bool txtCheck(std::vector<char> const& data) const;
+	bool txtCheck(std::string const& data) const;
 	void txtParseHeader();
 	void txtParse();
 	bool txtParseField(std::string const& line);
 	bool txtParseNote(std::string line);
-	bool iniCheck(std::vector<char> const& data) const;
+	bool iniCheck(std::string const& data) const;
 	void iniParseHeader();
-	bool midCheck(std::vector<char> const& data) const;
+	bool midCheck(std::string const& data) const;
 	void midParseHeader();
 	void midParse();
-	bool xmlCheck(std::vector<char> const& data) const;
+	bool xmlCheck(std::string const& data) const;
 	void xmlParseHeader();
 	void xmlParse();
 	Note xmlParseNote(xmlpp::Element const& noteNode, unsigned& ts);
-	bool smCheck(std::vector<char> const& data) const;
+	bool smCheck(std::string const& data) const;
 	void smParseHeader();
 	void smParse();
 	bool smParseField(std::string line);

--- a/game/unicode.cc
+++ b/game/unicode.cc
@@ -8,9 +8,6 @@
 #include <stdexcept>
 
 namespace {
-	// Codepage choices from config
-	static const char* codesets[] = { "CP1250", "CP1251", "CP1252", "CP1253", "CP1254", "CP1255", "CP1256", "CP1257", "CP1258" };
-
 	// Convert a string using Glib, throw exception on error.
 	// This is in fact (slightly modified) Glib::convert from glibmm.
 	std::string convert(const std::string& str, const std::string& to_codeset, const std::string& from_codeset) {
@@ -37,7 +34,7 @@ void convertToUTF8(std::stringstream &_stream, std::string _filename) {
 			_stream.str(data.substr(3)); // Remove BOM if there is one
 		}
 	} catch(...) {
-		const char* codeset = codesets[config["game/fallback_encoding"].i()];
+		std::string codeset = config["game/fallback_encoding"].getEnumName();
 		if (!_filename.empty())
 			std::clog << "unicode/warning: " << _filename << " is not UTF-8.\n  Assuming " << codeset
 				<< ". Use recode " << codeset << "..UTF-8 */*.txt to convert your files." << std::endl;


### PR DESCRIPTION
Do some light refactoring of the song loading. This unifies the fallback encoding and BOM handling code, so detection should be correct across all text file formats that we support.

I'm currently doing a test build for Windows, to see if the last commit breaks anything, but I don't expect it. As far as I understand it, this is only a problem when combining libraries compiled with different runtimes (for example, compiling Performous with Visual Studio and linking against a glibmm compiled with GCC)