### PR TITLE
Fix IP detection on macOS.

### DIFF
--- a/game/screen_intro.cc
+++ b/game/screen_intro.cc
@@ -214,7 +214,7 @@ std::string ScreenIntro::getIPaddr() {
 	try {
 		boost::asio::io_service netService;
 		boost::asio::ip::udp::resolver resolver(netService);
-		boost::asio::ip::udp::resolver::query query(boost::asio::ip::udp::v4(), "google.com", ""); //it's a bit of a dirty hack, but it works!
+		boost::asio::ip::udp::resolver::query query(boost::asio::ip::udp::v4(), "8.8.8.8", "80"); //it's a bit of a dirty hack, but it works!
 		boost::asio::ip::udp::resolver::iterator endpoints = resolver.resolve(query);
 		boost::asio::ip::udp::endpoint ep = *endpoints;
 		boost::asio::ip::udp::socket socket(netService);
@@ -224,6 +224,5 @@ std::string ScreenIntro::getIPaddr() {
 	} catch(std::exception& e) {
 			return "cannot obtain IP";
 	}
-
 	return "IP address";
 }


### PR DESCRIPTION
1) Changed google.com to google’s name server.
2) Added a port number, which effectively fixes this approach for macOS.

Can you guys please test whether it still works fine on the remaining platforms? (I don't see why it wouldn't)