### PR TITLE
Make the build reproducible

### DIFF
--- a/game/main.cc
+++ b/game/main.cc
@@ -404,7 +404,6 @@ int main(int argc, char** argv) try {
 
 void outputOptionalFeatureStatus() {
 	std::clog << "core/notice: " PACKAGE " " VERSION " starting..."
-	  << "\n  Build date:           " __DATE__
 	  << "\n  Internationalization: " << (Gettext::enabled() ? "Enabled" : "Disabled")
 	  << "\n  MIDI Hardware I/O:    " << (input::Hardware::midiEnabled() ? "Enabled" : "Disabled")
 	  << "\n  Webcam support:       " << (Webcam::enabled() ? "Enabled" : "Disabled")


### PR DESCRIPTION
by removing the __DATE__ macro.

With free software, anyone can inspect the source code for malicious flaws. But Debian provides binary packages to its users. The idea of “deterministic” or “reproducible” builds is to empower anyone to verify that no flaws have been introduced during the build process by reproducing byte-for-byte identical binary packages from a given source. 

This has a lot of advantages which are best described at

https://wiki.debian.org/ReproducibleBuilds/About

I think having reproducible builds outweighs the informational character of the build date value.