### PR TITLE
Feature/fix warnings

### DIFF
--- a/game/controllers-keyboard.cc
+++ b/game/controllers-keyboard.cc
@@ -1,4 +1,4 @@
-#include "controllers.hh"
+﻿#include "controllers.hh"
 #include "platform.hh"
 
 #include <set>
@@ -73,11 +73,11 @@ namespace input {
 					break;
 
 				// Keytar on keyboard
-				case SDL_SCANCODE_F12: button++;
-				case SDL_SCANCODE_F11: button++;
-				case SDL_SCANCODE_F10: button++;
-				case SDL_SCANCODE_F9: button++;
-				case SDL_SCANCODE_F8: button++;
+				case SDL_SCANCODE_F12: button++; /* Falls through. */
+				case SDL_SCANCODE_F11: button++; /* Falls through. */
+				case SDL_SCANCODE_F10: button++; /* Falls through. */
+				case SDL_SCANCODE_F9: button++; /* Falls through. */
+				case SDL_SCANCODE_F8: button++; /* Falls through. */
 				case SDL_SCANCODE_F7:
 					if (!m_keytar) return;
 					event.devType = DEVTYPE_KEYTAR;
@@ -98,14 +98,14 @@ namespace input {
 					break;
 
 				// Dance on keypad
-				case SDL_SCANCODE_KP_9: button++;
-				case SDL_SCANCODE_KP_7: button++;
-				case SDL_SCANCODE_KP_3: button++;
-				case SDL_SCANCODE_KP_1: button++;
-				case SDL_SCANCODE_KP_6: case SDL_SCANCODE_RIGHT: button++;
-				case SDL_SCANCODE_KP_8: case SDL_SCANCODE_UP: button++;
-				case SDL_SCANCODE_KP_2: case SDL_SCANCODE_DOWN: case SDL_SCANCODE_KP_5: button++;
-				case SDL_SCANCODE_KP_4: case SDL_SCANCODE_LEFT:
+				case SDL_SCANCODE_KP_9: button++; /* Falls through. */
+				case SDL_SCANCODE_KP_7: button++; /* Falls through. */
+				case SDL_SCANCODE_KP_3: button++; /* Falls through. */
+				case SDL_SCANCODE_KP_1: button++; /* Falls through. */
+				case SDL_SCANCODE_KP_6: case SDL_SCANCODE_RIGHT: button++; /* Falls through. */
+				case SDL_SCANCODE_KP_8: case SDL_SCANCODE_UP: button++; /* Falls through. */
+				case SDL_SCANCODE_KP_2: case SDL_SCANCODE_DOWN: case SDL_SCANCODE_KP_5: button++; /* Falls through. */
+				case SDL_SCANCODE_KP_4: case SDL_SCANCODE_LEFT: /* Falls through. */
 					if (!m_dancepad) return;
 					event.devType = DEVTYPE_DANCEPAD;
 					break;

--- a/game/controllers-keyboard.cc
+++ b/game/controllers-keyboard.cc
@@ -62,10 +62,10 @@ namespace input {
 				case SDL_SCANCODE_RCTRL: case SDL_SCANCODE_RALT: button = GUITAR_GODMODE; goto guitar_process;
 				case SDL_SCANCODE_RSHIFT: button = GUITAR_PICK_UP; goto guitar_process;
 				case SDL_SCANCODE_RETURN: case SDL_SCANCODE_KP_ENTER: button = GUITAR_PICK_DOWN; goto guitar_process;
-				case SDL_SCANCODE_F5: case SDL_SCANCODE_5: case SDL_SCANCODE_B: button++;
-				case SDL_SCANCODE_F4: case SDL_SCANCODE_4: case SDL_SCANCODE_V: button++;
-				case SDL_SCANCODE_F3: case SDL_SCANCODE_3: case SDL_SCANCODE_C: button++;
-				case SDL_SCANCODE_F2: case SDL_SCANCODE_2: case SDL_SCANCODE_X: button++;
+				case SDL_SCANCODE_F5: case SDL_SCANCODE_5: case SDL_SCANCODE_B: button++; /* Falls through. */
+				case SDL_SCANCODE_F4: case SDL_SCANCODE_4: case SDL_SCANCODE_V: button++; /* Falls through. */
+				case SDL_SCANCODE_F3: case SDL_SCANCODE_3: case SDL_SCANCODE_C: button++; /* Falls through. */
+				case SDL_SCANCODE_F2: case SDL_SCANCODE_2: case SDL_SCANCODE_X: button++; /* Falls through. */
 				case SDL_SCANCODE_F1: case SDL_SCANCODE_1: case SDL_SCANCODE_Z:
 				guitar_process:
 					if (!m_guitar) return;

--- a/game/ffmpeg.cc
+++ b/game/ffmpeg.cc
@@ -1,4 +1,4 @@
-#include "ffmpeg.hh"
+﻿#include "ffmpeg.hh"
 
 #include "config.hh"
 #include "util.hh"
@@ -92,7 +92,8 @@ void FFmpeg::open() {
 	m_streamId = av_find_best_stream(m_formatContext, (AVMediaType)m_mediaType, -1, -1, &codec, 0);
 	if (m_streamId < 0) throw std::runtime_error("No suitable track found");
 
-	AVCodecContext* cc = m_formatContext->streams[m_streamId]->codec;
+	AVCodecContext* cc = avcodec_alloc_context3(codec);
+	avcodec_parameters_to_context(cc, m_formatContext->streams[m_streamId]->codecpar);
 	if (avcodec_open2(cc, codec, nullptr) < 0) throw std::runtime_error("Cannot open codec");
 	cc->workaround_bugs = FF_BUG_AUTODETECT;
 	m_codecContext = cc;

--- a/game/ffmpeg.cc
+++ b/game/ffmpeg.cc
@@ -91,9 +91,12 @@ void FFmpeg::open() {
 	AVCodec* codec = nullptr;
 	m_streamId = av_find_best_stream(m_formatContext, (AVMediaType)m_mediaType, -1, -1, &codec, 0);
 	if (m_streamId < 0) throw std::runtime_error("No suitable track found");
-
+#if LIBAVCODEC_VERSION_INT >= (AV_VERSION_INT(57,89,100))
 	AVCodecContext* cc = avcodec_alloc_context3(codec);
 	avcodec_parameters_to_context(cc, m_formatContext->streams[m_streamId]->codecpar);
+#else
+	AVCodecContext* cc = m_formatContext->streams[m_streamId]->codec;
+#endif
 	if (avcodec_open2(cc, codec, nullptr) < 0) throw std::runtime_error("Cannot open codec");
 	cc->workaround_bugs = FF_BUG_AUTODETECT;
 	m_codecContext = cc;
@@ -187,6 +190,11 @@ void FFmpeg::decodePacket() {
 
 	// Read an AVPacket and decode it into AVFrames
 	ReadFramePacket packet(m_formatContext);
+#if LIBAVCODEC_VERSION_INT < (AV_VERSION_INT(57,89,100))
+	int packetSize = packet.size;
+	-	while (packetSize) {
+	-		if (packetSize < 0) throw std::logic_error("negative packet size?!");
+#endif
 		if (m_quit || m_seekTarget == m_seekTarget) return;
 		if (packet.stream_index != m_streamId) return;
 #if (LIBAVCODEC_VERSION_INT) < (AV_VERSION_INT(55,0,0))
@@ -194,6 +202,19 @@ void FFmpeg::decodePacket() {
 #else
 		boost::shared_ptr<AVFrame> frame(av_frame_alloc(), [](AVFrame* ptr) { av_frame_free(&ptr); });
 #endif
+#if LIBAVCODEC_VERSION_INT < (AV_VERSION_INT(57,89,100))
+		int frameFinished = 0;
+		-		int decodeSize = (m_mediaType == AVMEDIA_TYPE_VIDEO ?
+		-		  avcodec_decode_video2(m_codecContext, frame.get(), &frameFinished, &packet) :
+		-		  avcodec_decode_audio4(m_codecContext, frame.get(), &frameFinished, &packet));
+		-		if (decodeSize < 0) return; // Packet didn't produce any output (could be waiting for B frames or something)
+		-		packetSize -= decodeSize; // Move forward within the packet
+		-		if (!frameFinished) continue;
+		-		// Update current position if timecode is available
+		-		if (frame->pkt_pts != int64_t(AV_NOPTS_VALUE)) {
+		-			m_position = double(frame->pkt_pts) * av_q2d(m_formatContext->streams[m_streamId]->time_base);
+#else
+
 		if(avcodec_send_packet(m_codecContext,&packet)!= 0) {
 			std::clog << "ffmpeg/error: " << "can't send packet" << std::endl;
 		}
@@ -203,10 +224,14 @@ void FFmpeg::decodePacket() {
 		}
 		if (frame->pts != int64_t(AV_NOPTS_VALUE)) {
 			m_position = double(frame->pts) * av_q2d(m_formatContext->streams[m_streamId]->time_base);
+#endif
 			if (m_formatContext->start_time != int64_t(AV_NOPTS_VALUE))
 				m_position -= double(m_formatContext->start_time) / AV_TIME_BASE;
 		}
 		if (m_mediaType == AVMEDIA_TYPE_VIDEO) processVideo(frame.get()); else processAudio(frame.get());
+#if LIBAVCODEC_VERSION_INT < (AV_VERSION_INT(57,89,100))
+	}
+#endif
 }
 
 void FFmpeg::processVideo(AVFrame* frame) {

--- a/game/menu.cc
+++ b/game/menu.cc
@@ -1,4 +1,4 @@
-#include "menu.hh"
+﻿#include "menu.hh"
 #include "screen.hh"
 #include "surface.hh"
 #include "fs.hh"
@@ -58,9 +58,9 @@ void Menu::action(int dir) {
 			}
 			break;
 		}
-		case MenuOption::SET_AND_CLOSE: {
+		case MenuOption::SET_AND_CLOSE: { /* Falls through. */
 			if (current().value) *(current().value) = current().newValue;
-			// Fall-through to closing
+			/* Falls through. */
 		}
 		case MenuOption::CLOSE_SUBMENU: {
 			closeSubmenu();

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -60,7 +60,7 @@ void Songs::reload_internal() {
 	std::clog << std::flush;
 	m_loading = false;
 	std::clog << "songs/notice: Done Loading. Loaded " << m_songs.size() << " Songs." << std::endl;
-	Game* gm = Game::getSingletonPtr();
+//	Game* gm = Game::getSingletonPtr();
     //gm->dialog(_("Done Loading!\n Loaded ") + boost::lexical_cast<std::string>(m_songs.size()) + " Songs.");	//crashes on ubuntu 16.10 but not on 16.04
 }
 


### PR DESCRIPTION
fixed compile warnings, mostly case fall through ones (which require a comment to let the compiler know it was on purpose) and some ffmpeg stuff (they actually made the API easier to understand, but forgot to document it as always). there are still some std-auto-ptr deprecated errors, but these come from boost which is not our buisness. boost should fix those.