### PR TITLE
Playlist duration

### DIFF
--- a/data/themes/default/index.html
+++ b/data/themes/default/index.html
@@ -260,7 +260,7 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#feffff', end
 				}
 				var minutestxt = ("00"+minutes).slice(-2);
 				if (minutes >= 100) {
-				("000"+minutes).slice(-3)
+				minutestxt = ("000"+minutes).slice(-3)
 					
 				}
 				$('#playListView').append('<li data-theme="c" data-icon="info"><a href="javascript:ViewInfo(' + i + ')" data-transition="slide"> #' + count + ' ' + songlist[i].Artist + ' - ' + songlist[i].Title + '      +' + minutestxt + ':' + ("0"+sec).slice(-2) + '</a></li>\n');

--- a/data/themes/default/index.html
+++ b/data/themes/default/index.html
@@ -258,7 +258,12 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#feffff', end
 					minutes++;
 					sec -=60;				
 				}
-				$('#playListView').append('<li data-theme="c" data-icon="info"><a href="javascript:ViewInfo(' + i + ')" data-transition="slide"> #' + count + ' ' + songlist[i].Artist + ' - ' + songlist[i].Title + '      +' + ("00"+minutes).slice(-2) + ':' + ("0"+sec).slice(-2) + '</a></li>\n');
+				var minutestxt = ("00"+minutes).slice(-2);
+				if (minutes >= 100) {
+				("000"+minutes).slice(-3)
+					
+				}
+				$('#playListView').append('<li data-theme="c" data-icon="info"><a href="javascript:ViewInfo(' + i + ')" data-transition="slide"> #' + count + ' ' + songlist[i].Artist + ' - ' + songlist[i].Title + '      +' + minutestxt + ':' + ("0"+sec).slice(-2) + '</a></li>\n');
 				totalduration += songlist[i].Duration + 15;
 			}
 			$('#playListView').listview('refresh');

--- a/data/themes/default/index.html
+++ b/data/themes/default/index.html
@@ -49,6 +49,8 @@ th {border: 1px solid #456f9a;
     filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#feffff', endColorstr='#a8aac1',GradientType=1 ); /* IE6-9 fallback on horizontal gradient */}
 a.ui-btn-active.ui-state-persist.ui-btn.ui-btn-inline.ui-btn-icon-top.ui-btn-up-a {
     margin-right: 0px; /*Fixing the 4 pixel side scrolling bug*/}    
+table#songtable {
+    width: 100%;/*Fix table width*/}
 </style>
 <!-- Home -->
 <div data-role="page" id="page1">

--- a/data/themes/default/index.html
+++ b/data/themes/default/index.html
@@ -207,6 +207,7 @@ table#songtable {
 	var invertedsort = false;
 	var database = {};
 	var songlist = {};
+	var playlistScreenTimeout = 0;
 	
 
 
@@ -277,6 +278,9 @@ table#songtable {
 	function RefreshPlayList() {
 		$.get("api/getCurrentPlaylist.json", function(data){
 		songlist = JSON.parse(data);
+		if(playlistScreenTimeout == 0) {
+			$.get("/api/getplaylistTimeout", playlistScreenTimeout);
+		}
 		$('#playListView').html('<li data-role="list-divider" role="heading">Upcoming songs:</li><li data-theme="c">\n');
 			var totalduration = 0;
 			for (i in songlist) {
@@ -292,7 +296,7 @@ table#songtable {
 				minutestxt = ("000"+minutes).slice(-3);	
 				}
 				$('#playListView').append('<li data-theme="c" data-icon="info"><a href="javascript:ViewInfo(' + i + ')" data-transition="slide"> #' + count + ' ' + songlist[i].Artist + ' - ' + songlist[i].Title + '      +' + minutestxt + ':' + ("0"+sec).slice(-2) + '</a></li>\n');
-				totalduration += songlist[i].Duration + 15;
+				totalduration += songlist[i].Duration + playlistScreenTimeout;
 			}
 			$('#playListView').listview('refresh');
 		});

--- a/data/themes/default/index.html
+++ b/data/themes/default/index.html
@@ -289,7 +289,7 @@ table#songtable {
 				}
 				var minutestxt = ("00"+minutes).slice(-2);
 				if (minutes >= 100) {
-				minutestxt = ("000"+minutes).slice(-3)			
+				minutestxt = ("000"+minutes).slice(-3);	
 				}
 				$('#playListView').append('<li data-theme="c" data-icon="info"><a href="javascript:ViewInfo(' + i + ')" data-transition="slide"> #' + count + ' ' + songlist[i].Artist + ' - ' + songlist[i].Title + '      +' + minutestxt + ':' + ("0"+sec).slice(-2) + '</a></li>\n');
 				totalduration += songlist[i].Duration + 15;

--- a/data/themes/default/index.html
+++ b/data/themes/default/index.html
@@ -206,6 +206,7 @@ table#songtable {
 	var update = false;
 	var invertedsort = false;
 	var database = {};
+	var AutocompleteList = {};
 	var songlist = {};
 	var playlistScreenTimeout = 0;
 	
@@ -263,10 +264,17 @@ table#songtable {
     });
 	}
 	
-	function AddSong(number) {
-		$.post("api/add", JSON.stringify(database[number]));
+	function AddSong(number, autocomplete) {
+		if(autocomplete) {
+			$.post("api/add", JSON.stringify(AutocompleteList[number]));
+			$('#searchv2').val("added: " + AutocompleteList[number].Title); 
+		} else {
+			$.post("api/add", JSON.stringify(database[number]));
+			$('#searchv2').val("added: " + database[number].Title); 
+		}
+
 		RefreshPlayList();
-		$('#searchv2').val("added: " + database[number].Title); 
+		
 	}
 
 	<!-- Playlist -->
@@ -295,7 +303,7 @@ table#songtable {
 				if (minutes >= 100) {
 				minutestxt = ("000"+minutes).slice(-3);	
 				}
-				$('#playListView').append('<li data-theme="c" data-icon="info"><a href="javascript:ViewInfo(' + i + ')" data-transition="slide"> #' + count + ' ' + songlist[i].Artist + ' - ' + songlist[i].Title + '      +' + minutestxt + ':' + ("0"+sec).slice(-2) + '</a></li>\n');
+				$('#playListView').append('<li data-theme="c" data-icon="info"><a href="javascript:ViewInfo(' + i + ', false)" data-transition="slide"> #' + count + ' ' + songlist[i].Artist + ' - ' + songlist[i].Title + '      +' + minutestxt + ':' + ("0"+sec).slice(-2) + '</a></li>\n');
 				totalduration += songlist[i].Duration + playlistScreenTimeout;
 			}
 			$('#playListView').listview('refresh');
@@ -383,11 +391,11 @@ $(document).keypress(function(e) {
 		if ( value && value.length > 2 ) {
 			$("#autocomplete").show();
 			results = $.post("api/autocomplete",$input.val(), function (data) {
-				database = JSON.parse(data);
+				AutocompleteList = JSON.parse(data);
 				$ul.html("<li><div class='ui-loader'><span class='ui-icon ui-icon-loading'></span></div></li>");
-					for (i in database) {
+					for (i in AutocompleteList) {
 					var count = parseInt(i,10) + parseInt(1,10);
-					html += '<li data-theme="c" data-icon="info"><a href="javascript:AddSong(' + i + ')" data-transition="slide">' + ' ' + database[i].Artist + ' - ' + database[i].Title + '</a></li>\n';
+					html += '<li data-theme="c" data-icon="info"><a href="javascript:AddSong(' + i + ',true)" data-transition="slide">' + ' ' + AutocompleteList[i].Artist + ' - ' + AutocompleteList[i].Title + '</a></li>\n';
 				}
 				$ul.html( html );
 				$ul.listview("refresh");

--- a/data/themes/default/index.html
+++ b/data/themes/default/index.html
@@ -289,8 +289,7 @@ table#songtable {
 				}
 				var minutestxt = ("00"+minutes).slice(-2);
 				if (minutes >= 100) {
-				minutestxt = ("000"+minutes).slice(-3)
-					
+				minutestxt = ("000"+minutes).slice(-3)			
 				}
 				$('#playListView').append('<li data-theme="c" data-icon="info"><a href="javascript:ViewInfo(' + i + ')" data-transition="slide"> #' + count + ' ' + songlist[i].Artist + ' - ' + songlist[i].Title + '      +' + minutestxt + ':' + ("0"+sec).slice(-2) + '</a></li>\n');
 				totalduration += songlist[i].Duration + 15;

--- a/data/themes/default/index.html
+++ b/data/themes/default/index.html
@@ -37,16 +37,18 @@ th {border: 1px solid #456f9a;
     background-image: -moz-linear-gradient(#6facd5,#497bae);
     background-image: -ms-linear-gradient(#6facd5,#497bae);
     background-image: -o-linear-gradient(#6facd5,#497bae);
-    background-image: linear-gradient(#6facd5,#497bae);}
+    background-image: linear-gradient(#6facd5,#497bae);
+    text-align: left;}
 .ui-page {background: #feffff; /* Old browsers */
-background: -moz-linear-gradient(-45deg, #feffff 0%, #ddf1f9 35%, #a8aac1 100%); /* FF3.6+ */
-background: -webkit-gradient(linear, left top, right bottom, color-stop(0%,#feffff), color-stop(35%,#ddf1f9), color-stop(100%,#a8aac1)); /* Chrome,Safari4+ */
-background: -webkit-linear-gradient(-45deg, #feffff 0%,#ddf1f9 35%,#a8aac1 100%); /* Chrome10+,Safari5.1+ */
-background: -o-linear-gradient(-45deg, #feffff 0%,#ddf1f9 35%,#a8aac1 100%); /* Opera 11.10+ */
-background: -ms-linear-gradient(-45deg, #feffff 0%,#ddf1f9 35%,#a8aac1 100%); /* IE10+ */
-background: linear-gradient(135deg, #feffff 0%,#ddf1f9 35%,#a8aac1 100%); /* W3C */
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#feffff', endColorstr='#a8aac1',GradientType=1 ); /* IE6-9 fallback on horizontal gradient */
-}
+    background: -moz-linear-gradient(-45deg, #feffff 0%, #ddf1f9 35%, #a8aac1 100%); /* FF3.6+ */
+    background: -webkit-gradient(linear, left top, right bottom, color-stop(0%,#feffff), color-stop(35%,#ddf1f9), color-stop(100%,#a8aac1)); /* Chrome,Safari4+ */
+    background: -webkit-linear-gradient(-45deg, #feffff 0%,#ddf1f9 35%,#a8aac1 100%); /* Chrome10+,Safari5.1+ */
+    background: -o-linear-gradient(-45deg, #feffff 0%,#ddf1f9 35%,#a8aac1 100%); /* Opera 11.10+ */
+    background: -ms-linear-gradient(-45deg, #feffff 0%,#ddf1f9 35%,#a8aac1 100%); /* IE10+ */
+    background: linear-gradient(135deg, #feffff 0%,#ddf1f9 35%,#a8aac1 100%); /* W3C */
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#feffff', endColorstr='#a8aac1',GradientType=1 ); /* IE6-9 fallback on horizontal gradient */}
+a.ui-btn-active.ui-state-persist.ui-btn.ui-btn-inline.ui-btn-icon-top.ui-btn-up-a {
+    margin-right: 0px; /*Fixing the 4 pixel side scrolling bug*/}    
 </style>
 <!-- Home -->
 <div data-role="page" id="page1">

--- a/data/themes/default/index.html
+++ b/data/themes/default/index.html
@@ -287,23 +287,37 @@ table#songtable {
 		$.get("api/getCurrentPlaylist.json", function(data){
 		songlist = JSON.parse(data);
 		if(playlistScreenTimeout == 0) {
-			$.get("/api/getplaylistTimeout", playlistScreenTimeout);
+		var timeout = "";
+		jQuery.ajaxSetup({async:false});
+			$.get("api/getplaylistTimeout",function (data) { 
+				playlistScreenTimeout = parseInt(data);
+
+			});
+		jQuery.ajaxSetup({async:true});
 		}
 		$('#playListView').html('<li data-role="list-divider" role="heading">Upcoming songs:</li><li data-theme="c">\n');
 			var totalduration = 0;
 			for (i in songlist) {
 				var count = parseInt(i,10) + parseInt(1,10);
+				var hours = 0;
 				var minutes = 0;
 				var sec = totalduration;
 				while (sec >= 60) {
 					minutes++;
 					sec -=60;				
 				}
-				var minutestxt = ("00"+minutes).slice(-2);
-				if (minutes >= 100) {
-				minutestxt = ("000"+minutes).slice(-3);	
+				while (minutes >= 60) {
+					hours++;
+					minutes -=60;				
 				}
-				$('#playListView').append('<li data-theme="c" data-icon="info"><a href="javascript:ViewInfo(' + i + ', false)" data-transition="slide"> #' + count + ' ' + songlist[i].Artist + ' - ' + songlist[i].Title + '      +' + minutestxt + ':' + ("0"+sec).slice(-2) + '</a></li>\n');
+				
+				var durationtext;
+				if (hours > 0) {
+					durationtext = ("00"+hours).slice(-2) + ':' + ("00"+minutes).slice(-2) + ':' + ("0"+sec).slice(-2);
+				} else {
+					durationtext = ("00"+minutes).slice(-2) + ':' + ("0"+sec).slice(-2);
+				}
+				$('#playListView').append('<li data-theme="c" data-icon="info"><a href="javascript:ViewInfo(' + i + ', false)" data-transition="slide"> #' + count + ' ' + songlist[i].Artist + ' - ' + songlist[i].Title + '      +' + durationtext + '</a></li>\n');
 				totalduration += songlist[i].Duration + playlistScreenTimeout;
 			}
 			$('#playListView').listview('refresh');

--- a/data/themes/default/index.html
+++ b/data/themes/default/index.html
@@ -249,9 +249,17 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#feffff', end
 		$.get("api/getCurrentPlaylist.json", function(data){
 		songlist = JSON.parse(data);
 		$('#playListView').html('<li data-role="list-divider" role="heading">Upcoming songs:</li><li data-theme="c">\n');
+			var totalduration = 0;
 			for (i in songlist) {
 				var count = parseInt(i,10) + parseInt(1,10);
-				$('#playListView').append('<li data-theme="c" data-icon="info"><a href="javascript:ViewInfo(' + i + ')" data-transition="slide"> #' + count + ' ' + songlist[i].Artist + ' - ' + songlist[i].Title + '</a></li>\n');
+				var minutes = 0;
+				var sec = totalduration;
+				while (sec >= 60) {
+					minutes++;
+					sec -=60;				
+				}
+				$('#playListView').append('<li data-theme="c" data-icon="info"><a href="javascript:ViewInfo(' + i + ')" data-transition="slide"> #' + count + ' ' + songlist[i].Artist + ' - ' + songlist[i].Title + '      +' + ("00"+minutes).slice(-2) + ':' + ("0"+sec).slice(-2) + '</a></li>\n');
+				totalduration += songlist[i].Duration + 15;
 			}
 			$('#playListView').listview('refresh');
 		});

--- a/data/themes/default/index.html
+++ b/data/themes/default/index.html
@@ -13,6 +13,31 @@
 </head>
 <body>
 <style>
+table, th, td {
+   border: none;
+   border-collapse: collapse;}
+tr {border: 1px solid #ccc;
+    background: #eee;
+    font-weight: 700;
+    color: #222;
+    text-shadow: 0 1px 0 #fff;
+    background-image: -webkit-gradient(linear,left top,left bottom,from(#fff),to(#f1f1f1));
+    background-image: -webkit-linear-gradient(#fff,#f1f1f1);
+    background-image: -moz-linear-gradient(#fff,#f1f1f1);
+    background-image: -ms-linear-gradient(#fff,#f1f1f1);
+    background-image: -o-linear-gradient(#fff,#f1f1f1);
+    background-image: linear-gradient(#fff,#f1f1f1);}
+th {border: 1px solid #456f9a;
+    background: #5e87b0;
+    color: #fff;
+    font-weight: 700;
+    text-shadow: 0 1px 0 #3e6790;
+    background-image: -webkit-gradient(linear,left top,left bottom,from(#6facd5),to(#497bae));
+    background-image: -webkit-linear-gradient(#6facd5,#497bae);
+    background-image: -moz-linear-gradient(#6facd5,#497bae);
+    background-image: -ms-linear-gradient(#6facd5,#497bae);
+    background-image: -o-linear-gradient(#6facd5,#497bae);
+    background-image: linear-gradient(#6facd5,#497bae);}
 .ui-page {background: #feffff; /* Old browsers */
 background: -moz-linear-gradient(-45deg, #feffff 0%, #ddf1f9 35%, #a8aac1 100%); /* FF3.6+ */
 background: -webkit-gradient(linear, left top, right bottom, color-stop(0%,#feffff), color-stop(35%,#ddf1f9), color-stop(100%,#a8aac1)); /* Chrome,Safari4+ */

--- a/game/color.cc
+++ b/game/color.cc
@@ -60,14 +60,14 @@ glmath::vec4 Color::linear() const {
 }
 
 Color MicrophoneColor::get(std::string name) {
-	if (name == "blue") return Color(0.0, 42.0/255.0, 1.0);
+	if (name == "blue") return Color(0.0, 8.0/255.0, 1.0);
 	else if (name == "red") return Color(1, 0.0, 0.0);
 	else if (name == "green") return Color(0.0, 1.0, 0.0);
 	else if (name == "yellow") return Color(1.0, 1.0, 0.0);
-	else if (name == "fuchsia") return Color(1.0, 86.0/255.0, 214.0/255.0);
-	else if (name == "orange") return Color(1.0, 132.0/255, 0.0);
-	else if (name == "purple") return Color(143.0/255.0, 43.0/255.0, 1.0);
-	else if (name == "aqua") return Color(0.0, 192.0/255.0, 1.0);
+	else if (name == "fuchsia") return Color(1.0, 109.0/255.0, 178.0/255.0);
+	else if (name == "orange") return Color(1.0, 85.0/255, 0.0);
+	else if (name == "purple") return Color(132.0/255.0, 0, 1.0);
+	else if (name == "aqua") return Color(0.0, 1.0, 1.0);
 	else return Color(0.5, 0.5, 0.5);
 }
 

--- a/game/color.cc
+++ b/game/color.cc
@@ -60,14 +60,14 @@ glmath::vec4 Color::linear() const {
 }
 
 Color MicrophoneColor::get(std::string name) {
-	if (name == "blue") return Color(0.0, 0.0, 1.0);
+	if (name == "blue") return Color(0.0, 42.0/255.0, 1.0);
 	else if (name == "red") return Color(1, 0.0, 0.0);
 	else if (name == "green") return Color(0.0, 1.0, 0.0);
 	else if (name == "yellow") return Color(1.0, 1.0, 0.0);
-	else if (name == "fuchsia") return Color(1.0, 0.5, 191.0/255.0);
-	else if (name == "lightgreen") return Color(0.0, 1.0, 64.0/255.0);
-	else if (name == "purple") return Color(132.0/255.0, 0.0, 1.0);
-	else if (name == "aqua") return Color(0.0, 1.0, 1.0);
+	else if (name == "fuchsia") return Color(1.0, 86.0/255.0, 214.0/255.0);
+	else if (name == "orange") return Color(1.0, 132.0/255, 0.0);
+	else if (name == "purple") return Color(143.0/255.0, 43.0/255.0, 1.0);
+	else if (name == "aqua") return Color(0.0, 192.0/255.0, 1.0);
 	else return Color(0.5, 0.5, 0.5);
 }
 

--- a/game/main.cc
+++ b/game/main.cc
@@ -34,6 +34,13 @@
 #include <vector>
 #include <cstdlib>
 
+#if defined(_WIN32)
+extern "C" {
+// For DWORD (see end of file)
+#include "windef.h"
+}
+#endif
+
 // Disable main level exception handling for debug builds (because gdb cannot properly catch throwing otherwise)
 #ifdef NDEBUG
 #define RUNTIME_ERROR std::runtime_error

--- a/game/screen_audiodevices.cc
+++ b/game/screen_audiodevices.cc
@@ -44,7 +44,7 @@ void ScreenAudioDevices::enter() {
 			if (!countRow("green", *it, countmap["green"])) { ok = false; break; }
 			if (!countRow("yellow", *it, countmap["yellow"])) { ok = false; break; }
 			if(!countRow("fuchsia", *it, countmap["fuchsia"])) { ok = false; break; }
-			if(!countRow("lightgreen", *it, countmap["lightgreen"])) { ok = false; break; }
+			if(!countRow("orange", *it, countmap["orange"])) { ok = false; break; }
 			if(!countRow("purple", *it, countmap["purple"])) { ok = false; break; }
 			if(!countRow("aqua", *it, countmap["aqua"])) { ok = false; break; }
 			if (!countRow("out=", *it, countmap["out="])) { ok = false; break; }
@@ -140,7 +140,7 @@ void ScreenAudioDevices::draw() {
 }
 
 void ScreenAudioDevices::load() {
-	std::string names[] = { "blue", "red", "green", "yellow", "fuchsia", "lightgreen", "purple", "aqua", "OUT" }; //there were 4 colors here
+	std::string names[] = { "blue", "red", "green", "yellow", "fuchsia", "orange", "purple", "aqua", "OUT" }; //there were 4 colors here
 	m_channels.assign(std::begin(names), std::end(names));
 	// Get the currently assigned devices for each channel (FIXME: this is a really stupid algorithm)
 	for (auto const& d: m_audio.devices()) {

--- a/game/screen_playlist.cc
+++ b/game/screen_playlist.cc
@@ -302,7 +302,7 @@ void ScreenPlaylist::createSongListMenu() {
 			std::setw(2) << std::setfill('0') << minutes << ":" << std::setw(2) << std::setfill('0') << seconds;
 		std::string songinfo = oss_playlist.str();
 		if (songinfo.length() > 20) {
-			songinfo = songinfo + "                          >"; //FIXME: ugly hack to make the text scale so it fits on screen!
+			songinfo = songinfo + "                           >"; //FIXME: ugly hack to make the text scale so it fits on screen!
 		}
 		songlist_menu.add(MenuOption(_(songinfo.c_str()),_("Press enter to view song options")).call([this, count]() {
 			createSongMenu(count);

--- a/game/screen_playlist.cc
+++ b/game/screen_playlist.cc
@@ -292,8 +292,6 @@ void ScreenPlaylist::createSongListMenu() {
 	int totaldurationSeconds = 0;
 	for (auto const& song: currentList) {
 		//timestamp handles
-		totaldurationSeconds += song->getDurationSeconds();
-		totaldurationSeconds += config["game/playlist_screen_timeout"].i();
 		int minutes = 0;
 		int seconds = totaldurationSeconds;
 		while(seconds >= 60) {

--- a/game/screen_playlist.cc
+++ b/game/screen_playlist.cc
@@ -289,14 +289,19 @@ void ScreenPlaylist::createSongListMenu() {
 	int count = 1;
 	songlist_menu.clear();
 	SongList& currentList = gm->getCurrentPlayList().getList();
+	int totaldurationSeconds = 0;
 	for (auto const& song: currentList) {
+		//timestamp handles
+		totaldurationSeconds += song->getDurationSeconds();
+		totaldurationSeconds += config["game/playlist_screen_timeout"].i();
 		int minutes = 0;
-		int seconds = song->getDurationSeconds();
-		while(seconds > 60) {
+		int seconds = totaldurationSeconds;
+		while(seconds >= 60) {
 			minutes++;
 			seconds -= 60;
 		}
-		oss_playlist << "#" << count << " : " << song->artist << " - " << song->title << "  +" << minutes << ":" << seconds;
+		oss_playlist << "#" << count << " : " << song->artist << " - " << song->title << "  +" <<
+			std::setw(2) << std::setfill('0') << minutes << ":" << std::setw(2) << std::setfill('0') << seconds;
 		std::string songinfo = oss_playlist.str();
 		if (songinfo.length() > 20) {
 			songinfo = songinfo + "                          >"; //FIXME: ugly hack to make the text scale so it fits on screen!

--- a/game/screen_playlist.cc
+++ b/game/screen_playlist.cc
@@ -292,8 +292,6 @@ void ScreenPlaylist::createSongListMenu() {
 	int totaldurationSeconds = 0;
 	for (auto const& song: currentList) {
 		//timestamp handles
-		totaldurationSeconds += song->getDurationSeconds();
-		totaldurationSeconds += config["game/playlist_screen_timeout"].i();
 		int minutes = 0;
 		int seconds = totaldurationSeconds;
 		while(seconds >= 60) {
@@ -312,6 +310,8 @@ void ScreenPlaylist::createSongListMenu() {
 		}));
 		oss_playlist.str("");
 		count++;
+		totaldurationSeconds += song->getDurationSeconds();
+		totaldurationSeconds += config["game/playlist_screen_timeout"].i();
 	}
 	songlist_menu.add(MenuOption(_("View more options"),_("View general playlist settings")).call([this]() {
 		createEscMenu();

--- a/game/screen_playlist.cc
+++ b/game/screen_playlist.cc
@@ -292,6 +292,8 @@ void ScreenPlaylist::createSongListMenu() {
 	int totaldurationSeconds = 0;
 	for (auto const& song: currentList) {
 		//timestamp handles
+		totaldurationSeconds += song->getDurationSeconds();
+		totaldurationSeconds += config["game/playlist_screen_timeout"].i();
 		int minutes = 0;
 		int seconds = totaldurationSeconds;
 		while(seconds >= 60) {

--- a/game/screen_playlist.cc
+++ b/game/screen_playlist.cc
@@ -43,6 +43,7 @@ void ScreenPlaylist::enter() {
 	if(timervalue == 0) { timervalue = 1; }
 	m_nextTimer.setValue(timervalue);
 	overlay_menu.close();
+	gm->loading(_("Loading song timestamps..."), 0.2);
 	createSongListMenu();
 	songlist_menu.open();
 	reloadGL();
@@ -292,18 +293,27 @@ void ScreenPlaylist::createSongListMenu() {
 	int totaldurationSeconds = 0;
 	for (auto const& song: currentList) {
 		//timestamp handles
+		int hours = 0;
 		int minutes = 0;
 		int seconds = totaldurationSeconds;
 		while(seconds >= 60) {
 			minutes++;
 			seconds -= 60;
 		}
-		oss_playlist << "#" << count << " : " << song->artist << " - " << song->title << "  +" <<
-			std::setw(2) << std::setfill('0') << minutes << ":" << std::setw(2) << std::setfill('0') << seconds;
+		while(minutes >= 60) {
+			hours ++;
+			minutes -=60;
+		}
+		oss_playlist << "#" << count << " : " << song->artist << " - " << song->title << "  +";
+		if(hours > 0) {
+			oss_playlist << std::setw(2) << std::setfill('0') << hours << ":";
+		}
+			oss_playlist << std::setw(2) << std::setfill('0') << minutes << ":" << std::setw(2) << std::setfill('0') << seconds;
 		std::string songinfo = oss_playlist.str();
 		if (songinfo.length() > 20) {
 			songinfo = songinfo + "                           >"; //FIXME: ugly hack to make the text scale so it fits on screen!
 		}
+		//then add it to the menu:
 		songlist_menu.add(MenuOption(_(songinfo.c_str()),_("Press enter to view song options")).call([this, count]() {
 			createSongMenu(count);
 			overlay_menu.open();

--- a/game/screen_playlist.cc
+++ b/game/screen_playlist.cc
@@ -290,7 +290,13 @@ void ScreenPlaylist::createSongListMenu() {
 	songlist_menu.clear();
 	SongList& currentList = gm->getCurrentPlayList().getList();
 	for (auto const& song: currentList) {
-		oss_playlist << "#" << count << " : " << song->artist << " - " << song->title;
+		int minutes = 0;
+		int seconds = song->getDurationSeconds();
+		while(seconds > 60) {
+			minutes++;
+			seconds -= 60;
+		}
+		oss_playlist << "#" << count << " : " << song->artist << " - " << song->title << "  +" << minutes << ":" << seconds;
 		std::string songinfo = oss_playlist.str();
 		if (songinfo.length() > 20) {
 			songinfo = songinfo + "                          >"; //FIXME: ugly hack to make the text scale so it fits on screen!

--- a/game/song.cc
+++ b/game/song.cc
@@ -134,7 +134,8 @@ VocalTrack& Song::getVocalTrack(unsigned idx) {
 	return it->second;
 }
 
-double Song::getDurationSeconds() { //FIXME make async to avoid waiting for resources from disk on the renderthread
+double Song::getDurationSeconds() {
+	boost::mutex::scoped_lock l(m_mutex);
 	if(m_duration == 0) {
 		AVFormatContext *pFormatCtx = avformat_alloc_context();
 		avformat_open_input(&pFormatCtx, music["background"].string().c_str(), NULL, NULL);

--- a/game/song.cc
+++ b/game/song.cc
@@ -1,9 +1,12 @@
 #include "song.hh"
-
+#include "config.hh"
 #include "songparser.hh"
 #include "util.hh"
 #include <limits>
 #include <algorithm>
+extern "C" {
+#include AVFORMAT_INCLUDE
+}
 
 void Song::reload(bool errorIgnore) {
 	loadStatus = NONE;
@@ -130,6 +133,23 @@ VocalTrack& Song::getVocalTrack(unsigned idx) {
 	return it->second;
 }
 
+double Song::getDurationSeconds() {
+	if(m_duration == 0) {
+		//  get duration from avcontext and store it in the song class to avoid having to re-load the file from disk again.
+		AVFormatContext* pFormatCtx = avformat_alloc_context();
+		avformat_open_input(&pFormatCtx, music["background"].string().c_str(), NULL, NULL); //HELPME! file path is correctly loaded but duration is negative!
+		int64_t duration = pFormatCtx->duration;
+		m_duration = duration;
+		avformat_close_input(&pFormatCtx);
+		avformat_free_context(pFormatCtx);
+		double dur = duration;
+		return dur/10;
+	} else { //duration is still in memmory that means we already loaded it
+		double preloadedDuration = m_duration;
+		return preloadedDuration / 10;
+	}
+return 0;
+}
 
 
 

--- a/game/song.hh
+++ b/game/song.hh
@@ -68,6 +68,8 @@ class Song: boost::noncopyable {
 		}
 		return result;
 	}
+
+	double getDurationSeconds();
 	mutable boost::mutex m_mutex;
 	InstrumentTracks instrumentTracks; ///< guitar etc. notes for this song
 	DanceTracks danceTracks; ///< dance tracks
@@ -107,7 +109,7 @@ class Song: boost::noncopyable {
 	double videoGap; ///< gap with video
 	double start; ///< start of song
 	double preview_start; ///< starting time for the preview
-
+	int64_t m_duration = 0;
 	typedef std::vector<std::pair<double,double> > Stops;
 	Stops stops; ///< related to dance
 	typedef std::vector<double> Beats;

--- a/game/webserver.cc
+++ b/game/webserver.cc
@@ -86,6 +86,8 @@ http_server::response WebServer::GETresponse(const http_server::request &request
 				jsonRoot.append(SongObject);
 		}
 		return http_server::response::stock_reply(http_server::response::ok, jsonRoot.toStyledString());
+	} else if(request.destination == "/api/getplaylistTimeout") {
+		return http_server::response::stock_reply(http_server::response::ok, std::to_string(config["game/playlist_screen_timeout"].i()));
 	} else {
 		//other text files
 		try {

--- a/game/webserver.cc
+++ b/game/webserver.cc
@@ -82,6 +82,7 @@ http_server::response WebServer::GETresponse(const http_server::request &request
 				SongObject["Edition"] = song->edition;
 				SongObject["Language"] = song->language;
 				SongObject["Creator"] = song->creator;
+				SongObject["Duration"] = song->getDurationSeconds();
 				jsonRoot.append(SongObject);
 		}
 		return http_server::response::stock_reply(http_server::response::ok, jsonRoot.toStyledString());

--- a/lang/hu.po
+++ b/lang/hu.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# Skyli <skyli91@gmail.com>, 2015.
+# Skyli <skyli91@gmail.com>, 2015-2016.
 #
 msgid ""
 msgstr ""
@@ -60,16 +60,16 @@ msgstr "Harmonikus 3"
 
 #: ../game/configuration.cc:112
 msgid "Enabled"
-msgstr "Engedélyezve"
+msgstr "Bekapcsolva"
 
 #: ../game/configuration.cc:112
 msgid "Disabled"
-msgstr "Letiltva"
+msgstr "Kikapcsolva"
 
 #: ../game/configuration.cc:116
 #, c-format
 msgid "%d items"
-msgstr "%d elem"
+msgstr "%d eszköz"
 
 #: ../game/dancegraph.cc:18
 msgid "Beginner"
@@ -98,7 +98,7 @@ msgstr "Kész!"
 #: ../game/dancegraph.cc:107 ../game/guitargraph.cc:193
 #: ../game/screen_intro.cc:166
 msgid "Start performing!"
-msgstr "Lépj fel a színpadon!"
+msgstr "Lépj a színpadra!"
 
 #: ../game/dancegraph.cc:118 ../game/guitargraph.cc:182
 msgid "Select track"
@@ -182,7 +182,7 @@ msgstr "Folytatás"
 
 #: ../game/instrumentgraph.cc:56 ../game/screen_sing.cc:125
 msgid "Back to performing!"
-msgstr "Játék folytatása!"
+msgstr "Vissza a játékba!"
 
 #: ../game/instrumentgraph.cc:57
 msgid "Rejoin"
@@ -263,7 +263,7 @@ msgstr "Egyes eszközöket nem sikerült betölteni!"
 
 #: ../game/screen_intro.cc:24
 msgid "No playback devices could be used.\n"
-msgstr "Nincs lejátszási eszköz beállítva!\n"
+msgstr "Nincs hozzáadva a hangszóró!\n"
 
 #: ../game/screen_intro.cc:25
 msgid ""
@@ -271,7 +271,7 @@ msgid ""
 "Please configure some before playing."
 msgstr ""
 "\n"
-"Kérlek állítsd be a hangszórót:\n"
+"Kérlek állítsd be, mielőtt elkezdesz játszani:\n"
 "Beállítások > Hangeszközök"
 
 #: ../game/screen_intro.cc:69
@@ -304,7 +304,7 @@ msgstr "Beállítások"
 
 #: ../game/screen_intro.cc:183
 msgid "Configure audio and game options"
-msgstr "Hang- és játékbeállítások konfigurálása"
+msgstr "Hang- és játékbeállítások"
 
 #: ../game/screen_intro.cc:184
 msgid "Leave the game"
@@ -331,7 +331,7 @@ msgstr ""
 
 #: ../game/screen_players.cc:117
 msgid "No players found!"
-msgstr "Játékos nem található!"
+msgstr "Nem található játékos!"
 
 #: ../game/screen_players.cc:118
 msgid "Enter a name to create a new player."
@@ -343,15 +343,15 @@ msgstr "Nyomj entert a játkos létrehozásához."
 
 #: ../game/screen_players.cc:124
 msgid "No players worth mentioning!"
-msgstr "Egyik játékos se említésre méltó..."
+msgstr "Egyik játékos se szerepelt említésre méltóan..."
 
 #: ../game/screen_players.cc:129
 msgid "You reached %1% points!"
-msgstr "%1% pontot értél el!"
+msgstr "%1% pontot szereztél!"
 
 #: ../game/screen_players.cc:130
 msgid "Change player with arrow keys."
-msgstr "Játékos választása a nyilakkal."
+msgstr "Játékos váltása nyilakkal."
 
 #: ../game/screen_players.cc:131
 msgid "Name:"
@@ -496,7 +496,7 @@ msgstr "Választás duett és normál énekmód között"
 
 #: ../game/screen_sing.cc:92
 msgid "Change vocal track"
-msgstr "Énekes kiválasztása"
+msgstr "Duett-énekes kiválasztása"
 
 #: ../game/screen_sing.cc:127
 msgid "Skip"
@@ -786,7 +786,7 @@ msgstr "Téma"
 
 #: ../data/config/schema.xml:71
 msgid "Name of the theme to use."
-msgstr ""
+msgstr "Válassz témát."
 
 #: ../data/config/schema.xml:74
 msgid "Keyboard as guitar"
@@ -794,7 +794,7 @@ msgstr "Billentyűzet, mint gitár"
 
 #: ../data/config/schema.xml:75
 msgid "Enable keyboard as guitar (Frets on Fire mode)."
-msgstr ""
+msgstr "Billentyűzet használata gitárként (Frets on Fire mód)."
 
 #: ../data/config/schema.xml:78
 msgid "Keyboard as drumkit"
@@ -802,7 +802,7 @@ msgstr "Billentyűzet, mint dobfelszerelés"
 
 #: ../data/config/schema.xml:79
 msgid "Enable keyboard as drumkit."
-msgstr ""
+msgstr "Billentyűzet használata, mint dobfelszerelés."
 
 #: ../data/config/schema.xml:82
 msgid "Keyboard as dance pad"
@@ -810,7 +810,7 @@ msgstr "Billentyűzet, mint táncszőnyeg"
 
 #: ../data/config/schema.xml:83
 msgid "Enable keyboard as dance pad."
-msgstr ""
+msgstr "Billentyűzet használata tánszőnyegként."
 
 #: ../data/config/schema.xml:86
 msgid "Keyboard as keytar"
@@ -818,7 +818,7 @@ msgstr "Billentyűzet, mint keytar"
 
 #: ../data/config/schema.xml:87
 msgid "Enable keyboard as keytar."
-msgstr ""
+msgstr "Billentyűzet használata keytarként."
 
 #: ../data/config/schema.xml:94
 msgid "Force controller A's type"
@@ -888,7 +888,7 @@ msgstr "Szélesség"
 
 #: ../data/config/schema.xml:155
 msgid "The width of the window."
-msgstr ""
+msgstr "Az ablak szélessége."
 
 #: ../data/config/schema.xml:160
 msgid "Windowed height"
@@ -896,7 +896,7 @@ msgstr "Magasság"
 
 #: ../data/config/schema.xml:161
 msgid "The height of the window."
-msgstr ""
+msgstr "Az ablak magassága."
 
 #: ../data/config/schema.xml:164
 msgid "Fullscreen mode"
@@ -942,8 +942,8 @@ msgid ""
 "this enabled as Performous will still smoothly fade out the video if your "
 "computer is not fast enough."
 msgstr ""
-"Kikapcsolhatod az összes háttérvideót. Ajánlott bekapcsolva hagyni, mert ha "
-"nem elég gyors a géped, a Performous automatikusan leveszi a videót."
+"Kikapcsolhatod az összes háttérvideót. Ajánlott bekapcsolni, mert ha "
+"nem elég gyors a géped, a automatikusan kikapcsolódik."
 
 #: ../data/config/schema.xml:191
 msgid "Webcam background"
@@ -955,7 +955,7 @@ msgid ""
 "crashes while entering a song."
 msgstr ""
 "Webkamera használata háttérvideóként. Kapcsold ki, ha összeomlik tőle a "
-"performous."
+"játék."
 
 #: ../data/config/schema.xml:196
 msgid "Webcam id"
@@ -992,14 +992,14 @@ msgstr ""
 
 #: ../data/config/schema.xml:212
 msgid "Benchmark mode"
-msgstr "FPS mutatása"
+msgstr "Benchmark mód"
 
 #: ../data/config/schema.xml:213
 msgid ""
 "Framerate limit of 100 FPS is removed and the game instead renders at full "
 "speed. FPS values are printed to console. Please note that the display "
 "drivers may still limit the rendering speed to the screen refresh rate."
-msgstr "FPS érték kijelzése teljesítmény-felméréshez"
+msgstr "100-as FPS limit eltávolítása és FPS érték kijelzése teljesítmény-felméréshez"
 
 #: ../data/config/schema.xml:220
 msgid "Suggested latency"
@@ -1010,12 +1010,12 @@ msgid ""
 "This is a hint for the audio engine about the desired latency. Set this as "
 "low as possible while retaining clear audio playback. Requires restart."
 msgstr ""
-"Tipp az audió-motor késleltetéséhez. Legyen olyan alacsony, amennyire csak "
-"lehet, amíg megmarad a tiszta lejátszás. Újraindítást igényel."
+"Tipp az audió-motornak késleltetéséhez. Legyen olyan alacsony, amennyire csak "
+"lehet, amíg működik a hang. Újraindítást igényel."
 
 #: ../data/config/schema.xml:226
 msgid "Audio/video latency"
-msgstr "Hang/videó késleltetés"
+msgstr "Audió/videó késleltetés"
 
 #: ../data/config/schema.xml:227
 msgid ""
@@ -1026,19 +1026,19 @@ msgid ""
 "performing."
 msgstr ""
 "Minden módra hat. Negatív: ha a megjelenítés késik, a hanghoz képest. "
-"Pozitív: ellenkezőleg. Úgy kell beállítani, hogy a hangjegyek pontosan "
-"zenére jelenjenek meg. Játék közben: Ctrl+F1/F2"
+"A hangjegyek pontosan "
+"zenére jelenjenek meg. Játék közben: Ctrl+,/."
 
 #: ../data/config/schema.xml:232
 msgid "Audio round-trip latency"
-msgstr "Hang oda-vissza késleltetés"
+msgstr "Audió oda-vissza késleltetés"
 
 #: ../data/config/schema.xml:233
 msgid ""
 "Affects singing only. The time it takes for Performous playback to reach "
 "your speakers, fly to the microphone and all the way back until Performous "
 "captures and analyzes it. While performing, press Ctrl+S for synth mode and "
-"adjust with Ctrl+F3/F4."
+"adjust with Ctrl+Ü/Ó."
 msgstr ""
 "Csak az éneklésre hat. Az idő, ami eltelik, amíg a Performousból a "
 "hangszórókon át a mikrofonba és vissza jut a hang. Játék közben: Ctrl+F3/F4"
@@ -1053,7 +1053,7 @@ msgid ""
 "latency combined with audio output latency. Adjust so that you can hit the "
 "notes best when playing by ear (not looking on screen). Use Ctrl+F5/F6 to "
 "adjust while performing."
-msgstr ""
+msgstr "Csak táncra és hangszerekre hat. Igazítsd a hanghoz (ne a képhez). Ctrl+Ő/Ú"
 
 #: ../data/config/schema.xml:246
 msgid "Audio devices"
@@ -1069,7 +1069,7 @@ msgstr "Háttérzene hangerő"
 
 #: ../data/config/schema.xml:253
 msgid "The volume level of menus, song previews and jukebox mode."
-msgstr ""
+msgstr "Hátterzene, menü, dal előlnézet és zenedoboz-mód hangereje."
 
 #: ../data/config/schema.xml:258
 msgid "Music volume"
@@ -1109,11 +1109,11 @@ msgstr ""
 
 #: ../data/config/schema.xml:278
 msgid "Suppress center channel"
-msgstr "Közép-csatorna némítása (Karaoke mód)"
+msgstr "Közép-csatorna némítása (Énekhang-eltávolító)"
 
 #: ../data/config/schema.xml:279
 msgid "Suppress audio of center channel (e.g. vocals)."
-msgstr "Elnémítja az énekhangot a zene alól."
+msgstr "Elnémítja az énekhangot a zene alól. Játék közben: Ctrl+C"
 
 #: ../data/config/schema.xml:290
 msgid "Song folders"


### PR DESCRIPTION
this branch allows you to view how long it takes until song X arrives as described in #182 
The only way to get the duration of an audio file is to completely read it, this puts stress on the filesystem so to make sure we access the filesystem as little as possible I designed it in the following way:
when screenPlaylist comes up (main thread) or the playlist is requested from the web frontend (webserver thread) they call getDurationSeconds() on the song object. this function checks whether the duration is already known and if so, it returns it, if not it opens up ffmpeg and decodes the music file, calculates the duration and stores it in memmory so it doesn't have to be read from disk again when the duration is requested next time.
this way we put as little stress on the system as possible, only fully loading the songs that are actually put in the playlist and only loading them once.