### PR TITLE
Issue/sanitize platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ osx-utils/Performous.dmg
 osx-utils/CMakeCache.txt
 CMakeCache.txt
 CMakeFiles
+*.xcodeproj

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,11 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 	endif()
 endif()
 
+if (Boost_VERSION VERSION_LESS 105500)
+	message("-- Using Boost < 1.55: defining BOOST_NO_CXX11_SCOPED_ENUMS")
+	set(CMAKE_CXX_FLAGS "-DBOOST_NO_CXX11_SCOPED_ENUMS ${CMAKE_CXX_FLAGS}")
+endif()
+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 	set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wextra ${CMAKE_CXX_FLAGS}")
 endif()

--- a/boost_predef/detail/os_detected.h
+++ b/boost_predef/detail/os_detected.h
@@ -1,0 +1,10 @@
+/*
+Copyright Rene Rivera 2013
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_DETAIL_OS_DETECTED
+#define BOOST_PREDEF_DETAIL_OS_DETECTED 1
+#endif

--- a/boost_predef/detail/test.h
+++ b/boost_predef/detail/test.h
@@ -1,0 +1,17 @@
+/*
+Copyright Rene Rivera 2011-2012
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_DETAIL_TEST_H
+#define BOOST_PREDEF_DETAIL_TEST_H
+
+#if !defined(BOOST_PREDEF_INTERNAL_GENERATE_TESTS)
+
+#define BOOST_PREDEF_DECLARE_TEST(x,s)
+
+#endif
+
+#endif

--- a/boost_predef/make.h
+++ b/boost_predef/make.h
@@ -1,0 +1,89 @@
+/*
+Copyright Rene Rivera 2008-2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+#include "detail/test.h"
+
+#ifndef BOOST_PREDEF_MAKE_H
+#define BOOST_PREDEF_MAKE_H
+
+/*
+Shorthands for the common version number formats used by vendors...
+*/
+
+/*`
+[heading `BOOST_PREDEF_MAKE_..` macros]
+
+These set of macros decompose common vendor version number
+macros which are composed version, revision, and patch digits.
+The naming convention indicates:
+
+* The base of the specified version number. "`BOOST_PREDEF_MAKE_0X`" for
+  hexadecimal digits, and "`BOOST_PREDEF_MAKE_10`" for decimal digits.
+* The format of the vendor version number. Where "`V`" indicates the version digits,
+  "`R`" indicates the revision digits, "`P`" indicates the patch digits, and "`0`"
+  indicates an ignored digit.
+
+Macros are:
+*/
+/*` `BOOST_PREDEF_MAKE_0X_VRP(V)` */
+#define BOOST_PREDEF_MAKE_0X_VRP(V) BOOST_VERSION_NUMBER((V&0xF00)>>8,(V&0xF0)>>4,(V&0xF))
+/*` `BOOST_PREDEF_MAKE_0X_VVRP(V)` */
+#define BOOST_PREDEF_MAKE_0X_VVRP(V) BOOST_VERSION_NUMBER((V&0xFF00)>>8,(V&0xF0)>>4,(V&0xF))
+/*` `BOOST_PREDEF_MAKE_0X_VRPP(V)` */
+#define BOOST_PREDEF_MAKE_0X_VRPP(V) BOOST_VERSION_NUMBER((V&0xF000)>>12,(V&0xF00)>>8,(V&0xFF))
+/*` `BOOST_PREDEF_MAKE_0X_VVRR(V)` */
+#define BOOST_PREDEF_MAKE_0X_VVRR(V) BOOST_VERSION_NUMBER((V&0xFF00)>>8,(V&0xFF),0)
+/*` `BOOST_PREDEF_MAKE_0X_VRRPPPP(V)` */
+#define BOOST_PREDEF_MAKE_0X_VRRPPPP(V) BOOST_VERSION_NUMBER((V&0xF000000)>>24,(V&0xFF0000)>>16,(V&0xFFFF))
+/*` `BOOST_PREDEF_MAKE_0X_VVRRP(V)` */
+#define BOOST_PREDEF_MAKE_0X_VVRRP(V) BOOST_VERSION_NUMBER((V&0xFF000)>>12,(V&0xFF0)>>4,(V&0xF))
+/*` `BOOST_PREDEF_MAKE_0X_VRRPP000(V)` */
+#define BOOST_PREDEF_MAKE_0X_VRRPP000(V) BOOST_VERSION_NUMBER((V&0xF0000000)>>28,(V&0xFF00000)>>20,(V&0xFF000)>>12)
+/*` `BOOST_PREDEF_MAKE_0X_VVRRPP(V)` */
+#define BOOST_PREDEF_MAKE_0X_VVRRPP(V) BOOST_VERSION_NUMBER((V&0xFF0000)>>16,(V&0xFF00)>>8,(V&0xFF))
+/*` `BOOST_PREDEF_MAKE_10_VPPP(V)` */
+#define BOOST_PREDEF_MAKE_10_VPPP(V) BOOST_VERSION_NUMBER(((V)/1000)%10,0,(V)%1000)
+/*` `BOOST_PREDEF_MAKE_10_VRP(V)` */
+#define BOOST_PREDEF_MAKE_10_VRP(V) BOOST_VERSION_NUMBER(((V)/100)%10,((V)/10)%10,(V)%10)
+/*` `BOOST_PREDEF_MAKE_10_VRP000(V)` */
+#define BOOST_PREDEF_MAKE_10_VRP000(V) BOOST_VERSION_NUMBER(((V)/100000)%10,((V)/10000)%10,((V)/1000)%10)
+/*` `BOOST_PREDEF_MAKE_10_VRPP(V)` */
+#define BOOST_PREDEF_MAKE_10_VRPP(V) BOOST_VERSION_NUMBER(((V)/1000)%10,((V)/100)%10,(V)%100)
+/*` `BOOST_PREDEF_MAKE_10_VRR(V)` */
+#define BOOST_PREDEF_MAKE_10_VRR(V) BOOST_VERSION_NUMBER(((V)/100)%10,(V)%100,0)
+/*` `BOOST_PREDEF_MAKE_10_VRRPP(V)` */
+#define BOOST_PREDEF_MAKE_10_VRRPP(V) BOOST_VERSION_NUMBER(((V)/10000)%10,((V)/100)%100,(V)%100)
+/*` `BOOST_PREDEF_MAKE_10_VRR000(V)` */
+#define BOOST_PREDEF_MAKE_10_VRR000(V) BOOST_VERSION_NUMBER(((V)/100000)%10,((V)/1000)%100,0)
+/*` `BOOST_PREDEF_MAKE_10_VV00(V)` */
+#define BOOST_PREDEF_MAKE_10_VV00(V) BOOST_VERSION_NUMBER(((V)/100)%100,0,0)
+/*` `BOOST_PREDEF_MAKE_10_VVRR(V)` */
+#define BOOST_PREDEF_MAKE_10_VVRR(V) BOOST_VERSION_NUMBER(((V)/100)%100,(V)%100,0)
+/*` `BOOST_PREDEF_MAKE_10_VVRRPP(V)` */
+#define BOOST_PREDEF_MAKE_10_VVRRPP(V) BOOST_VERSION_NUMBER(((V)/10000)%100,((V)/100)%100,(V)%100)
+/*` `BOOST_PREDEF_MAKE_10_VVRR0PP00(V)` */
+#define BOOST_PREDEF_MAKE_10_VVRR0PP00(V) BOOST_VERSION_NUMBER(((V)/10000000)%100,((V)/100000)%100,((V)/100)%100)
+/*` `BOOST_PREDEF_MAKE_10_VVRR0PPPP(V)` */
+#define BOOST_PREDEF_MAKE_10_VVRR0PPPP(V) BOOST_VERSION_NUMBER(((V)/10000000)%100,((V)/100000)%100,(V)%10000)
+/*` `BOOST_PREDEF_MAKE_10_VVRR00PP00(V)` */
+#define BOOST_PREDEF_MAKE_10_VVRR00PP00(V) BOOST_VERSION_NUMBER(((V)/100000000)%100,((V)/1000000)%100,((V)/100)%100)
+/*`
+[heading `BOOST_PREDEF_MAKE_*..` date macros]
+
+Date decomposition macros return a date in the relative to the 1970
+Epoch date. If the month is not available, January 1st is used as the month and day.
+If the day is not available, but the month is, the 1st of the month is used as the day.
+*/
+/*` `BOOST_PREDEF_MAKE_DATE(Y,M,D)` */
+#define BOOST_PREDEF_MAKE_DATE(Y,M,D) BOOST_VERSION_NUMBER((Y)%10000-1970,(M)%100,(D)%100)
+/*` `BOOST_PREDEF_MAKE_YYYYMMDD(V)` */
+#define BOOST_PREDEF_MAKE_YYYYMMDD(V) BOOST_PREDEF_MAKE_DATE(((V)/10000)%10000,((V)/100)%100,(V)%100)
+/*` `BOOST_PREDEF_MAKE_YYYY(V)` */
+#define BOOST_PREDEF_MAKE_YYYY(V) BOOST_PREDEF_MAKE_DATE(V,1,1)
+/*` `BOOST_PREDEF_MAKE_YYYYMM(V)` */
+#define BOOST_PREDEF_MAKE_YYYYMM(V) BOOST_PREDEF_MAKE_DATE((V)/100,(V)%100,1)
+
+#endif

--- a/boost_predef/os.h
+++ b/boost_predef/os.h
@@ -1,0 +1,33 @@
+/*
+Copyright Rene Rivera 2008-2015
+Copyright Franz Detro 2014
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#if !defined(BOOST_PREDEF_OS_H) || defined(BOOST_PREDEF_INTERNAL_GENERATE_TESTS)
+#ifndef BOOST_PREDEF_OS_H
+#define BOOST_PREDEF_OS_H
+#endif
+
+#include "os/aix.h"
+#include "os/amigaos.h"
+#include "os/android.h"
+#include "os/beos.h"
+#include "os/bsd.h"
+#include "os/cygwin.h"
+#include "os/haiku.h"
+#include "os/hpux.h"
+#include "os/irix.h"
+#include "os/ios.h"
+#include "os/linux.h"
+#include "os/macos.h"
+#include "os/os400.h"
+#include "os/qnxnto.h"
+#include "os/solaris.h"
+#include "os/unix.h"
+#include "os/vms.h"
+#include "os/windows.h"
+
+#endif

--- a/boost_predef/os/aix.h
+++ b/boost_predef/os/aix.h
@@ -1,0 +1,66 @@
+/*
+Copyright Rene Rivera 2008-2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_OS_AIX_H
+#define BOOST_PREDEF_OS_AIX_H
+
+#include "../version_number.h"
+#include "../make.h"
+
+/*`
+[heading `BOOST_OS_AIX`]
+
+[@http://en.wikipedia.org/wiki/AIX_operating_system IBM AIX] operating system.
+Version number available as major, minor, and patch.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`_AIX`] [__predef_detection__]]
+    [[`__TOS_AIX__`] [__predef_detection__]]
+
+    [[`_AIX43`] [4.3.0]]
+    [[`_AIX41`] [4.1.0]]
+    [[`_AIX32`] [3.2.0]]
+    [[`_AIX3`] [3.0.0]]
+    ]
+ */
+
+#define BOOST_OS_AIX BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
+    defined(_AIX) || defined(__TOS_AIX__) \
+    )
+#   undef BOOST_OS_AIX
+#   if !defined(BOOST_OS_AIX) && defined(_AIX43)
+#       define BOOST_OS_AIX BOOST_VERSION_NUMBER(4,3,0)
+#   endif
+#   if !defined(BOOST_OS_AIX) && defined(_AIX41)
+#       define BOOST_OS_AIX BOOST_VERSION_NUMBER(4,1,0)
+#   endif
+#   if !defined(BOOST_OS_AIX) && defined(_AIX32)
+#       define BOOST_OS_AIX BOOST_VERSION_NUMBER(3,2,0)
+#   endif
+#   if !defined(BOOST_OS_AIX) && defined(_AIX3)
+#       define BOOST_OS_AIX BOOST_VERSION_NUMBER(3,0,0)
+#   endif
+#   if !defined(BOOST_OS_AIX)
+#       define BOOST_OS_AIX BOOST_VERSION_NUMBER_AVAILABLE
+#   endif
+#endif
+
+#if BOOST_OS_AIX
+#   define BOOST_OS_AIX_AVAILABLE
+#   include "../detail/os_detected.h"
+#endif
+
+#define BOOST_OS_AIX_NAME "IBM AIX"
+
+#endif
+
+#include "../detail/test.h"
+BOOST_PREDEF_DECLARE_TEST(BOOST_OS_AIX,BOOST_OS_AIX_NAME)

--- a/boost_predef/os/amigaos.h
+++ b/boost_predef/os/amigaos.h
@@ -1,0 +1,46 @@
+/*
+Copyright Rene Rivera 2008-2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_OS_AMIGAOS_H
+#define BOOST_PREDEF_OS_AMIGAOS_H
+
+#include "../version_number.h"
+#include "../make.h"
+
+/*`
+[heading `BOOST_OS_AMIGAOS`]
+
+[@http://en.wikipedia.org/wiki/AmigaOS AmigaOS] operating system.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`AMIGA`] [__predef_detection__]]
+    [[`__amigaos__`] [__predef_detection__]]
+    ]
+ */
+
+#define BOOST_OS_AMIGAOS BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
+    defined(AMIGA) || defined(__amigaos__) \
+    )
+#   undef BOOST_OS_AMIGAOS
+#   define BOOST_OS_AMIGAOS BOOST_VERSION_NUMBER_AVAILABLE
+#endif
+
+#if BOOST_OS_AMIGAOS
+#   define BOOST_OS_AMIGAOS_AVAILABLE
+#   include "../detail/os_detected.h"
+#endif
+
+#define BOOST_OS_AMIGAOS_NAME "AmigaOS"
+
+#endif
+
+#include "../detail/test.h"
+BOOST_PREDEF_DECLARE_TEST(BOOST_OS_AMIGAOS,BOOST_OS_AMIGAOS_NAME)

--- a/boost_predef/os/android.h
+++ b/boost_predef/os/android.h
@@ -1,0 +1,45 @@
+/*
+Copyright Rene Rivera 2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_OS_ADROID_H
+#define BOOST_PREDEF_OS_ADROID_H
+
+#include "../version_number.h"
+#include "../make.h"
+
+/*`
+[heading `BOOST_OS_ANDROID`]
+
+[@http://en.wikipedia.org/wiki/Android_%28operating_system%29 Android] operating system.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`__ANDROID__`] [__predef_detection__]]
+    ]
+ */
+
+#define BOOST_OS_ANDROID BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
+    defined(__ANDROID__) \
+    )
+#   undef BOOST_OS_ANDROID
+#   define BOOST_OS_ANDROID BOOST_VERSION_NUMBER_AVAILABLE
+#endif
+
+#if BOOST_OS_ANDROID
+#   define BOOST_OS_ANDROID_AVAILABLE
+#   include "../detail/os_detected.h"
+#endif
+
+#define BOOST_OS_ANDROID_NAME "Android"
+
+#endif
+
+#include "../detail/test.h"
+BOOST_PREDEF_DECLARE_TEST(BOOST_OS_ANDROID,BOOST_OS_ANDROID_NAME)

--- a/boost_predef/os/beos.h
+++ b/boost_predef/os/beos.h
@@ -1,0 +1,45 @@
+/*
+Copyright Rene Rivera 2008-2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_OS_BEOS_H
+#define BOOST_PREDEF_OS_BEOS_H
+
+#include "../version_number.h"
+#include "../make.h"
+
+/*`
+[heading `BOOST_OS_BEOS`]
+
+[@http://en.wikipedia.org/wiki/BeOS BeOS] operating system.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`__BEOS__`] [__predef_detection__]]
+    ]
+ */
+
+#define BOOST_OS_BEOS BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
+    defined(__BEOS__) \
+    )
+#   undef BOOST_OS_BEOS
+#   define BOOST_OS_BEOS BOOST_VERSION_NUMBER_AVAILABLE
+#endif
+
+#if BOOST_OS_BEOS
+#   define BOOST_OS_BEOS_AVAILABLE
+#   include "../detail/os_detected.h"
+#endif
+
+#define BOOST_OS_BEOS_NAME "BeOS"
+
+#endif
+
+#include "../detail/test.h"
+BOOST_PREDEF_DECLARE_TEST(BOOST_OS_BEOS,BOOST_OS_BEOS_NAME)

--- a/boost_predef/os/bsd.h
+++ b/boost_predef/os/bsd.h
@@ -1,0 +1,103 @@
+/*
+Copyright Rene Rivera 2008-2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_OS_BSD_H
+#define BOOST_PREDEF_OS_BSD_H
+
+/* Special case: OSX will define BSD predefs if the sys/param.h
+ * header is included. We can guard against that, but only if we
+ * detect OSX first. Hence we will force include OSX detection
+ * before doing any BSD detection.
+ */
+#include "../os/macos.h"
+
+#include "../version_number.h"
+#include "../make.h"
+
+/*`
+[heading `BOOST_OS_BSD`]
+
+[@http://en.wikipedia.org/wiki/Berkeley_Software_Distribution BSD] operating system.
+
+BSD has various branch operating systems possible and each detected
+individually. This detects the following variations and sets a specific
+version number macro to match:
+
+* `BOOST_OS_BSD_DRAGONFLY` [@http://en.wikipedia.org/wiki/DragonFly_BSD DragonFly BSD]
+* `BOOST_OS_BSD_FREE` [@http://en.wikipedia.org/wiki/Freebsd FreeBSD]
+* `BOOST_OS_BSD_BSDI` [@http://en.wikipedia.org/wiki/BSD/OS BSDi BSD/OS]
+* `BOOST_OS_BSD_NET` [@http://en.wikipedia.org/wiki/Netbsd NetBSD]
+* `BOOST_OS_BSD_OPEN` [@http://en.wikipedia.org/wiki/Openbsd OpenBSD]
+
+[note The general `BOOST_OS_BSD` is set in all cases to indicate some form
+of BSD. If the above variants is detected the corresponding macro is also set.]
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`BSD`] [__predef_detection__]]
+    [[`_SYSTYPE_BSD`] [__predef_detection__]]
+
+    [[`BSD4_2`] [4.2.0]]
+    [[`BSD4_3`] [4.3.0]]
+    [[`BSD4_4`] [4.4.0]]
+    [[`BSD`] [V.R.0]]
+    ]
+ */
+
+#include "../os/bsd/bsdi.h"
+#include "../os/bsd/dragonfly.h"
+#include "../os/bsd/free.h"
+#include "../os/bsd/open.h"
+#include "../os/bsd/net.h"
+
+#ifndef BOOST_OS_BSD
+#define BOOST_OS_BSD BOOST_VERSION_NUMBER_NOT_AVAILABLE
+#endif
+
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
+    defined(BSD) || \
+    defined(_SYSTYPE_BSD) \
+    )
+#   undef BOOST_OS_BSD
+#   include <sys/param.h>
+#   if !defined(BOOST_OS_BSD) && defined(BSD4_4)
+#       define BOOST_OS_BSD BOOST_VERSION_NUMBER(4,4,0)
+#   endif
+#   if !defined(BOOST_OS_BSD) && defined(BSD4_3)
+#       define BOOST_OS_BSD BOOST_VERSION_NUMBER(4,3,0)
+#   endif
+#   if !defined(BOOST_OS_BSD) && defined(BSD4_2)
+#       define BOOST_OS_BSD BOOST_VERSION_NUMBER(4,2,0)
+#   endif
+#   if !defined(BOOST_OS_BSD) && defined(BSD)
+#       define BOOST_OS_BSD BOOST_PREDEF_MAKE_10_VVRR(BSD)
+#   endif
+#   if !defined(BOOST_OS_BSD)
+#       define BOOST_OS_BSD BOOST_VERSION_NUMBER_AVAILABLE
+#   endif
+#endif
+
+#if BOOST_OS_BSD
+#   define BOOST_OS_BSD_AVAILABLE
+#   include "../detail/os_detected.h"
+#endif
+
+#define BOOST_OS_BSD_NAME "BSD"
+
+#else
+
+#include "../os/bsd/bsdi.h"
+#include "../os/bsd/dragonfly.h"
+#include "../os/bsd/free.h"
+#include "../os/bsd/open.h"
+#include "../os/bsd/net.h"
+
+#endif
+
+#include "../detail/test.h"
+BOOST_PREDEF_DECLARE_TEST(BOOST_OS_BSD,BOOST_OS_BSD_NAME)

--- a/boost_predef/os/bsd/bsdi.h
+++ b/boost_predef/os/bsd/bsdi.h
@@ -1,0 +1,48 @@
+/*
+Copyright Rene Rivera 2012-2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_OS_BSD_BSDI_H
+#define BOOST_PREDEF_OS_BSD_BSDI_H
+
+#include "../bsd.h"
+
+/*`
+[heading `BOOST_OS_BSD_BSDI`]
+
+[@http://en.wikipedia.org/wiki/BSD/OS BSDi BSD/OS] operating system.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`__bsdi__`] [__predef_detection__]]
+    ]
+ */
+
+#define BOOST_OS_BSD_BSDI BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
+    defined(__bsdi__) \
+    )
+#   ifndef BOOST_OS_BSD_AVAILABLE
+#       define BOOST_OS_BSD BOOST_VERSION_NUMBER_AVAILABLE
+#       define BOOST_OS_BSD_AVAILABLE
+#   endif
+#   undef BOOST_OS_BSD_BSDI
+#   define BOOST_OS_BSD_BSDI BOOST_VERSION_NUMBER_AVAILABLE
+#endif
+
+#if BOOST_OS_BSD_BSDI
+#   define BOOST_OS_BSD_BSDI_AVAILABLE
+#   include "../../detail/os_detected.h"
+#endif
+
+#define BOOST_OS_BSD_BSDI_NAME "BSDi BSD/OS"
+
+#endif
+
+#include "../../detail/test.h"
+BOOST_PREDEF_DECLARE_TEST(BOOST_OS_BSD_BSDI,BOOST_OS_BSD_BSDI_NAME)

--- a/boost_predef/os/bsd/dragonfly.h
+++ b/boost_predef/os/bsd/dragonfly.h
@@ -1,0 +1,50 @@
+/*
+Copyright Rene Rivera 2012-2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_OS_BSD_DRAGONFLY_H
+#define BOOST_PREDEF_OS_BSD_DRAGONFLY_H
+
+#include "../bsd.h"
+
+/*`
+[heading `BOOST_OS_BSD_DRAGONFLY`]
+
+[@http://en.wikipedia.org/wiki/DragonFly_BSD DragonFly BSD] operating system.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`__DragonFly__`] [__predef_detection__]]
+    ]
+ */
+
+#define BOOST_OS_BSD_DRAGONFLY BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
+    defined(__DragonFly__) \
+    )
+#   ifndef BOOST_OS_BSD_AVAILABLE
+#       define BOOST_OS_BSD BOOST_VERSION_NUMBER_AVAILABLE
+#       define BOOST_OS_BSD_AVAILABLE
+#   endif
+#   undef BOOST_OS_BSD_DRAGONFLY
+#   if defined(__DragonFly__)
+#       define BOOST_OS_DRAGONFLY_BSD BOOST_VERSION_NUMBER_AVAILABLE
+#   endif
+#endif
+
+#if BOOST_OS_BSD_DRAGONFLY
+#   define BOOST_OS_BSD_DRAGONFLY_AVAILABLE
+#   include "../../detail/os_detected.h"
+#endif
+
+#define BOOST_OS_BSD_DRAGONFLY_NAME "DragonFly BSD"
+
+#endif
+
+#include "../../detail/test.h"
+BOOST_PREDEF_DECLARE_TEST(BOOST_OS_BSD_DRAGONFLY,BOOST_OS_BSD_DRAGONFLY_NAME)

--- a/boost_predef/os/bsd/free.h
+++ b/boost_predef/os/bsd/free.h
@@ -1,0 +1,60 @@
+/*
+Copyright Rene Rivera 2012-2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_OS_BSD_FREE_H
+#define BOOST_PREDEF_OS_BSD_FREE_H
+
+#include "../bsd.h"
+
+/*`
+[heading `BOOST_OS_BSD_FREE`]
+
+[@http://en.wikipedia.org/wiki/Freebsd FreeBSD] operating system.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`__FreeBSD__`] [__predef_detection__]]
+
+    [[`__FreeBSD_version`] [V.R.P]]
+    ]
+ */
+
+#define BOOST_OS_BSD_FREE BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
+    defined(__FreeBSD__) \
+    )
+#   ifndef BOOST_OS_BSD_AVAILABLE
+#       define BOOST_OS_BSD BOOST_VERSION_NUMBER_AVAILABLE
+#       define BOOST_OS_BSD_AVAILABLE
+#   endif
+#   undef BOOST_OS_BSD_FREE
+#   if defined(__FreeBSD_version)
+#       if __FreeBSD_version < 500000
+#           define BOOST_OS_BSD_FREE \
+                BOOST_PREDEF_MAKE_10_VRP000(__FreeBSD_version)
+#       else
+#           define BOOST_OS_BSD_FREE \
+                BOOST_PREDEF_MAKE_10_VRR000(__FreeBSD_version)
+#       endif
+#   else
+#       define BOOST_OS_BSD_FREE BOOST_VERSION_NUMBER_AVAILABLE
+#   endif
+#endif
+
+#if BOOST_OS_BSD_FREE
+#   define BOOST_OS_BSD_FREE_AVAILABLE
+#   include "../../detail/os_detected.h"
+#endif
+
+#define BOOST_OS_BSD_FREE_NAME "Free BSD"
+
+#endif
+
+#include "../../detail/test.h"
+BOOST_PREDEF_DECLARE_TEST(BOOST_OS_BSD_FREE,BOOST_OS_BSD_FREE_NAME)

--- a/boost_predef/os/bsd/net.h
+++ b/boost_predef/os/bsd/net.h
@@ -1,0 +1,84 @@
+/*
+Copyright Rene Rivera 2012-2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_OS_BSD_NET_H
+#define BOOST_PREDEF_OS_BSD_NET_H
+
+#include "../bsd.h"
+
+/*`
+[heading `BOOST_OS_BSD_NET`]
+
+[@http://en.wikipedia.org/wiki/Netbsd NetBSD] operating system.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`__NETBSD__`] [__predef_detection__]]
+    [[`__NetBSD__`] [__predef_detection__]]
+
+    [[`__NETBSD_version`] [V.R.P]]
+    [[`NetBSD0_8`] [0.8.0]]
+    [[`NetBSD0_9`] [0.9.0]]
+    [[`NetBSD1_0`] [1.0.0]]
+    [[`__NetBSD_Version`] [V.R.P]]
+    ]
+ */
+
+#define BOOST_OS_BSD_NET BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
+    defined(__NETBSD__) || defined(__NetBSD__) \
+    )
+#   ifndef BOOST_OS_BSD_AVAILABLE
+#       define BOOST_OS_BSD BOOST_VERSION_NUMBER_AVAILABLE
+#       define BOOST_OS_BSD_AVAILABLE
+#   endif
+#   undef BOOST_OS_BSD_NET
+#   if defined(__NETBSD__)
+#       if defined(__NETBSD_version)
+#           if __NETBSD_version < 500000
+#               define BOOST_OS_BSD_NET \
+                    BOOST_PREDEF_MAKE_10_VRP000(__NETBSD_version)
+#           else
+#               define BOOST_OS_BSD_NET \
+                    BOOST_PREDEF_MAKE_10_VRR000(__NETBSD_version)
+#           endif
+#       else
+#           define BOOST_OS_BSD_NET BOOST_VERSION_NUMBER_AVAILABLE
+#       endif
+#   elif defined(__NetBSD__)
+#       if !defined(BOOST_OS_BSD_NET) && defined(NetBSD0_8)
+#           define BOOST_OS_BSD_NET BOOST_VERSION_NUMBER(0,8,0)
+#       endif
+#       if !defined(BOOST_OS_BSD_NET) && defined(NetBSD0_9)
+#           define BOOST_OS_BSD_NET BOOST_VERSION_NUMBER(0,9,0)
+#       endif
+#       if !defined(BOOST_OS_BSD_NET) && defined(NetBSD1_0)
+#           define BOOST_OS_BSD_NET BOOST_VERSION_NUMBER(1,0,0)
+#       endif
+#       if !defined(BOOST_OS_BSD_NET) && defined(__NetBSD_Version)
+#           define BOOST_OS_BSD_NET \
+                BOOST_PREDEF_MAKE_10_VVRR00PP00(__NetBSD_Version)
+#       endif
+#       if !defined(BOOST_OS_BSD_NET)
+#           define BOOST_OS_BSD_NET BOOST_VERSION_NUMBER_AVAILABLE
+#       endif
+#   endif
+#endif
+
+#if BOOST_OS_BSD_NET
+#   define BOOST_OS_BSD_NET_AVAILABLE
+#   include "../../detail/os_detected.h"
+#endif
+
+#define BOOST_OS_BSD_NET_NAME "DragonFly BSD"
+
+#endif
+
+#include "../../detail/test.h"
+BOOST_PREDEF_DECLARE_TEST(BOOST_OS_BSD_NET,BOOST_OS_BSD_NET_NAME)

--- a/boost_predef/os/bsd/open.h
+++ b/boost_predef/os/bsd/open.h
@@ -1,0 +1,171 @@
+/*
+Copyright Rene Rivera 2012-2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_OS_BSD_OPEN_H
+#define BOOST_PREDEF_OS_BSD_OPEN_H
+
+#include "../bsd.h"
+
+/*`
+[heading `BOOST_OS_BSD_OPEN`]
+
+[@http://en.wikipedia.org/wiki/Openbsd OpenBSD] operating system.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`__OpenBSD__`] [__predef_detection__]]
+
+    [[`OpenBSD2_0`] [2.0.0]]
+    [[`OpenBSD2_1`] [2.1.0]]
+    [[`OpenBSD2_2`] [2.2.0]]
+    [[`OpenBSD2_3`] [2.3.0]]
+    [[`OpenBSD2_4`] [2.4.0]]
+    [[`OpenBSD2_5`] [2.5.0]]
+    [[`OpenBSD2_6`] [2.6.0]]
+    [[`OpenBSD2_7`] [2.7.0]]
+    [[`OpenBSD2_8`] [2.8.0]]
+    [[`OpenBSD2_9`] [2.9.0]]
+    [[`OpenBSD3_0`] [3.0.0]]
+    [[`OpenBSD3_1`] [3.1.0]]
+    [[`OpenBSD3_2`] [3.2.0]]
+    [[`OpenBSD3_3`] [3.3.0]]
+    [[`OpenBSD3_4`] [3.4.0]]
+    [[`OpenBSD3_5`] [3.5.0]]
+    [[`OpenBSD3_6`] [3.6.0]]
+    [[`OpenBSD3_7`] [3.7.0]]
+    [[`OpenBSD3_8`] [3.8.0]]
+    [[`OpenBSD3_9`] [3.9.0]]
+    [[`OpenBSD4_0`] [4.0.0]]
+    [[`OpenBSD4_1`] [4.1.0]]
+    [[`OpenBSD4_2`] [4.2.0]]
+    [[`OpenBSD4_3`] [4.3.0]]
+    [[`OpenBSD4_4`] [4.4.0]]
+    [[`OpenBSD4_5`] [4.5.0]]
+    [[`OpenBSD4_6`] [4.6.0]]
+    [[`OpenBSD4_7`] [4.7.0]]
+    [[`OpenBSD4_8`] [4.8.0]]
+    [[`OpenBSD4_9`] [4.9.0]]
+    ]
+ */
+
+#define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
+    defined(__OpenBSD__) \
+    )
+#   ifndef BOOST_OS_BSD_AVAILABLE
+#       define BOOST_OS_BSD BOOST_VERSION_NUMBER_AVAILABLE
+#       define BOOST_OS_BSD_AVAILABLE
+#   endif
+#   undef BOOST_OS_BSD_OPEN
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD2_0)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(2,0,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD2_1)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(2,1,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD2_2)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(2,2,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD2_3)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(2,3,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD2_4)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(2,4,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD2_5)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(2,5,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD2_6)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(2,6,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD2_7)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(2,7,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD2_8)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(2,8,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD2_9)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(2,9,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD3_0)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(3,0,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD3_1)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(3,1,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD3_2)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(3,2,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD3_3)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(3,3,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD3_4)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(3,4,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD3_5)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(3,5,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD3_6)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(3,6,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD3_7)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(3,7,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD3_8)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(3,8,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD3_9)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(3,9,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD4_0)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(4,0,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD4_1)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(4,1,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD4_2)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(4,2,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD4_3)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(4,3,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD4_4)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(4,4,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD4_5)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(4,5,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD4_6)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(4,6,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD4_7)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(4,7,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD4_8)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(4,8,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN) && defined(OpenBSD4_9)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER(4,9,0)
+#   endif
+#   if !defined(BOOST_OS_BSD_OPEN)
+#       define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER_AVAILABLE
+#   endif
+#endif
+
+#if BOOST_OS_BSD_OPEN
+#   define BOOST_OS_BSD_OPEN_AVAILABLE
+#   include "../../detail/os_detected.h"
+#endif
+
+#define BOOST_OS_BSD_OPEN_NAME "OpenBSD"
+
+#endif
+
+#include "../../detail/test.h"
+BOOST_PREDEF_DECLARE_TEST(BOOST_OS_BSD_OPEN,BOOST_OS_BSD_OPEN_NAME)

--- a/boost_predef/os/cygwin.h
+++ b/boost_predef/os/cygwin.h
@@ -1,0 +1,45 @@
+/*
+Copyright Rene Rivera 2008-2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_OS_CYGWIN_H
+#define BOOST_PREDEF_OS_CYGWIN_H
+
+#include "../version_number.h"
+#include "../make.h"
+
+/*`
+[heading `BOOST_OS_CYGWIN`]
+
+[@http://en.wikipedia.org/wiki/Cygwin Cygwin] evironment.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`__CYGWIN__`] [__predef_detection__]]
+    ]
+ */
+
+#define BOOST_OS_CYGWIN BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
+    defined(__CYGWIN__) \
+    )
+#   undef BOOST_OS_CYGWIN
+#   define BOOST_OS_CYGWIN BOOST_VERSION_NUMBER_AVAILABLE
+#endif
+
+#if BOOST_OS_CYGWIN
+#   define BOOST_OS_CYGWIN_AVAILABLE
+#   include "../detail/os_detected.h"
+#endif
+
+#define BOOST_OS_CYGWIN_NAME "Cygwin"
+
+#endif
+
+#include "../detail/test.h"
+BOOST_PREDEF_DECLARE_TEST(BOOST_OS_CYGWIN,BOOST_OS_CYGWIN_NAME)

--- a/boost_predef/os/haiku.h
+++ b/boost_predef/os/haiku.h
@@ -1,0 +1,46 @@
+/*
+Copyright Jessica Hamilton 2014
+Copyright Rene Rivera 2014-2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_OS_HAIKU_H
+#define BOOST_PREDEF_OS_HAIKU_H
+
+#include "../version_number.h"
+#include "../make.h"
+
+/*`
+[heading `BOOST_OS_HAIKU`]
+
+[@http://en.wikipedia.org/wiki/Haiku_(operating_system) Haiku] operating system.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`__HAIKU__`] [__predef_detection__]]
+    ]
+ */
+
+#define BOOST_OS_HAIKU BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
+    defined(__HAIKU__) \
+    )
+#   undef BOOST_OS_HAIKU
+#   define BOOST_OS_HAIKU BOOST_VERSION_NUMBER_AVAILABLE
+#endif
+
+#if BOOST_OS_HAIKU
+#   define BOOST_OS_HAIKU_AVAILABLE
+#   include "../detail/os_detected.h"
+#endif
+
+#define BOOST_OS_HAIKU_NAME "Haiku"
+
+#endif
+
+#include "../detail/test.h"
+BOOST_PREDEF_DECLARE_TEST(BOOST_OS_HAIKU,BOOST_OS_HAIKU_NAME)

--- a/boost_predef/os/hpux.h
+++ b/boost_predef/os/hpux.h
@@ -1,0 +1,47 @@
+/*
+Copyright Rene Rivera 2008-2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_OS_HPUX_H
+#define BOOST_PREDEF_OS_HPUX_H
+
+#include "../version_number.h"
+#include "../make.h"
+
+/*`
+[heading `BOOST_OS_HPUX`]
+
+[@http://en.wikipedia.org/wiki/HP-UX HP-UX] operating system.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`hpux`] [__predef_detection__]]
+    [[`_hpux`] [__predef_detection__]]
+    [[`__hpux`] [__predef_detection__]]
+    ]
+ */
+
+#define BOOST_OS_HPUX BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
+    defined(hpux) || defined(_hpux) || defined(__hpux) \
+    )
+#   undef BOOST_OS_HPUX
+#   define BOOST_OS_HPUX BOOST_VERSION_NUMBER_AVAILABLE
+#endif
+
+#if BOOST_OS_HPUX
+#   define BOOST_OS_HPUX_AVAILABLE
+#   include "../detail/os_detected.h"
+#endif
+
+#define BOOST_OS_HPUX_NAME "HP-UX"
+
+#endif
+
+#include "../detail/test.h"
+BOOST_PREDEF_DECLARE_TEST(BOOST_OS_HPUX,BOOST_OS_HPUX_NAME)

--- a/boost_predef/os/ios.h
+++ b/boost_predef/os/ios.h
@@ -1,0 +1,51 @@
+/*
+Copyright Franz Detro 2014
+Copyright Rene Rivera 2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_OS_IOS_H
+#define BOOST_PREDEF_OS_IOS_H
+
+#include "../version_number.h"
+#include "../make.h"
+
+/*`
+[heading `BOOST_OS_IOS`]
+
+[@http://en.wikipedia.org/wiki/iOS iOS] operating system.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`__APPLE__`] [__predef_detection__]]
+    [[`__MACH__`] [__predef_detection__]]
+    [[`__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__`] [__predef_detection__]]
+
+    [[`__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__`] [__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__*1000]]
+    ]
+ */
+
+#define BOOST_OS_IOS BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
+    defined(__APPLE__) && defined(__MACH__) && \
+    defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) \
+    )
+#   undef BOOST_OS_IOS
+#   define BOOST_OS_IOS (__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__*1000)
+#endif
+
+#if BOOST_OS_IOS
+#   define BOOST_OS_IOS_AVAILABLE
+#   include "../detail/os_detected.h"
+#endif
+
+#define BOOST_OS_IOS_NAME "iOS"
+
+#endif
+
+#include "../detail/test.h"
+BOOST_PREDEF_DECLARE_TEST(BOOST_OS_IOS,BOOST_OS_IOS_NAME)

--- a/boost_predef/os/irix.h
+++ b/boost_predef/os/irix.h
@@ -1,0 +1,46 @@
+/*
+Copyright Rene Rivera 2008-2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_OS_IRIX_H
+#define BOOST_PREDEF_OS_IRIX_H
+
+#include "../version_number.h"
+#include "../make.h"
+
+/*`
+[heading `BOOST_OS_IRIX`]
+
+[@http://en.wikipedia.org/wiki/Irix IRIX] operating system.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`sgi`] [__predef_detection__]]
+    [[`__sgi`] [__predef_detection__]]
+    ]
+ */
+
+#define BOOST_OS_IRIX BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
+    defined(sgi) || defined(__sgi) \
+    )
+#   undef BOOST_OS_IRIX
+#   define BOOST_OS_IRIX BOOST_VERSION_NUMBER_AVAILABLE
+#endif
+
+#if BOOST_OS_IRIX
+#   define BOOST_OS_IRIX_AVAILABLE
+#   include "../detail/os_detected.h"
+#endif
+
+#define BOOST_OS_IRIX_NAME "IRIX"
+
+#endif
+
+#include "../detail/test.h"
+BOOST_PREDEF_DECLARE_TEST(BOOST_OS_IRIX,BOOST_OS_IRIX_NAME)

--- a/boost_predef/os/linux.h
+++ b/boost_predef/os/linux.h
@@ -1,0 +1,46 @@
+/*
+Copyright Rene Rivera 2008-2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_OS_LINUX_H
+#define BOOST_PREDEF_OS_LINUX_H
+
+#include "../version_number.h"
+#include "../make.h"
+
+/*`
+[heading `BOOST_OS_LINUX`]
+
+[@http://en.wikipedia.org/wiki/Linux Linux] operating system.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`linux`] [__predef_detection__]]
+    [[`__linux`] [__predef_detection__]]
+    ]
+ */
+
+#define BOOST_OS_LINUX BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
+    defined(linux) || defined(__linux) \
+    )
+#   undef BOOST_OS_LINUX
+#   define BOOST_OS_LINUX BOOST_VERSION_NUMBER_AVAILABLE
+#endif
+
+#if BOOST_OS_LINUX
+#   define BOOST_OS_LINUX_AVAILABLE
+#   include "../detail/os_detected.h"
+#endif
+
+#define BOOST_OS_LINUX_NAME "Linux"
+
+#endif
+
+#include "../detail/test.h"
+BOOST_PREDEF_DECLARE_TEST(BOOST_OS_LINUX,BOOST_OS_LINUX_NAME)

--- a/boost_predef/os/macos.h
+++ b/boost_predef/os/macos.h
@@ -1,0 +1,65 @@
+/*
+Copyright Rene Rivera 2008-2015
+Copyright Franz Detro 2014
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_OS_MACOS_H
+#define BOOST_PREDEF_OS_MACOS_H
+
+/* Special case: iOS will define the same predefs as MacOS, and additionally
+ '__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__'. We can guard against that,
+ but only if we detect iOS first. Hence we will force include iOS detection
+ * before doing any MacOS detection.
+ */
+#include "../os/ios.h"
+
+#include "../version_number.h"
+#include "../make.h"
+
+/*`
+[heading `BOOST_OS_MACOS`]
+
+[@http://en.wikipedia.org/wiki/Mac_OS Mac OS] operating system.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`macintosh`] [__predef_detection__]]
+    [[`Macintosh`] [__predef_detection__]]
+    [[`__APPLE__`] [__predef_detection__]]
+    [[`__MACH__`] [__predef_detection__]]
+
+    [[`__APPLE__`, `__MACH__`] [10.0.0]]
+    [[ /otherwise/ ] [9.0.0]]
+    ]
+ */
+
+#define BOOST_OS_MACOS BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
+    defined(macintosh) || defined(Macintosh) || \
+    (defined(__APPLE__) && defined(__MACH__)) \
+    )
+#   undef BOOST_OS_MACOS
+#   if !defined(BOOST_OS_MACOS) && defined(__APPLE__) && defined(__MACH__)
+#       define BOOST_OS_MACOS BOOST_VERSION_NUMBER(10,0,0)
+#   endif
+#   if !defined(BOOST_OS_MACOS)
+#       define BOOST_OS_MACOS BOOST_VERSION_NUMBER(9,0,0)
+#   endif
+#endif
+
+#if BOOST_OS_MACOS
+#   define BOOST_OS_MACOS_AVAILABLE
+#   include "../detail/os_detected.h"
+#endif
+
+#define BOOST_OS_MACOS_NAME "Mac OS"
+
+#endif
+
+#include "../detail/test.h"
+BOOST_PREDEF_DECLARE_TEST(BOOST_OS_MACOS,BOOST_OS_MACOS_NAME)

--- a/boost_predef/os/os400.h
+++ b/boost_predef/os/os400.h
@@ -1,0 +1,45 @@
+/*
+Copyright Rene Rivera 2011-2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_OS_OS400_H
+#define BOOST_PREDEF_OS_OS400_H
+
+#include "../version_number.h"
+#include "../make.h"
+
+/*`
+[heading `BOOST_OS_OS400`]
+
+[@http://en.wikipedia.org/wiki/IBM_i IBM OS/400] operating system.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`__OS400__`] [__predef_detection__]]
+    ]
+ */
+
+#define BOOST_OS_OS400 BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
+    defined(__OS400__) \
+    )
+#   undef BOOST_OS_OS400
+#   define BOOST_OS_OS400 BOOST_VERSION_NUMBER_AVAILABLE
+#endif
+
+#if BOOST_OS_OS400
+#   define BOOST_OS_OS400_AVAILABLE
+#   include "../detail/os_detected.h"
+#endif
+
+#define BOOST_OS_OS400_NAME "IBM OS/400"
+
+#endif
+
+#include "../detail/test.h"
+BOOST_PREDEF_DECLARE_TEST(BOOST_OS_OS400,BOOST_OS_OS400_NAME)

--- a/boost_predef/os/qnxnto.h
+++ b/boost_predef/os/qnxnto.h
@@ -1,0 +1,59 @@
+/*
+Copyright Rene Rivera 2008-2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_OS_QNXNTO_H
+#define BOOST_PREDEF_OS_QNXNTO_H
+
+#include "../version_number.h"
+#include "../make.h"
+
+/*`
+[heading `BOOST_OS_QNX`]
+
+[@http://en.wikipedia.org/wiki/QNX QNX] operating system.
+Version number available as major, and minor if possible. And
+version 4 is specifically detected.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`__QNX__`] [__predef_detection__]]
+    [[`__QNXNTO__`] [__predef_detection__]]
+
+    [[`_NTO_VERSION`] [V.R.0]]
+    [[`__QNX__`] [4.0.0]]
+    ]
+ */
+
+#define BOOST_OS_QNX BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
+    defined(__QNX__) || defined(__QNXNTO__) \
+    )
+#   undef BOOST_OS_QNX
+#   if !defined(BOOST_OS_QNX) && defined(_NTO_VERSION)
+#       define BOOST_OS_QNX BOOST_PREDEF_MAKE_10_VVRR(_NTO_VERSION)
+#   endif
+#   if !defined(BOOST_OS_QNX) && defined(__QNX__)
+#       define BOOST_OS_QNX BOOST_VERSION_NUMBER(4,0,0)
+#   endif
+#   if !defined(BOOST_OS_QNX)
+#       define BOOST_OS_QNX BOOST_VERSION_NUMBER_AVAILABLE
+#   endif
+#endif
+
+#if BOOST_OS_QNX
+#   define BOOST_OS_QNX_AVAILABLE
+#   include "../detail/os_detected.h"
+#endif
+
+#define BOOST_OS_QNX_NAME "QNX"
+
+#endif
+
+#include "../detail/test.h"
+BOOST_PREDEF_DECLARE_TEST(BOOST_OS_QNX,BOOST_OS_QNX_NAME)

--- a/boost_predef/os/solaris.h
+++ b/boost_predef/os/solaris.h
@@ -1,0 +1,46 @@
+/*
+Copyright Rene Rivera 2008-2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_OS_SOLARIS_H
+#define BOOST_PREDEF_OS_SOLARIS_H
+
+#include "../version_number.h"
+#include "../make.h"
+
+/*`
+[heading `BOOST_OS_SOLARIS`]
+
+[@http://en.wikipedia.org/wiki/Solaris_Operating_Environment Solaris] operating system.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`sun`] [__predef_detection__]]
+    [[`__sun`] [__predef_detection__]]
+    ]
+ */
+
+#define BOOST_OS_SOLARIS BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
+    defined(sun) || defined(__sun) \
+    )
+#   undef BOOST_OS_SOLARIS
+#   define BOOST_OS_SOLARIS BOOST_VERSION_NUMBER_AVAILABLE
+#endif
+
+#if BOOST_OS_SOLARIS
+#   define BOOST_OS_SOLARIS_AVAILABLE
+#   include "../detail/os_detected.h"
+#endif
+
+#define BOOST_OS_SOLARIS_NAME "Solaris"
+
+#endif
+
+#include "../detail/test.h"
+BOOST_PREDEF_DECLARE_TEST(BOOST_OS_SOLARIS,BOOST_OS_SOLARIS_NAME)

--- a/boost_predef/os/unix.h
+++ b/boost_predef/os/unix.h
@@ -1,0 +1,76 @@
+/*
+Copyright Rene Rivera 2008-2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_OS_UNIX_H
+#define BOOST_PREDEF_OS_UNIX_H
+
+#include "../version_number.h"
+#include "../make.h"
+
+/*`
+[heading `BOOST_OS_UNIX`]
+
+[@http://en.wikipedia.org/wiki/Unix Unix Environment] operating system.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`unix`] [__predef_detection__]]
+    [[`__unix`] [__predef_detection__]]
+    [[`_XOPEN_SOURCE`] [__predef_detection__]]
+    [[`_POSIX_SOURCE`] [__predef_detection__]]
+    ]
+ */
+
+#define BOOST_OS_UNIX BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if defined(unix) || defined(__unix) || \
+    defined(_XOPEN_SOURCE) || defined(_POSIX_SOURCE)
+#   undef BOOST_OS_UNIX
+#   define BOOST_OS_UNIX BOOST_VERSION_NUMBER_AVAILABLE
+#endif
+
+#if BOOST_OS_UNIX
+#   define BOOST_OS_UNIX_AVAILABLE
+#endif
+
+#define BOOST_OS_UNIX_NAME "Unix Environment"
+
+/*`
+[heading `BOOST_OS_SVR4`]
+
+[@http://en.wikipedia.org/wiki/UNIX_System_V SVR4 Environment] operating system.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`__sysv__`] [__predef_detection__]]
+    [[`__SVR4`] [__predef_detection__]]
+    [[`__svr4__`] [__predef_detection__]]
+    [[`_SYSTYPE_SVR4`] [__predef_detection__]]
+    ]
+ */
+
+#define BOOST_OS_SVR4 BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if defined(__sysv__) || defined(__SVR4) || \
+    defined(__svr4__) || defined(_SYSTYPE_SVR4)
+#   undef BOOST_OS_SVR4
+#   define BOOST_OS_SVR4 BOOST_VERSION_NUMBER_AVAILABLE
+#endif
+
+#if BOOST_OS_SVR4
+#   define BOOST_OS_SVR4_AVAILABLE
+#endif
+
+#define BOOST_OS_SVR4_NAME "SVR4 Environment"
+
+#endif
+
+#include "../detail/test.h"
+BOOST_PREDEF_DECLARE_TEST(BOOST_OS_UNIX,BOOST_OS_UNIX_NAME)
+BOOST_PREDEF_DECLARE_TEST(BOOST_OS_SVR4,BOOST_OS_SVR4_NAME)

--- a/boost_predef/os/vms.h
+++ b/boost_predef/os/vms.h
@@ -1,0 +1,52 @@
+/*
+Copyright Rene Rivera 2011-2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_OS_VMS_H
+#define BOOST_PREDEF_OS_VMS_H
+
+#include "../version_number.h"
+#include "../make.h"
+
+/*`
+[heading `BOOST_OS_VMS`]
+
+[@http://en.wikipedia.org/wiki/Vms VMS] operating system.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`VMS`] [__predef_detection__]]
+    [[`__VMS`] [__predef_detection__]]
+
+    [[`__VMS_VER`] [V.R.P]]
+    ]
+ */
+
+#define BOOST_OS_VMS BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
+    defined(VMS) || defined(__VMS) \
+    )
+#   undef BOOST_OS_VMS
+#   if defined(__VMS_VER)
+#       define BOOST_OS_VMS BOOST_PREDEF_MAKE_10_VVRR00PP00(__VMS_VER)
+#   else
+#       define BOOST_OS_VMS BOOST_VERSION_NUMBER_AVAILABLE
+#   endif
+#endif
+
+#if BOOST_OS_VMS
+#   define BOOST_OS_VMS_AVAILABLE
+#   include "../detail/os_detected.h"
+#endif
+
+#define BOOST_OS_VMS_NAME "VMS"
+
+#endif
+
+#include "../detail/test.h"
+BOOST_PREDEF_DECLARE_TEST(BOOST_OS_VMS,BOOST_OS_VMS_NAME)

--- a/boost_predef/os/windows.h
+++ b/boost_predef/os/windows.h
@@ -1,0 +1,51 @@
+/*
+Copyright Rene Rivera 2008-2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_OS_WINDOWS_H
+#define BOOST_PREDEF_OS_WINDOWS_H
+
+#include "../version_number.h"
+#include "../make.h"
+
+/*`
+[heading `BOOST_OS_WINDOWS`]
+
+[@http://en.wikipedia.org/wiki/Category:Microsoft_Windows Microsoft Windows] operating system.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`_WIN32`] [__predef_detection__]]
+    [[`_WIN64`] [__predef_detection__]]
+    [[`__WIN32__`] [__predef_detection__]]
+    [[`__TOS_WIN__`] [__predef_detection__]]
+    [[`__WINDOWS__`] [__predef_detection__]]
+    ]
+ */
+
+#define BOOST_OS_WINDOWS BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
+    defined(_WIN32) || defined(_WIN64) || \
+    defined(__WIN32__) || defined(__TOS_WIN__) || \
+    defined(__WINDOWS__) \
+    )
+#   undef BOOST_OS_WINDOWS
+#   define BOOST_OS_WINDOWS BOOST_VERSION_NUMBER_AVAILABLE
+#endif
+
+#if BOOST_OS_WINDOWS
+#   define BOOST_OS_WINDOWS_AVAILABLE
+#   include "../detail/os_detected.h"
+#endif
+
+#define BOOST_OS_WINDOWS_NAME "Microsoft Windows"
+
+#endif
+
+#include "../detail/test.h"
+BOOST_PREDEF_DECLARE_TEST(BOOST_OS_WINDOWS,BOOST_OS_WINDOWS_NAME)

--- a/boost_predef/version_number.h
+++ b/boost_predef/version_number.h
@@ -1,0 +1,53 @@
+/*
+Copyright Rene Rivera 2005, 2008-2013
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_VERSION_NUMBER_H
+#define BOOST_PREDEF_VERSION_NUMBER_H
+
+/*`
+[heading `BOOST_VERSION_NUMBER`]
+
+``
+BOOST_VERSION_NUMBER(major,minor,patch)
+``
+
+Defines standard version numbers, with these properties:
+
+* Decimal base whole numbers in the range \[0,1000000000).
+  The number range is designed to allow for a (2,2,5) triplet.
+  Which fits within a 32 bit value.
+* The `major` number can be in the \[0,99\] range.
+* The `minor` number can be in the \[0,99\] range.
+* The `patch` number can be in the \[0,99999\] range.
+* Values can be specified in any base. As the defined value
+  is an constant expression.
+* Value can be directly used in both preprocessor and compiler
+  expressions for comparison to other similarly defined values.
+* The implementation enforces the individual ranges for the
+  major, minor, and patch numbers. And values over the ranges
+  are truncated (modulo).
+
+*/
+#define BOOST_VERSION_NUMBER(major,minor,patch) \
+    ( (((major)%100)*10000000) + (((minor)%100)*100000) + ((patch)%100000) )
+
+#define BOOST_VERSION_NUMBER_MAX \
+    BOOST_VERSION_NUMBER(99,99,99999)
+
+#define BOOST_VERSION_NUMBER_ZERO \
+    BOOST_VERSION_NUMBER(0,0,0)
+
+#define BOOST_VERSION_NUMBER_MIN \
+    BOOST_VERSION_NUMBER(0,0,1)
+
+#define BOOST_VERSION_NUMBER_AVAILABLE \
+    BOOST_VERSION_NUMBER_MIN
+
+#define BOOST_VERSION_NUMBER_NOT_AVAILABLE \
+    BOOST_VERSION_NUMBER_ZERO
+
+#endif

--- a/game/audio.cc
+++ b/game/audio.cc
@@ -10,10 +10,10 @@
 #include <map>
 
 #include "configuration.hh"
-#include "libda/fft.hpp"  // For M_PI
 #include "libda/portaudio.hpp"
 #include "util.hh"
 
+extern const double m_pi;
 using namespace boost::posix_time;
 
 namespace {
@@ -295,7 +295,7 @@ struct Synth {
 		for (size_t i = 0, iend = mixbuf.size(); i != iend; ++i) {
 			if (i % 2 == 0) {
 				value = d * 0.2 * std::sin(phase) + 0.2 * std::sin(2 * phase) + (1.0 - d) * 0.2 * std::sin(4 * phase);
-				phase += 2.0 * M_PI * freq / srate;
+				phase += 2.0 * m_pi * freq / srate;
 			}
 			begin[i] += value;
 		}

--- a/game/execname.hh
+++ b/game/execname.hh
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "fs.hh"
-
-/// Get the current executable name with path. Returns empty path if the name
-/// cannot be found. May return absolute or relative paths.
-fs::path execname();
-

--- a/game/fs.cc
+++ b/game/fs.cc
@@ -60,6 +60,30 @@ namespace {
 	typedef boost::lock_guard<boost::mutex> Lock;
 }
 
+void copyDirectoryRecursively(const fs::path& sourceDir, const fs::path& destinationDir)
+{
+    if (!fs::exists(sourceDir) || !fs::is_directory(sourceDir))
+    {
+        throw std::runtime_error("Source directory " + sourceDir.string() + " does not exist or is not a directory");
+    }
+    if (fs::exists(destinationDir))
+    {
+        throw std::runtime_error("Destination directory " + destinationDir.string() + " already exists");
+    }
+    if (!fs::create_directory(destinationDir))
+    {
+        throw std::runtime_error("Cannot create destination directory " + destinationDir.string());
+    }
+
+    for (const auto& dirEnt : fs::recursive_directory_iterator{sourceDir})
+    {
+        const auto& path = dirEnt.path();
+        auto relativePathStr = path.string();
+        boost::algorithm::replace_first(relativePathStr, sourceDir.string(), "");
+        fs::copy(path, destinationDir / relativePathStr);
+    }
+}
+
 void pathBootstrap() { Lock l(mutex); cache.pathBootstrap(); }
 void pathInit() { Lock l(mutex); cache.pathInit(); }
 fs::path getLogFilename() { Lock l(mutex); return cache.cache / "infolog.txt"; }

--- a/game/fs.cc
+++ b/game/fs.cc
@@ -4,11 +4,11 @@
 #include "platform.hh"
 
 #include <boost/algorithm/string/replace.hpp>
-#include <boost/filesystem/fstream.hpp>
-#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/range.hpp>
+#include <boost/thread.hpp>
 #include <cstdlib>
 
-#include <boost/thread.hpp>
 #include <set>
 #include <sstream>
 #include <algorithm>
@@ -70,10 +70,17 @@ void copyDirectoryRecursively(const fs::path& sourceDir, const fs::path& destina
     {
         throw std::runtime_error("Cannot create destination directory " + destinationDir.string());
     }
-
+#if ((BOOST_VERSION / 100 % 1000) >= 55)
     for (const auto& dirEnt : fs::recursive_directory_iterator{sourceDir})
+#else
+    for (fs::recursive_directory_iterator dirEnt(sourceDir); dirEnt !=fs::recursive_directory_iterator(); ++dirEnt)
+#endif
     {
+    #if ((BOOST_VERSION / 100 % 1000) >= 55)
         const auto& path = dirEnt.path();
+    #else
+        const auto& path = dirEnt->path();    
+    #endif
         auto relativePathStr = path.string();
         boost::algorithm::replace_first(relativePathStr, sourceDir.string(), "");
         try { 

--- a/game/fs.cc
+++ b/game/fs.cc
@@ -1,22 +1,17 @@
-﻿#include "fs.hh"
-
-#include "config.hh"
+﻿#include "config.hh"
 #include "configuration.hh"
-#include "execname.hh"
+#include "fs.hh"
+#include "platform.hh"
 
+#include <boost/algorithm/string/replace.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <cstdlib>
-#include <iostream>
+
 #include <boost/thread.hpp>
 #include <set>
 #include <sstream>
 #include <algorithm>
-
-#ifdef _WIN32
-#include <windows.h>
-#include <shlobj.h>
-#endif
 
 namespace {
 	/// Test if a path begins with name and if so, remove that element and return true
@@ -32,11 +27,14 @@ namespace {
 	}
 
 	const fs::path performous = "performous";
-	const fs::path configSchema = "config/schema.xml";
+	const fs::path configSchema = "config/schema.xml";	
 
 	struct PathCache {
+		Paths paths;
+		
+		fs::path base, share, locale, sysConf, home, conf, data, cache;
 		/// Expand a path specifier as a list of actual paths. Expands ~ (home) and DATADIR (Performous search path).
-		Paths pathExpand(fs::path p) {
+	Paths pathExpand(fs::path p) {
 			Paths ret;
 			if (pathRootHack(p, "~")) ret.push_back(home / p);
 			else if (pathRootHack(p, "DATADIR")) {
@@ -46,135 +44,18 @@ namespace {
 			else ret.push_back(p);
 			return ret;
 		}
-
-		fs::path base, share, locale, sysConf, home, conf, data, cache;
-		Paths paths;
 		// Note: three-phase init:
 		// 1. Default constructor runs in static context (before main) and cannot do much
 		// 2. pathBootstrap is called to find out static system paths (critical for logging and for loading config files)
 		// 3. pathInit is called to process the full search path, using config settings
-		void pathBootstrap() {
-			if (!base.empty()) return;  // Only bootstrap once
-			// Base (e.g. /usr/local), share (src or installed data files) and locale (built or installed .mo files)
-			{
-				char const* root = getenv("PERFORMOUS_ROOT");
-				base = fs::absolute(root ? root : execname().parent_path());
-				do {
-					if (base.empty()) throw std::runtime_error("Unable to find Performous data files. Install properly or set environment variable PERFORMOUS_ROOT.");
-					for (fs::path const& infix: { fs::path(SHARED_DATA_DIR), fs::path("data"), fs::path() }) {
-						if (!fs::exists(base / infix / configSchema)) continue;
-						share = base / infix;
-						goto found;
-					}
-					// Use locale .mo files from build folder?
-					if (base.filename() == "build" && fs::exists(base / "lang")) {
-						locale = base / "lang";
-					}
-					base = base.parent_path();
-				} while (true);
-			found:;
-				if (locale.empty() && fs::exists(base / LOCALEDIR)) locale = base / LOCALEDIR;
-			}
-			// System-wide config files
-			{
-			#ifdef _WIN32
-				sysConf = execname().parent_path() / "config";  // I.e. Program Files/Performous/config or build/config/
-			#else
-				sysConf = "/etc/xdg/performous";
-			#endif
-			}
-			// Home
-			{
-			#ifdef _WIN32
-				char const* p = getenv("USERPROFILE");
-			#else
-				char const* p = getenv("HOME");
-			#endif
-				if (p) home = p;
-			}
-			// Config
-			{
-			#ifdef _WIN32
-				ITEMIDLIST* pidl;
-				HRESULT hRes = SHGetSpecialFolderLocation(nullptr, CSIDL_APPDATA|CSIDL_FLAG_CREATE, &pidl);
-				if (hRes != NOERROR) throw std::runtime_error("Unable to determine where Application Data is stored");
-				char p[MAX_PATH];
-				SHGetPathFromIDList(pidl, p);
-				conf = p;
-			#else
-				char const* p = getenv("XDG_CONFIG_HOME");
-				conf = (p ? p : home / ".config");
-			#endif
-				conf /= performous;
-			}
-			// Data
-			{
-			#ifdef _WIN32
-				data = conf;
-			#else
-				char const* p = getenv("XDG_DATA_HOME");
-				data = (p ? p / performous : home / ".local" / SHARED_DATA_DIR);
-			#endif
-			}
-			// Cache
-			{
-			#ifdef _WIN32
-				cache = data / "cache";  // FIXME: Should we use GetTempPath?
-			#else
-				char const* p = getenv("XDG_CACHE_HOME");
-				cache = (p ? p / performous : home / ".cache" / performous);
-			#endif
-			}
-			pathInit();
-		}
-		/// Initialize/reset data dirs (search path).
-		void pathInit() {
-			bool bootstrapping = paths.empty();  // The first run (during bootstrap)
-			if (!bootstrapping) {
-				std::string logmsg = "fs/info: Found system paths:\n";
-				logmsg += "  base:     " + base.string() + '\n';
-				logmsg += "  share:    " + share.string() + '\n';
-				logmsg += "  locale:   " + locale.string() + '\n';
-				logmsg += "  sysConf:  " + sysConf.string() + '\n';
-				logmsg += "  home:     " + home.string() + '\n';
-				logmsg += "  config:   " + conf.string() + '\n';
-				logmsg += "  data:     " + data.string() + '\n';
-				logmsg += "  cache:    " + cache.string() + '\n';
-				std::clog << logmsg << std::flush;
-			}
-			// Data dirs
-			std::string logmsg = "fs/info: Determining data dirs (search path):\n";
-			{
-				Paths dirs;
-				dirs.push_back(data);  // Adding user's data dir
-				dirs.push_back(share);  // Adding system data dir (relative to performous executable or PERFORMOUS_ROOT)
-			#ifndef _WIN32
-				// Adding XDG_DATA_DIRS
-				{
-					char const* xdg_data_dirs = getenv("XDG_DATA_DIRS");
-					std::istringstream iss(xdg_data_dirs ? xdg_data_dirs : "/usr/local/share/:/usr/share/");
-					for (std::string p; std::getline(iss, p, ':'); dirs.push_back(p / performous)) {}
-				}
-			#endif
-				// Adding paths from config file (during bootstrap config options are not yet available)
-				if (!bootstrapping) {
-					auto const& conf = config["paths/system"].sl();
-					for (std::string const& dir: conf) dirs.splice(dirs.end(), pathExpand(dir));
-				}
-				// Check if they actually exist and print debug
-				paths.clear();
-				std::set<fs::path> used;
-				for (auto dir: dirs) {
-					dir = fs::absolute(dir);
-					if (used.find(dir) != used.end()) continue;
-					logmsg += "  " + dir.string() + '\n';
-					paths.push_back(dir);
-					used.insert(dir);
-				}
-			}
-			if (!bootstrapping) std::clog << logmsg << std::flush;
-		}
+		
+	#if (BOOST_OS_WINDOWS)
+	#include "platform/fs_paths.win.inc"
+	#else
+	#include "platform/fs_paths.unix.inc"
+	#endif
 	} cache;
+
 	boost::mutex mutex;
 	typedef boost::lock_guard<boost::mutex> Lock;
 }

--- a/game/fs.hh
+++ b/game/fs.hh
@@ -6,6 +6,10 @@
 namespace fs = boost::filesystem;
 
 std::list<std::string> getThemes();  ///< Find all theme folders and return theme names.
+
+/// Recursively copies a folder, throws on error.
+void copyDirectoryRecursively(const fs::path& sourceDir, const fs::path& destinationDir);
+
 /// Determine where the important system paths and most importantly the config schema are. Must be run before any of the functions below.
 void pathBootstrap();
 

--- a/game/fs.hh
+++ b/game/fs.hh
@@ -5,6 +5,7 @@
 
 namespace fs = boost::filesystem;
 
+std::list<std::string> getThemes();  ///< Find all theme folders and return theme names.
 /// Determine where the important system paths and most importantly the config schema are. Must be run before any of the functions below.
 void pathBootstrap();
 
@@ -13,8 +14,11 @@ void pathBootstrap();
 /// - Logging and config must be running before pathInit (pathInit is first called from configuration.cc).
 void pathInit();
 
-std::list<std::string> getThemes();  ///< Find all theme folders and return theme names.
+/// Test if a path begins with name and if so, remove that element and return true
+/// Mostly a workaround for fs::path's crippled API that makes this operation difficult
+bool pathRootHack(fs::path& p, std::string const& name);
 
+fs::path execname(); ///< Get the path and filename of the main executable.
 fs::path getLogFilename();  ///< Get the log filename.
 fs::path getSchemaFilename();  ///< Get the config schema filename.
 fs::path getHomeDir();  ///< Get user's home folder.
@@ -26,6 +30,12 @@ fs::path getShareDir();  ///< Get Performous system-level data folder.
 fs::path getLocaleDir();  ///< Get the system local folder.
 
 typedef std::list<fs::path> Paths;
+
+struct pathCache {
+	Paths pathExpand(fs::path p);
+	void pathBootstrap();
+	void pathInit();
+};
 
 fs::path findFile(fs::path const& filename);  ///< Look for the specified file in theme and data folders.
 Paths listFiles(fs::path const& dir);  ///< List contents of specified folder in theme and data folders (omit duplicates).

--- a/game/game.cc
+++ b/game/game.cc
@@ -10,6 +10,8 @@
 #include <stdexcept>
 #include <cstdlib>
 
+extern const double m_pi;
+
 template<> Game* Singleton<Game>::ms_Singleton = nullptr;
 
 Game::Game(Window& _window):
@@ -113,7 +115,7 @@ bool Game::closeDialog() {
 }
 
 void Game::drawLogo() {
-	double v = 0.5 - 0.5 * std::cos(M_PI * m_logoAnim.get());
+	double v = 0.5 - 0.5 * std::cos(m_pi * m_logoAnim.get());
 	m_logo.dimensions.fixedHeight(0.1).left(-0.45).screenTop(-0.1 + 0.11 * v);
 	m_logo.draw();
 }

--- a/game/glmath.hh
+++ b/game/glmath.hh
@@ -6,11 +6,9 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+#include <boost/math/constants/constants.hpp>
 
-// FIXME: Temporary MinGW fix
-#ifndef M_PI
-#define M_PI 3.1415926535
-#endif
+// extern const double m_pi;
 
 namespace glmath {
 

--- a/game/libda/fft.hpp
+++ b/game/libda/fft.hpp
@@ -9,11 +9,9 @@
 #include <cstddef>
 #include <vector>
 
-#ifndef M_PI
-#define M_PI 3.141592653589793
-#endif
+extern const double m_pi;
 
-#define M_TAU (2.0 * M_PI)
+const double m_tau = (2.0 * m_pi);
 
 namespace da {
 
@@ -34,7 +32,7 @@ namespace da {
 				const std::complex<T> temp = data[i + M] * w;
 				data[M + i] = data[i] - temp;
 				data[i] += temp;
-				w *= std::polar<T>(1.0, -M_TAU / N);
+				w *= std::polar<T>(1.0, -m_tau / N);
 			}
 		}
 	};

--- a/game/main.cc
+++ b/game/main.cc
@@ -34,13 +34,6 @@
 #include <vector>
 #include <cstdlib>
 
-#if defined(_WIN32)
-extern "C" {
-// For DWORD (see end of file)
-#include "windef.h"
-}
-#endif
-
 // Disable main level exception handling for debug builds (because gdb cannot properly catch throwing otherwise)
 #ifdef NDEBUG
 #define RUNTIME_ERROR std::runtime_error
@@ -420,13 +413,3 @@ void outputOptionalFeatureStatus() {
 	  << "\n  Webcam support:       " << (Webcam::enabled() ? "Enabled" : "Disabled")
 	  << std::endl;
 }
-
-#if defined(_WIN32)
-// Force high-performance graphics on dual-GPU systems
-extern "C" {
-	// http://developer.download.nvidia.com/devzone/devcenter/gamegraphics/files/OptimusRenderingPolicies.pdf
-	__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
-	// https://community.amd.com/thread/169965
-	__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
-}
-#endif

--- a/game/main.cc
+++ b/game/main.cc
@@ -6,6 +6,7 @@
 #include "glutil.hh"
 #include "i18n.hh"
 #include "log.hh"
+#include "platform.hh"
 #include "profiler.hh"
 #include "screen.hh"
 #include "songs.hh"
@@ -142,6 +143,7 @@ static void checkEvents(Game& gm) {
 }
 
 void mainLoop(std::string const& songlist) {
+	Platform platform;
 	std::clog << "core/notice: Starting the audio subsystem (errors printed on console may be ignored)." << std::endl;
 	Audio audio;
 	std::clog << "core/info: Loading assets." << std::endl;

--- a/game/main.cc
+++ b/game/main.cc
@@ -6,6 +6,7 @@
 #include "glutil.hh"
 #include "i18n.hh"
 #include "log.hh"
+#include "pi.hh"
 #include "platform.hh"
 #include "profiler.hh"
 #include "screen.hh"
@@ -33,6 +34,8 @@
 #include <string>
 #include <vector>
 #include <cstdlib>
+
+const double m_pi = boost::math::constants::pi<double>();
 
 // Disable main level exception handling for debug builds (because gdb cannot properly catch throwing otherwise)
 #ifdef NDEBUG

--- a/game/notegraph.cc
+++ b/game/notegraph.cc
@@ -5,6 +5,8 @@
 #include "engine.hh"
 #include "player.hh"
 
+extern const double m_pi;
+
 Dimensions dimensions; // Make a public member variable
 
 NoteGraph::NoteGraph(VocalTrack const& vocal):
@@ -132,7 +134,7 @@ void NoteGraph::draw(double time, Database const& database, Position position) {
 			float hh = -m_noteUnit;
 			float centery = m_baseY + (it->note + 0.4) * m_noteUnit; // Star is 0.4 notes higher than current note
 			float centerx = x + w - (player_star_offset + 1.2) * hh; // Star is 1.2 units from end
-			float rot = fmod(time * 5.0, 2.0 * M_PI); // They rotate!
+			float rot = fmod(time * 5.0, 2.0 * m_pi); // They rotate!
 			bool smallerNoteGraph = ((position == NoteGraph::TOP) || (position == NoteGraph::BOTTOM));
 			float zoom = (std::abs((rot-180) / 360.0f) * 0.8f + 0.6f) * (smallerNoteGraph ? 2.3 : 2.0) * hh;
 			using namespace glmath;

--- a/game/pi.hh
+++ b/game/pi.hh
@@ -1,0 +1,3 @@
+#include <boost/math/constants/constants.hpp>
+
+extern const double m_pi;

--- a/game/pitch.cc
+++ b/game/pitch.cc
@@ -44,7 +44,7 @@ Analyzer::Analyzer(double rate, std::string id, std::size_t step):
 	if (m_step > FFT_N) throw std::logic_error("Analyzer step is larger that FFT_N (ideally it should be less than a fourth of FFT_N).");
 	// Hamming window
 	for (size_t i=0; i < FFT_N; i++) {
-		m_window[i] = 0.53836 - 0.46164 * std::cos(2.0 * M_PI * i / (FFT_N - 1));
+		m_window[i] = 0.53836 - 0.46164 * std::cos(2.0 * m_pi * i / (FFT_N - 1));
 	}
 }
 
@@ -123,7 +123,7 @@ bool Analyzer::calcFFT() {
 void Analyzer::calcTones() {
 	// Precalculated constants
 	const double freqPerBin = m_rate / FFT_N;
-	const double phaseStep = 2.0 * M_PI * m_step / FFT_N;
+	const double phaseStep = 2.0 * m_pi * m_step / FFT_N;
 	const double normCoeff = 1.0 / FFT_N;
 	const double minMagnitude = pow(10, -100.0 / 20.0) / normCoeff; // -100 dB
 	// Limit frequency range of processing
@@ -137,7 +137,7 @@ void Analyzer::calcTones() {
 		double delta = phase - m_fftLastPhase[k];
 		m_fftLastPhase[k] = phase;
 		delta -= k * phaseStep;  // subtract expected phase difference
-		delta = remainder(delta, 2.0 * M_PI);  // map delta phase into +/- M_PI interval
+		delta = remainder(delta, 2.0 * m_pi);  // map delta phase into +/- m_pi interval
 		delta /= phaseStep;  // calculate diff from bin center frequency
 		double freq = (k + delta) * freqPerBin;  // calculate the true frequency
 		if (freq > 1.0 && magnitude > minMagnitude) {

--- a/game/platform.cc
+++ b/game/platform.cc
@@ -1,0 +1,15 @@
+#include "platform.hh"
+#include "fs.hh"
+
+Platform::platforms Platform::currentOS() {
+if (BOOST_OS_WINDOWS != 0) { return windows; }
+else if (BOOST_OS_LINUX != 0) { return linux; }
+else if (BOOST_OS_MACOS != 0) { return macos; }
+else if (BOOST_OS_BSD != 0) { return bsd; }
+else if (BOOST_OS_SOLARIS != 0) { return solaris; }
+else if (BOOST_OS_UNIX != 0) { return unix; }
+}
+
+Platform::Platform() {}
+
+const std::array<const char*,6> Platform::platformNames = {{ "Windows", "Linux", "MacOS", "BSD", "Solaris", "Unix" }}; // Relevant for debug only.

--- a/game/platform.cc
+++ b/game/platform.cc
@@ -13,3 +13,15 @@ else if (BOOST_OS_UNIX != 0) { return unix; }
 Platform::Platform() {}
 
 const std::array<const char*,6> Platform::platformNames = {{ "Windows", "Linux", "MacOS", "BSD", "Solaris", "Unix" }}; // Relevant for debug only.
+
+#if (BOOST_OS_WINDOWS)
+extern "C" {
+// For DWORD (see end of file)
+#include "windef.h"
+// Force high-performance graphics on dual-GPU systems
+	// http://developer.download.nvidia.com/devzone/devcenter/gamegraphics/files/OptimusRenderingPolicies.pdf
+	__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+	// https://community.amd.com/thread/169965
+	__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+}
+#endif

--- a/game/platform.hh
+++ b/game/platform.hh
@@ -5,7 +5,13 @@
 
 #include <array>
 #include <iostream>
+
+#if ((BOOST_VERSION / 100 % 1000) >= 55)
 #include <boost/predef/os.h>
+#else
+#include "../boost_predef/os.h"
+#endif
+
 #include <boost/filesystem.hpp>
 
 struct Platform {

--- a/game/platform.hh
+++ b/game/platform.hh
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "fs.hh"
+#include "log.hh"
+
+#include <array>
+#include <iostream>
+#include <boost/predef/os.h>
+#include <boost/filesystem.hpp>
+
+struct Platform {
+enum platforms { windows, linux, macos, bsd, solaris, unix };
+Platform();
+static platforms currentOS();
+
+private:
+static const std::array<const char*,6> platformNames;
+};

--- a/game/platform/execname.bsd.inc
+++ b/game/platform/execname.bsd.inc
@@ -1,0 +1,16 @@
+#include <sys/sysctl.h>
+
+fs::path execname() {
+	int mib[4];
+	mib[0] = CTL_KERN;
+	mib[1] = KERN_PROC;
+	mib[2] = KERN_PROC_PATHNAME;
+	mib[3] = -1;
+	char buf[1024];
+	size_t maxchars = sizeof(buf) - 1;
+	size_t size = maxchars;
+	sysctl(mib, 4, buf, &size, NULL, 0);
+	if (size == 0 || size >= maxchars) return fs::path();
+	buf[size] = '\0';
+	return buf;
+}

--- a/game/platform/execname.mac.inc
+++ b/game/platform/execname.mac.inc
@@ -1,0 +1,9 @@
+#include <mach-o/dyld.h>
+
+fs::path execname() {
+	char buf[1024];
+	uint32_t size = sizeof(buf);
+	int ret = _NSGetExecutablePath(buf, &size);
+	if (ret != 0) return fs::path();
+	return buf;
+}

--- a/game/platform/execname.sun.inc
+++ b/game/platform/execname.sun.inc
@@ -1,0 +1,5 @@
+#include <stdlib.h>
+
+fs::path execname() {
+	return getexecname();
+}

--- a/game/platform/execname.unix.inc
+++ b/game/platform/execname.unix.inc
@@ -1,0 +1,10 @@
+#include <unistd.h>
+
+fs::path execname() {
+	char buf[1024];
+	ssize_t maxchars = sizeof(buf) - 1;
+	ssize_t size = readlink("/proc/self/exe", buf, sizeof(buf));
+	if (size <= 0 || size >= maxchars) return fs::path();
+	buf[size] = '\0';
+	return buf;
+}

--- a/game/platform/execname.win.inc
+++ b/game/platform/execname.win.inc
@@ -1,0 +1,8 @@
+#include <windows.h>
+
+fs::path execname() {
+	char buf[1024];
+	DWORD ret = GetModuleFileName(NULL, buf, sizeof(buf));
+	if (ret == 0 || ret == sizeof(buf)) return std::string();
+	return buf;
+}

--- a/game/platform/fs_paths.unix.inc
+++ b/game/platform/fs_paths.unix.inc
@@ -23,7 +23,7 @@
 			}
 			// System-wide config files
 			{
-				sysConf = "/etc/xdg/performous";
+				sysConf = (Platform::currentOS() == Platform::macos) ? "/Library/Preferences/Performous" : "/etc/xdg/performous";
 			}
 			
 			// Home
@@ -34,21 +34,35 @@
 			
 			// Config
 			{
-				char const* p = getenv("XDG_CONFIG_HOME");
-				conf = (p ? p : home / ".config");
-
-				conf /= performous;
+				if (Platform::currentOS() == Platform::macos) {
+					conf = (home / "Library/Preferences/Performous");
+				}
+				else {
+					char const* p = getenv("XDG_CONFIG_HOME");
+					conf = (p ? p : home / ".config");
+					conf /= performous;
+				}
 			}
 			
 			// Data
 			{
+				if (Platform::currentOS() == Platform::macos) {
+					data = share;
+				}
+				else {
 				char const* p = getenv("XDG_DATA_HOME");
 				data = (p ? p / performous : home / ".local" / SHARED_DATA_DIR);
+				}
 			}
 			// Cache
 			{
+				if (Platform::currentOS() == Platform::macos) {
+					cache = (home / "Library/Caches/Performous"); 
+				}
+				else {
 				char const* p = getenv("XDG_CACHE_HOME");
 				cache = (p ? p / performous : home / ".cache" / performous);
+				}
 			}
 			pathInit();
 		}

--- a/game/platform/fs_paths.unix.inc
+++ b/game/platform/fs_paths.unix.inc
@@ -1,0 +1,101 @@
+		// 2. pathBootstrap is called to find out static system paths (critical for logging and for loading config files)
+		void pathBootstrap() {
+			if (!base.empty()) return;  // Only bootstrap once
+			// Base (e.g. /usr/local), share (src or installed data files) and locale (built or installed .mo files)
+			{
+				char const* root = getenv("PERFORMOUS_ROOT");
+				base = fs::absolute(root ? root : execname().parent_path());
+				do {
+					if (base.empty()) throw std::runtime_error("Unable to find Performous data files. Install properly or set environment variable PERFORMOUS_ROOT.");
+					for (fs::path const& infix: { fs::path(SHARED_DATA_DIR), fs::path("data"), fs::path() }) {
+						if (!fs::exists(base / infix / configSchema)) continue;
+						share = base / infix;
+						goto found;
+					}
+					// Use locale .mo files from build folder?
+					if (base.filename() == "build" && fs::exists(base / "lang")) {
+						locale = base / "lang";
+					}
+					base = base.parent_path();
+				} while (true);
+			found:;
+				if (locale.empty() && fs::exists(base / LOCALEDIR)) locale = base / LOCALEDIR;
+			}
+			// System-wide config files
+			{
+				sysConf = "/etc/xdg/performous";
+			}
+			
+			// Home
+			{
+			char const* p = getenv("HOME");
+				if (p) home = p;
+			}
+			
+			// Config
+			{
+				char const* p = getenv("XDG_CONFIG_HOME");
+				conf = (p ? p : home / ".config");
+
+				conf /= performous;
+			}
+			
+			// Data
+			{
+				char const* p = getenv("XDG_DATA_HOME");
+				data = (p ? p / performous : home / ".local" / SHARED_DATA_DIR);
+			}
+			// Cache
+			{
+				char const* p = getenv("XDG_CACHE_HOME");
+				cache = (p ? p / performous : home / ".cache" / performous);
+			}
+			pathInit();
+		}
+		
+		/// Initialize/reset data dirs (search path).
+		void pathInit() {
+			bool bootstrapping = paths.empty();  // The first run (during bootstrap)
+			if (!bootstrapping) {
+				std::string logmsg = "fs/info: Found system paths:\n";
+				logmsg += "  base:     " + base.string() + '\n';
+				logmsg += "  share:    " + share.string() + '\n';
+				logmsg += "  locale:   " + locale.string() + '\n';
+				logmsg += "  sysConf:  " + sysConf.string() + '\n';
+				logmsg += "  home:     " + home.string() + '\n';
+				logmsg += "  config:   " + conf.string() + '\n';
+				logmsg += "  data:     " + data.string() + '\n';
+				logmsg += "  cache:    " + cache.string() + '\n';
+				std::clog << logmsg << std::flush;
+			}
+			// Data dirs
+			std::string logmsg = "fs/info: Determining data dirs (search path):\n";
+			{
+				Paths dirs;
+				dirs.push_back(data);  // Adding user's data dir
+				dirs.push_back(share);  // Adding system data dir (relative to performous executable or PERFORMOUS_ROOT)
+				
+				// Adding XDG_DATA_DIRS
+				{
+					char const* xdg_data_dirs = getenv("XDG_DATA_DIRS");
+					std::istringstream iss(xdg_data_dirs ? xdg_data_dirs : "/usr/local/share/:/usr/share/");
+					for (std::string p; std::getline(iss, p, ':'); dirs.push_back(p / performous)) {}
+				}
+				// Adding paths from config file (during bootstrap config options are not yet available)
+				if (!bootstrapping) {
+					auto const& conf = config["paths/system"].sl();
+					for (std::string const& dir: conf) dirs.splice(dirs.end(), pathExpand(dir));
+				}
+				// Check if they actually exist and print debug
+				paths.clear();
+				std::set<fs::path> used;
+				for (auto dir: dirs) {
+					dir = fs::absolute(dir);
+					if (used.find(dir) != used.end()) continue;
+					logmsg += "  " + dir.string() + '\n';
+					paths.push_back(dir);
+					used.insert(dir);
+				}
+			}
+			if (!bootstrapping) std::clog << logmsg << std::flush;
+		}

--- a/game/platform/fs_paths.unix.inc
+++ b/game/platform/fs_paths.unix.inc
@@ -82,6 +82,24 @@
 				logmsg += "  cache:    " + cache.string() + '\n';
 				std::clog << logmsg << std::flush;
 			}
+				if (Platform::currentOS() == Platform::macos) {
+				char const* p = getenv("XDG_CONFIG_HOME");
+				fs::path oldConf = (p ? p : home / ".config");
+				oldConf /= performous;
+				if (is_directory(oldConf)) {
+				std::clog << "fs/info: Configuration files found in old path: ~/.config/performous" << std::endl;
+				conf = (home / "/Library/Preferences/Performous");
+				try {
+					copyDirectoryRecursively(oldConf, conf);
+					fs::remove_all(oldConf);
+					fs::path oldCache = (home / ".cache/performous");
+					fs::remove_all(oldCache);
+				std::clog << "fs/info: Succesfully moved configuration files to their new location: " << conf.string() << std::endl;
+				} catch (...) {
+				throw std::runtime_error("Unable to move configuration data to " + conf.string());
+				}
+				}
+				}
 			// Data dirs
 			std::string logmsg = "fs/info: Determining data dirs (search path):\n";
 			{

--- a/game/platform/fs_paths.unix.inc
+++ b/game/platform/fs_paths.unix.inc
@@ -84,21 +84,24 @@
 			}
 				if (Platform::currentOS() == Platform::macos) {
 				char const* p = getenv("XDG_CONFIG_HOME");
-				fs::path oldConf = (p ? p : home / ".config");
-				oldConf /= performous;
-				if (is_directory(oldConf)) {
-				std::clog << "fs/info: Configuration files found in old path: ~/.config/performous" << std::endl;
+				fs::path oldConf = (p ? p : home / ".config/performous");
+				if (fs::is_directory(oldConf)) {
+				std::clog << "fs/info: Configuration files found in old path, " << oldConf << std::endl;
 				conf = (home / "/Library/Preferences/Performous");
-				try {
-					copyDirectoryRecursively(oldConf, conf);
-					fs::remove_all(oldConf);
-					fs::path oldCache = (home / ".cache/performous");
-					fs::remove_all(oldCache);
-				std::clog << "fs/info: Succesfully moved configuration files to their new location: " << conf.string() << std::endl;
-				} catch (...) {
-				throw std::runtime_error("Unable to move configuration data to " + conf.string());
+					if (bootstrapping) {
+						copyDirectoryRecursively(oldConf, conf);
+					try {
+						fs::remove_all(oldConf);
+						fs::path oldCache = (home / ".cache/performous");
+						fs::remove_all(oldCache);
+						didMigrateConfig = true;
+					}
+					catch (...) {
+						throw std::runtime_error("There was an error migrating configuration to " + conf.string());
+					}
+					}
 				}
-				}
+				if (didMigrateConfig) { std::clog << "fs/info: Succesfully moved configuration files to their new location: " << conf.string() << std::endl; }
 				}
 			// Data dirs
 			std::string logmsg = "fs/info: Determining data dirs (search path):\n";

--- a/game/platform/fs_paths.win.inc
+++ b/game/platform/fs_paths.win.inc
@@ -1,0 +1,95 @@
+#include <windows.h>
+#include <shlobj.h>
+
+		// 2. pathBootstrap is called to find out static system paths (critical for logging and for loading config files)
+		void pathBootstrap() {
+			if (!base.empty()) return;  // Only bootstrap once
+			// Base (e.g. /usr/local), share (src or installed data files) and locale (built or installed .mo files)
+			{
+				char const* root = getenv("PERFORMOUS_ROOT");
+				base = fs::absolute(root ? root : execname().parent_path());
+				do {
+					if (base.empty()) throw std::runtime_error("Unable to find Performous data files. Install properly or set environment variable PERFORMOUS_ROOT.");
+					for (fs::path const& infix: { fs::path(SHARED_DATA_DIR), fs::path("data"), fs::path() }) {
+						if (!fs::exists(base / infix / configSchema)) continue;
+						share = base / infix;
+						goto found;
+					}
+					// Use locale .mo files from build folder?
+					if (base.filename() == "build" && fs::exists(base / "lang")) {
+						locale = base / "lang";
+					}
+					base = base.parent_path();
+				} while (true);
+			found:;
+				if (locale.empty() && fs::exists(base / LOCALEDIR)) locale = base / LOCALEDIR;
+			}
+			// System-wide config files
+			{
+				sysConf = execname().parent_path() / "config";
+			}
+			// Home
+			{
+			char const* p = getenv("USERPROFILE");
+				if (p) home = p;
+			}
+			// Config
+			{
+				ITEMIDLIST* pidl;
+				HRESULT hRes = SHGetSpecialFolderLocation(nullptr, CSIDL_APPDATA|CSIDL_FLAG_CREATE, &pidl);
+				if (hRes != NOERROR) throw std::runtime_error("Unable to determine where Application Data is stored");
+				char p[MAX_PATH];
+				SHGetPathFromIDList(pidl, p);
+				conf = p;
+				conf /= performous;
+			}
+			// Data
+			{
+				data = conf;
+			}
+			// Cache
+			{
+				cache = data / "cache";  // FIXME: Should we use GetTempPath?
+			}
+			pathInit();
+		}
+		/// Initialize/reset data dirs (search path).
+		void pathInit() {
+			bool bootstrapping = paths.empty();  // The first run (during bootstrap)
+			if (!bootstrapping) {
+				std::string logmsg = "fs/info: Found system paths:\n";
+				logmsg += "  base:     " + base.string() + '\n';
+				logmsg += "  share:    " + share.string() + '\n';
+				logmsg += "  locale:   " + locale.string() + '\n';
+				logmsg += "  sysConf:  " + sysConf.string() + '\n';
+				logmsg += "  home:     " + home.string() + '\n';
+				logmsg += "  config:   " + conf.string() + '\n';
+				logmsg += "  data:     " + data.string() + '\n';
+				logmsg += "  cache:    " + cache.string() + '\n';
+				std::clog << logmsg << std::flush;
+			}
+			// Data dirs
+			std::string logmsg = "fs/info: Determining data dirs (search path):\n";
+			{
+				Paths dirs;
+				dirs.push_back(data);  // Adding user's data dir
+				dirs.push_back(share);  // Adding system data dir (relative to performous executable or PERFORMOUS_ROOT)
+
+				// Adding paths from config file (during bootstrap config options are not yet available)
+				if (!bootstrapping) {
+					auto const& conf = config["paths/system"].sl();
+					for (std::string const& dir: conf) dirs.splice(dirs.end(), pathExpand(dir));
+				}
+				// Check if they actually exist and print debug
+				paths.clear();
+				std::set<fs::path> used;
+				for (auto dir: dirs) {
+					dir = fs::absolute(dir);
+					if (used.find(dir) != used.end()) continue;
+					logmsg += "  " + dir.string() + '\n';
+					paths.push_back(dir);
+					used.insert(dir);
+				}
+			}
+			if (!bootstrapping) std::clog << logmsg << std::flush;
+		}

--- a/game/screen_intro.cc
+++ b/game/screen_intro.cc
@@ -9,6 +9,7 @@
 #include "menu.hh"
 #include "xtime.hh"
 
+extern const double m_pi;
 
 ScreenIntro::ScreenIntro(std::string const& name, Audio& audio): Screen(name), m_audio(audio), m_first(true) {
 }
@@ -134,7 +135,7 @@ void ScreenIntro::draw() {
 	glutil::GLErrorChecker glerror("ScreenIntro::draw()");
 	{
 		float anim = SDL_GetTicks() % 20000 / 20000.0;
-		ColorTrans c(glmath::rotate(2.0 * M_PI * anim, glmath::vec3(1.0, 1.0, 1.0)));
+		ColorTrans c(glmath::rotate(2.0 * m_pi * anim, glmath::vec3(1.0, 1.0, 1.0)));
 		theme->bg.draw();
 	}
 	glerror.check("bg");

--- a/game/screen_songs.cc
+++ b/game/screen_songs.cc
@@ -15,6 +15,7 @@
 #include <sstream>
 #include <boost/format.hpp>
 
+extern const double m_pi;
 static const double IDLE_TIMEOUT = 45.0; // seconds
 
 ScreenSongs::ScreenSongs(std::string const& name, Audio& audio, Songs& songs, Database& database):
@@ -360,12 +361,12 @@ void ScreenSongs::drawCovers() {
 		Song& song = *m_songs[baseidx + i];
 		Surface& s = getCover(song);
 		// Calculate dimensions for cover and instrument markers
-		double diff = 0.5 * (1.0 + std::cos(std::min(M_PI, std::abs(i - shift))));  // 0..1 for current cover hilight level
+		double diff = 0.5 * (1.0 + std::cos(std::min(m_pi, std::abs(i - shift))));  // 0..1 for current cover hilight level
 		double y = 0.5 * virtH();
 		using namespace glmath;
 		Transform trans(
 		  translate(vec3(-0.2 + 0.20 * (i - shift), y, -0.2 - 0.3 * (1.0 - diff)))
-		  * rotate(0.4 * std::sin(std::min(M_PI, i - shift)), vec3(0.0, 1.0, 0.0))
+		  * rotate(0.4 * std::sin(std::min(m_pi, i - shift)), vec3(0.0, 1.0, 0.0))
 		);
 		double c = 0.4 + 0.6 * diff;
 		if (m_menuPos == 1 /* Cover browser */ && baseidx + i == currentId) c = beat;


### PR DESCRIPTION
Things in this PR:

1) Created a Platform struct that can provide robust platform information for minor things that can be done at runtime.

2) Refactored platform-dependent implementations for filesystem tasks into independent include files, thus making code saner and providing a framework to do the same with the platform-dependent implementations we will be merging eventually.

3) Changed path for macOS config files and such to appropriate locations (~/Library/Preferences/Performous instead of ~/.config/performous). Also, modified pathInit so that it searches the old location and copies the settings over in case it finds them in there.
It would be great if somebody take a look at the windows implementation and checks double-checks whether we are actually storing things in the correct places.

4) Moved the dGPU enforcing code out of main.cc