### PR TITLE
Fixes pressing return twice

### DIFF
--- a/game/main.cc
+++ b/game/main.cc
@@ -126,7 +126,7 @@ static void checkEvents(Game& gm) {
 			continue; // Already handled here...
 		}
 		// If a dialog is open, any nav event will close it
-		if (gm.isDialogOpen()) { gm.closeDialog(); continue; }
+		if (gm.isDialogOpen()) { gm.closeDialog(); }
 		// Let the current screen handle other events
 		gm.getCurrentScreen()->manageEvent(event);
 	}


### PR DESCRIPTION
Whenever a dialog was shown any key would hide the dialog and then stop the current event loop. This is not handy since any other actions by the key would be ignored. Fixed by removing the `continue` keyword.