### PR TITLE
Add pick for GUITAR_GUITARHERO_XPLORER

### DIFF
--- a/data/config/controllers.xml
+++ b/data/config/controllers.xml
@@ -98,11 +98,12 @@
 				<button hw="4" map="orange" />
 				<button hw="6" map="cancel" />
 				<button hw="7" map="start" />
+				<hat hw="0" up="pick_up" down="pick_down" />
 				<axis hw="1" negative="pick_up" positive="pick_down"/>
 				<axis hw="2" map="whammy" />
 				<axis hw="3" map="godmode"/>
-				<axis hw="4" negative="left" positive="right" />
-				<axis hw="5" negative="up" positive="down" />
+				<!--<axis hw="4" negative="left" positive="right" />-->
+				<!--<axis hw="5" negative="up" positive="down" />-->
 			</mapping>
 		</controller>
 		<controller type="guitar" name="GUITAR_ROCKBAND_XBOX360">


### PR DESCRIPTION
I own this guitar too, and pick is register as:

hat hw="0" up="pick_up" down="pick_down"

Also hw="4" and hw="5" are very problematic for menu and song navigation. Both are motion sensor and are very sensitive. I tried to calibrate the controller using jstest-gtk but I was getting the same results. Every time I started the game it was impossible to move through the menu or the songs because the cursor started jumping all over the place.

axis hw="5" could be use for godmode but it is very inaccurate too. I suggest just disable them all along, since the D-pad and the pick can be use to navigate the menus and the songs anyway. If I found any other axis that can be use for godmod I let you know.