### PR TITLE
ffmpeg2.9 transition

### DIFF
--- a/game/ffmpeg.cc
+++ b/game/ffmpeg.cc
@@ -116,7 +116,7 @@ void FFmpeg::open() {
 		height = cc->height;
 		m_swsContext = sws_getContext(
 		  cc->width, cc->height, cc->pix_fmt,
-		  width, height, PIX_FMT_RGB24,
+		  width, height, AV_PIX_FMT_RGB24,
 		  SWS_POINT, nullptr, nullptr, nullptr);
 		break;
 	default:  // Should never be reached but avoids compile warnings


### PR DESCRIPTION
This commit replaces deprecated ffmpeg 2.8 functionality which will be removed
in 2.9 and will thus cause a build failure. The patch works with 2.8 and 2.9.

This is Debian bug https://bugs.debian.org/803853

Patch was provided by Andreas Cadhalpun