### PR TITLE
Modifiers: Use Command instead of Control on Mac.

### DIFF
--- a/game/controllers-keyboard.cc
+++ b/game/controllers-keyboard.cc
@@ -46,7 +46,11 @@ namespace input {
 			event.hw = sdlEv.key.keysym.scancode;
 			event.value = (sdlEv.type == SDL_KEYDOWN ? 1.0 : 0.0);
 			// Get the modifier keys that we actually use as modifiers
+			#ifdef __APPLE__
+			unsigned mod = sdlEv.key.keysym.mod & (KMOD_LGUI | KMOD_LALT);
+			#else
 			unsigned mod = sdlEv.key.keysym.mod & (KMOD_LCTRL | KMOD_LALT);
+			#endif
 			// Map to keyboard instruments (sets event.button if matching)
 			if (!mod) mapping(event);
 			// Map to menu navigation
@@ -126,7 +130,11 @@ namespace input {
 				if (k == SDL_SCANCODE_PAGEDOWN) return GENERIC_MOREDOWN;
 				if (k == SDL_SCANCODE_PAUSE) return GENERIC_PAUSE;
 			}
+			#ifdef __APPLE__
+			else if (mod == KMOD_LGUI) {
+			#else
 			else if (mod == KMOD_LCTRL) {
+			#endif
 				if (k == SDL_SCANCODE_UP) return GENERIC_VOLUME_UP;
 				if (k == SDL_SCANCODE_DOWN) return GENERIC_VOLUME_DOWN;
 				if (k == SDL_SCANCODE_P) return GENERIC_PAUSE;

--- a/game/main.cc
+++ b/game/main.cc
@@ -94,7 +94,11 @@ static void checkEvents(Game& gm) {
 				config["graphic/fullscreen"].b() = !config["graphic/fullscreen"].b();
 				continue; // Already handled here...
 			}
+			#ifdef __APPLE__
+			if (keypressed == SDL_SCANCODE_PRINTSCREEN || (keypressed == SDL_SCANCODE_F12 && (modifier & KMOD_GUI))) {
+			#else
 			if (keypressed == SDL_SCANCODE_PRINTSCREEN || (keypressed == SDL_SCANCODE_F12 && (modifier & KMOD_CTRL))) {
+			#endif
 				g_take_screenshot = true;
 				continue; // Already handled here...
 			}

--- a/game/screen_audiodevices.cc
+++ b/game/screen_audiodevices.cc
@@ -87,7 +87,11 @@ void ScreenAudioDevices::manageEvent(SDL_Event event) {
 		uint16_t modifier = event.key.keysym.mod;
 		if (m_devs.empty()) return; // The rest work if there are any config options
 		// Reset to defaults
+		#ifdef __APPLE__
+		else if (key == SDL_SCANCODE_R && modifier & KMOD_GUI) {
+		#else
 		else if (key == SDL_SCANCODE_R && modifier & KMOD_CTRL) {
+		#endif
 			config["audio/devices"].reset(modifier & KMOD_ALT);
 			save(true); // Save to disk, reload audio & reload UI to keep stuff consistent
 		}

--- a/game/screen_intro.cc
+++ b/game/screen_intro.cc
@@ -65,6 +65,11 @@ void ScreenIntro::manageEvent(SDL_Event event) {
 		// These are only available in config menu
 		int key = event.key.keysym.scancode;
 		uint16_t modifier = event.key.keysym.mod;
+		#ifdef __APPLE__
+		if (key == SDL_SCANCODE_R && modifier & KMOD_GUI && m_menu.current().value) {
+			m_menu.current().value->reset(modifier & KMOD_ALT);
+		} else if (key == SDL_SCANCODE_S && modifier & KMOD_GUI) {
+		#else
 		if (key == SDL_SCANCODE_R && modifier & KMOD_CTRL && m_menu.current().value) {
 			m_menu.current().value->reset(modifier & KMOD_ALT);
 		} else if (key == SDL_SCANCODE_S && modifier & KMOD_CTRL) {

--- a/game/screen_intro.cc
+++ b/game/screen_intro.cc
@@ -67,12 +67,16 @@ void ScreenIntro::manageEvent(SDL_Event event) {
 		uint16_t modifier = event.key.keysym.mod;
 		#ifdef __APPLE__
 		if (key == SDL_SCANCODE_R && modifier & KMOD_GUI && m_menu.current().value) {
-			m_menu.current().value->reset(modifier & KMOD_ALT);
-		} else if (key == SDL_SCANCODE_S && modifier & KMOD_GUI) {
 		#else
 		if (key == SDL_SCANCODE_R && modifier & KMOD_CTRL && m_menu.current().value) {
+		#endif
 			m_menu.current().value->reset(modifier & KMOD_ALT);
-		} else if (key == SDL_SCANCODE_S && modifier & KMOD_CTRL) {
+		}
+		#ifdef __APPLE__
+		else if (key == SDL_SCANCODE_S && modifier & KMOD_GUI) {
+		#else
+		else if (key == SDL_SCANCODE_S && modifier & KMOD_CTRL) {
+		#endif
 			writeConfig(modifier & KMOD_ALT);
 			Game::getSingletonPtr()->flashMessage((modifier & KMOD_ALT)
 				? _("Settings saved as system defaults.") : _("Settings saved."));

--- a/game/screen_paths.cc
+++ b/game/screen_paths.cc
@@ -28,16 +28,18 @@ void ScreenPaths::manageEvent(SDL_Event event) {
 		// Reset to defaults
 		#ifdef __APPLE__
 		if (key == SDL_SCANCODE_R && modifier & KMOD_GUI) {
-			config["paths/songs"].reset(modifier & KMOD_ALT);
-			config["paths/system"].reset(modifier & KMOD_ALT);
-			// TODO: Save
-		} else if (key == SDL_SCANCODE_S && modifier & KMOD_GUI) {
 		#else
 		if (key == SDL_SCANCODE_R && modifier & KMOD_CTRL) {
+		#endif
 			config["paths/songs"].reset(modifier & KMOD_ALT);
 			config["paths/system"].reset(modifier & KMOD_ALT);
 			// TODO: Save
-		} else if (key == SDL_SCANCODE_S && modifier & KMOD_CTRL) {
+		}
+		#ifdef __APPLE__
+		else if (key == SDL_SCANCODE_S && modifier & KMOD_GUI) {
+		#else
+		else if (key == SDL_SCANCODE_S && modifier & KMOD_CTRL) {
+		#endif
 			writeConfig(modifier & KMOD_ALT);
 			Game::getSingletonPtr()->flashMessage((modifier & KMOD_ALT)
 				? _("Settings saved as system defaults.") : _("Settings saved."));

--- a/game/screen_paths.cc
+++ b/game/screen_paths.cc
@@ -26,6 +26,13 @@ void ScreenPaths::manageEvent(SDL_Event event) {
 		SDL_Keycode key = event.key.keysym.scancode;
 		uint16_t modifier = event.key.keysym.mod;
 		// Reset to defaults
+		#ifdef __APPLE__
+		if (key == SDL_SCANCODE_R && modifier & KMOD_GUI) {
+			config["paths/songs"].reset(modifier & KMOD_ALT);
+			config["paths/system"].reset(modifier & KMOD_ALT);
+			// TODO: Save
+		} else if (key == SDL_SCANCODE_S && modifier & KMOD_GUI) {
+		#else
 		if (key == SDL_SCANCODE_R && modifier & KMOD_CTRL) {
 			config["paths/songs"].reset(modifier & KMOD_ALT);
 			config["paths/system"].reset(modifier & KMOD_ALT);

--- a/game/screen_sing.cc
+++ b/game/screen_sing.cc
@@ -352,7 +352,11 @@ void ScreenSing::manageEvent(SDL_Event event) {
 	double time = m_audio.getPosition();
 	SDL_Scancode key = event.key.keysym.scancode;
 	// Ctrl combinations that can be used while performing (not when score dialog is displayed)
+	#ifdef __APPLE__
+	if (event.type == SDL_KEYDOWN && (event.key.keysym.mod & KMOD_LGUI) && !m_score_window.get()) {
+	#else
 	if (event.type == SDL_KEYDOWN && (event.key.keysym.mod & KMOD_LCTRL) && !m_score_window.get()) {
+	#endif
 		if (key == SDL_SCANCODE_C) {
 			m_audio.toggleCenterChannelSuppressor();
 			++config["audio/suppress_center_channel"];

--- a/game/screen_songs.cc
+++ b/game/screen_songs.cc
@@ -155,7 +155,11 @@ void ScreenSongs::manageEvent(SDL_Event event) {
 			m_songs.setFilter(m_search.text);
 		}
 		else if (!m_jukebox) {
+		#ifdef __APPLE__
+			if (key == SDL_SCANCODE_R && mod & KMOD_GUI) {
+		#else
 			if (key == SDL_SCANCODE_R && mod & KMOD_CTRL) {
+		#endif
 				m_songs.reload();
 				m_songs.setFilter(m_search.text);
 				}


### PR DESCRIPTION
Fixes #94.

I’d actually forgotten I’d ever opened this until I found it by accident. XD
From here, I'd just have to maybe update strings, but to avoid headaches for everyone it might just be better to make a single "Ctrl/Cmd+S (or whatever key) to..." rather than actually change the string according to the platform.