### PR TITLE
Drums: Pro Mode

### DIFF
--- a/data/config/schema.xml
+++ b/data/config/schema.xml
@@ -98,6 +98,10 @@ to save the current settings to XML.
 		<short>Keyboard as drumkit</short>
 		<long>Enable keyboard as drumkit.</long>
 	</entry>
+	<entry name="game/drum_promode" type="bool" value="true">
+		<short>Drums use Pro mode</short>
+		<long>Drums use Pro mode (toms are not cymbals)</long>
+	</entry>
 	<entry name="game/keyboard_dancepad" type="bool" value="true">
 		<short>Keyboard as dance pad</short>
 		<long>Enable keyboard as dance pad.</long>

--- a/game/controllers-keyboard.cc
+++ b/game/controllers-keyboard.cc
@@ -85,8 +85,8 @@ namespace input {
 
 				// Drums on keyboard
 				case SDL_SCANCODE_8: button = DRUMS_YELLOW_CYMBAL; goto drum_process;
-				case SDL_SCANCODE_9: button = DRUMS_GREEN_CYMBAL; goto drum_process;
-				case SDL_SCANCODE_0: button = DRUMS_BLUE_CYMBAL; goto drum_process;
+				case SDL_SCANCODE_9: button = DRUMS_BLUE_CYMBAL; goto drum_process;
+				case SDL_SCANCODE_0: button = DRUMS_GREEN_CYMBAL; goto drum_process;
 				case SDL_SCANCODE_U: button = DRUMS_RED; goto drum_process;
 				case SDL_SCANCODE_I: button = DRUMS_YELLOW_TOM; goto drum_process;
 				case SDL_SCANCODE_O: button = DRUMS_BLUE_TOM; goto drum_process;

--- a/game/guitargraph.hh
+++ b/game/guitargraph.hh
@@ -77,7 +77,7 @@ class GuitarGraph: public InstrumentGraph {
 	void endBRE();
 	void endStreak() { m_streak = 0; m_bigStreak = 0; }
 	void updateDrumFill(double time);
-	void drumHit(double time, unsigned pad);
+	void drumHit(double time, unsigned layer, unsigned pad);
 	void guitarPlay(double time, input::Event const& ev);
 
 	// Media
@@ -155,6 +155,6 @@ class GuitarGraph: public InstrumentGraph {
 	double m_soloScore; /// score during solo
 	bool m_solo; /// are we currently playing a solo
 	bool m_hasTomTrack; /// true if the track has at least one tom track
+	bool m_proMode; /// true if pro drums. (it would be better to split guitar/trum tracks into sep classes)
 	double m_whammy; /// whammy value for pitch shift
 };
-


### PR DESCRIPTION
This is the work I've done on adding a pro mode for drums. It is enabled via config, and enforces cymbal/tom discrimination. Tested with keyboard (8,9,0 vs i,o,p).