### PR TITLE
Add picks for controller GUITAR_GUITARHERO5

### DIFF
--- a/data/config/controllers.xml
+++ b/data/config/controllers.xml
@@ -84,6 +84,7 @@
 				<axis hw="2" positive="whammy" />
 				<axis hw="4" negative="left" positive="right" />
 				<axis hw="5" negative="up" positive="down" />
+				<hat hw="0" up="pick_up" down="pick_down" />
 			</mapping>
 		</controller>
 		<controller type="guitar" name="GUITAR_GUITARHERO_XPLORER">


### PR DESCRIPTION
I own this hardware and pick was reported as:
<hat hw="0" up="pick_up" down="pick_down" />

Before no pick was configured, but adding that to controllers.xml made pick work. Thank you.