### PR TITLE
add the path for the xml config directory in ubuntu 17.10

### DIFF
--- a/cmake/Modules/FindLibXML++.cmake
+++ b/cmake/Modules/FindLibXML++.cmake
@@ -41,7 +41,7 @@ find_path(LibXML++_INCLUDE_DIR
 # Glib-related libraries also use a separate config header, which is in lib dir
 find_path(LibXML++Config_INCLUDE_DIR
   NAMES libxml++config.h
-  HINTS ${LibXML++_PKGCONF_INCLUDE_DIRS} /usr /usr/lib/x86_64-linux-gnu/libxml++-2.6/include/
+  HINTS ${LibXML++_PKGCONF_INCLUDE_DIRS} /usr /usr/lib/x86_64-linux-gnu/libxml++-${LibXML++_VERSION}/include/
   PATH_SUFFIXES lib/libxml++-${LibXML++_VERSION}/include ../lib/libxml++-${LibXML++_VERSION}/include
 )
 

--- a/cmake/Modules/FindLibXML++.cmake
+++ b/cmake/Modules/FindLibXML++.cmake
@@ -41,7 +41,7 @@ find_path(LibXML++_INCLUDE_DIR
 # Glib-related libraries also use a separate config header, which is in lib dir
 find_path(LibXML++Config_INCLUDE_DIR
   NAMES libxml++config.h
-  HINTS ${LibXML++_PKGCONF_INCLUDE_DIRS} /usr
+  HINTS ${LibXML++_PKGCONF_INCLUDE_DIRS} /usr /usr/lib/x86_64-linux-gnu/libxml++-2.6/include/
   PATH_SUFFIXES lib/libxml++-${LibXML++_VERSION}/include ../lib/libxml++-${LibXML++_VERSION}/include
 )
 


### PR DESCRIPTION
ubuntu 17.10 has a weird path to put the libxml++config header, add it to the cmake file so cmake finds it.