### PR TITLE
Fix crash when showing “done loading” popup.

### DIFF
--- a/game/main.cc
+++ b/game/main.cc
@@ -189,6 +189,10 @@ void mainLoop(std::string const& songlist) {
 		while (!gm.isFinished()) {
 			Profiler prof("mainloop");
 			bool benchmarking = config["graphic/fps"].b();
+			if (songs.doneLoading == true && songs.shownFinishDialog == false) {
+				gm.dialog(_("Done Loading!\n Loaded ") + std::to_string(songs.loadedSongs()) + " Songs.");
+				songs.shownFinishDialog = true;
+			}
 			if( g_take_screenshot ) {
 				try {
 					window.screenshot();

--- a/game/main.cc
+++ b/game/main.cc
@@ -189,9 +189,9 @@ void mainLoop(std::string const& songlist) {
 		while (!gm.isFinished()) {
 			Profiler prof("mainloop");
 			bool benchmarking = config["graphic/fps"].b();
-			if (songs.doneLoading == true && songs.shownFinishDialog == false) {
+			if (songs.doneLoading == true && songs.displayedAlert == false) {
 				gm.dialog(_("Done Loading!\n Loaded ") + std::to_string(songs.loadedSongs()) + " Songs.");
-				songs.shownFinishDialog = true;
+				songs.displayedAlert = true;
 			}
 			if( g_take_screenshot ) {
 				try {

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -60,8 +60,7 @@ void Songs::reload_internal() {
 	std::clog << std::flush;
 	m_loading = false;
 	std::clog << "songs/notice: Done Loading. Loaded " << m_songs.size() << " Songs." << std::endl;
-	Game* gm = Game::getSingletonPtr();
-    //gm->dialog(_("Done Loading!\n Loaded ") + boost::lexical_cast<std::string>(m_songs.size()) + " Songs.");	//crashes on ubuntu 16.10 but not on 16.04
+	doneLoading = true;
 }
 
 void Songs::reload_internal(fs::path const& parent) {

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -30,6 +30,10 @@ Songs::~Songs() {
 
 void Songs::reload() {
 	if (m_loading) return;
+	if (doneLoading == true) {
+		doneLoading = false;
+		displayedAlert = false;
+	}
 	// Run loading thread
 	m_loading = true;
 	m_thread.reset(new boost::thread(boost::bind(&Songs::reload_internal, boost::ref(*this))));

--- a/game/songs.hh
+++ b/game/songs.hh
@@ -70,6 +70,9 @@ class Songs: boost::noncopyable {
 	void sortSpecificChange(int sortOrder, bool descending = false);
 	/// parses file into Song &tmp
 	void parseFile(Song& tmp);
+	volatile bool doneLoading = false;
+	volatile bool shownFinishDialog = false;
+	size_t loadedSongs() const { return m_songs.size(); }
 
   private:
 	class RestoreSel;

--- a/game/songs.hh
+++ b/game/songs.hh
@@ -71,7 +71,7 @@ class Songs: boost::noncopyable {
 	/// parses file into Song &tmp
 	void parseFile(Song& tmp);
 	volatile bool doneLoading = false;
-	volatile bool shownFinishDialog = false;
+	volatile bool displayedAlert = false;
 	size_t loadedSongs() const { return m_songs.size(); }
 
   private:


### PR DESCRIPTION
In short, the crash was due to the GL Context being on a different thread.

Fixes #271 