### PR TITLE
Stdconversion

### DIFF
--- a/game/3dobject.cc
+++ b/game/3dobject.cc
@@ -1,7 +1,6 @@
 #include "3dobject.hh"
 
 #include <boost/filesystem/fstream.hpp>
-#include <boost/lexical_cast.hpp>
 #include <stdexcept>
 #include <sstream>
 
@@ -52,7 +51,7 @@ void Object3d::loadWavefrontObj(fs::path const& filepath, float scale) {
 		} else if (row.substr(0,2) == "vn") {  // Normals
 			srow >> tempst >> x >> y >> z;
 			double sum = std::abs(x)+std::abs(y)+std::abs(z);
-			if (sum == 0) throw std::runtime_error("Invalid normal in "+filepath.string()+":"+boost::lexical_cast<std::string>(linenumber));
+			if (sum == 0) throw std::runtime_error("Invalid normal in "+filepath.string()+":"+std::to_string(linenumber));
 			x /= sum; y /= sum; z /= sum; // Normalize components
 			normals.push_back(glmath::vec3(x, y, z));
 		} else if (row.substr(0,2) == "f ") {  // Faces
@@ -64,7 +63,7 @@ void Object3d::loadWavefrontObj(fs::path const& filepath, float scale) {
 					std::string st_id(getWord(fpoint,i,'/'));
 					if (!st_id.empty()) {
 						// Vertex indices are 1-based in the file
-						int v_id = boost::lexical_cast<int>(st_id) - 1;
+						int v_id = std::stoi(st_id) - 1;
 						switch (i) {
 							case 1: f.vertices.push_back(v_id); break;
 							case 2: f.texcoords.push_back(v_id); break;
@@ -74,14 +73,14 @@ void Object3d::loadWavefrontObj(fs::path const& filepath, float scale) {
 				}
 			}
 			if (!f.vertices.empty() && f.vertices.size() != 3)
-				throw std::runtime_error("Only triangle faces allowed in "+filepath.string()+":"+boost::lexical_cast<std::string>(linenumber));
+				throw std::runtime_error("Only triangle faces allowed in "+filepath.string()+":"+std::to_string(linenumber));
 			// Face must have equal number of v, vt, vn or none of a kind
 			if (!f.vertices.empty()
 			  && (f.texcoords.empty() || (f.texcoords.size() == f.vertices.size()))
 			  && (f.normals.empty()   || (f.normals.size() == f.vertices.size()))) {
 				m_faces.push_back(f);
 			} else {
-				throw std::runtime_error("Invalid face in "+filepath.string()+":"+boost::lexical_cast<std::string>(linenumber));
+				throw std::runtime_error("Invalid face in "+filepath.string()+":"+std::to_string(linenumber));
 			}
 		}
 	}

--- a/game/audio.cc
+++ b/game/audio.cc
@@ -4,7 +4,6 @@
 #include <boost/ptr_container/ptr_vector.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/lexical_cast.hpp>
 #include <cmath>
 #include <iostream>
 #include <map>

--- a/game/backgrounds.cc
+++ b/game/backgrounds.cc
@@ -4,7 +4,6 @@
 #include <boost/bind.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/regex.hpp>
 #include <algorithm>
 #include <cstdlib>

--- a/game/configuration.cc
+++ b/game/configuration.cc
@@ -157,11 +157,11 @@ namespace {
     }
     template <typename T, typename V> void setLimits(xmlpp::Element& e, V& min, V& max, V& step) {
         xmlpp::Attribute* a = e.get_attribute("min");
-        if (a) min = std::stod(a->get_value());
+        if (a) min = sconv<T>(a->get_value());
         a = e.get_attribute("max");
-        if (a) max = std::stod(a->get_value());
+        if (a) max = sconv<T>(a->get_value());
         a = e.get_attribute("step");
-        if (a) step = std::stod(a->get_value());
+        if (a) step = sconv<T>(a->get_value());
     }
 }
 
@@ -204,7 +204,7 @@ template <typename T> void ConfigItem::updateNumeric(xmlpp::Element& elem, int m
         std::string m;
         try {
             m = getAttribute(e, "multiplier");
-            m_multiplier = static_cast<T>(std::stod(m));
+            m_multiplier = sconv<T>(m);
         } catch (XMLError&) {}
         catch (std::exception&) { throw XMLError(e, "attribute multiplier='" + m + "' value invalid"); }
     }

--- a/game/configuration.cc
+++ b/game/configuration.cc
@@ -8,7 +8,6 @@
 #include "screen_intro.hh"
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
-#include <boost/lexical_cast.hpp>
 #include <algorithm>
 #include <iomanip>
 #include <stdexcept>
@@ -158,11 +157,11 @@ namespace {
     }
     template <typename T, typename V> void setLimits(xmlpp::Element& e, V& min, V& max, V& step) {
         xmlpp::Attribute* a = e.get_attribute("min");
-        if (a) min = boost::lexical_cast<T>(a->get_value());
+        if (a) min = std::stod(a->get_value());
         a = e.get_attribute("max");
-        if (a) max = boost::lexical_cast<T>(a->get_value());
+        if (a) max = std::stod(a->get_value());
         a = e.get_attribute("step");
-        if (a) step = boost::lexical_cast<T>(a->get_value());
+        if (a) step = std::stod(a->get_value());
     }
 }
 
@@ -205,9 +204,9 @@ template <typename T> void ConfigItem::updateNumeric(xmlpp::Element& elem, int m
         std::string m;
         try {
             m = getAttribute(e, "multiplier");
-            m_multiplier = boost::lexical_cast<T>(m);
+            m_multiplier = static_cast<T>(std::stod(m));
         } catch (XMLError&) {}
-        catch (boost::bad_lexical_cast&) { throw XMLError(e, "attribute multiplier='" + m + "' value invalid"); }
+        catch (std::exception&) { throw XMLError(e, "attribute multiplier='" + m + "' value invalid"); }
     }
 }
 
@@ -232,7 +231,7 @@ void ConfigItem::update(xmlpp::Element& elem, int mode) try {
         m_value = value;
     } else if (m_type == "int") {
         std::string value_string = getAttribute(elem, "value");
-        if (!value_string.empty()) m_value = boost::lexical_cast<int>(value_string);
+        if (!value_string.empty()) m_value = std::stoi(value_string);
             // Enum handling
             if (mode == 0) {
                 auto n2 = elem.find("limits/enum");
@@ -249,7 +248,7 @@ void ConfigItem::update(xmlpp::Element& elem, int mode) try {
         updateNumeric<int>(elem, mode);
     } else if (m_type == "float") {
         std::string value_string = getAttribute(elem, "value");
-        if (!value_string.empty()) m_value = boost::lexical_cast<double>(value_string);
+        if (!value_string.empty()) m_value = std::stod(value_string);
             updateNumeric<double>(elem, mode);
             } else if (m_type == "string") {
                 m_value = getText(elem, "stringvalue");
@@ -267,7 +266,7 @@ void ConfigItem::update(xmlpp::Element& elem, int mode) try {
         if (mode < 2) m_defaultValue = m_value;
             } catch (std::exception& e) {
                 int line = elem.get_line();
-                throw std::runtime_error(boost::lexical_cast<std::string>(line) + ": Error while reading entry: " + e.what());
+                throw std::runtime_error(std::to_string(line) + ": Error while reading entry: " + e.what());
             }
 
 // These are set in readConfig, once the paths have been bootstrapped.
@@ -387,7 +386,7 @@ void readConfigXML(fs::path const& file, int mode) {
     } catch (XMLError& e) {
         int line = e.elem.get_line();
         std::string name = e.elem.get_name();
-        throw std::runtime_error(file.string() + ":" + boost::lexical_cast<std::string>(line) + " element " + name + " " + e.message);
+        throw std::runtime_error(file.string() + ":" + std::to_string(line) + " element " + name + " " + e.message);
     } catch (std::exception& e) {
         throw std::runtime_error(file.string() + ":" + e.what());
     }

--- a/game/controllers.cc
+++ b/game/controllers.cc
@@ -23,12 +23,6 @@ namespace {
 		if (!a) throw XMLError(elem, "attribute " + attr + " not found");
 		return a->get_value();
 	}
-	template <typename T> T sconv(std::string const& s);
-	template <> int sconv(std::string const& s) { return std::stoi(s); }
-	template <> unsigned int sconv(std::string const& s) { return std::stoul(s); }
-	template <> double sconv(std::string const& s) { return std::stod(s); }
-	template <> std::string sconv(std::string const& s) { return s; }
-	
 	template <typename T> bool tryGetAttribute(xmlpp::Element const& elem, std::string const& attr, T& var) {
 		xmlpp::Attribute const* a = elem.get_attribute(attr);
 		if (!a) return false;

--- a/game/controllers.cc
+++ b/game/controllers.cc
@@ -4,7 +4,6 @@
 #include "fs.hh"
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/regex.hpp>
 #include <boost/smart_ptr/weak_ptr.hpp>
 #include <SDL2/SDL_joystick.h>
@@ -24,11 +23,17 @@ namespace {
 		if (!a) throw XMLError(elem, "attribute " + attr + " not found");
 		return a->get_value();
 	}
+	template <typename T> T sconv(std::string const& s);
+	template <> int sconv(std::string const& s) { return std::stoi(s); }
+	template <> unsigned int sconv(std::string const& s) { return std::stoul(s); }
+	template <> double sconv(std::string const& s) { return std::stod(s); }
+	template <> std::string sconv(std::string const& s) { return s; }
+	
 	template <typename T> bool tryGetAttribute(xmlpp::Element const& elem, std::string const& attr, T& var) {
 		xmlpp::Attribute const* a = elem.get_attribute(attr);
 		if (!a) return false;
 		try {
-			var = boost::lexical_cast<T>(a->get_value());
+			var = sconv<T>(a->get_value());
 		} catch (std::exception&) {
 			throw XMLError(elem, "attribute " + attr + " value invalid: " + a->get_value());
 		}
@@ -161,7 +166,7 @@ struct Controllers::Impl {
 		} catch (XMLError& e) {
 			int line = e.elem.get_line();
 			std::string name = e.elem.get_name();
-			throw std::runtime_error(file.string() + ":" + boost::lexical_cast<std::string>(line) + " element " + name + " " + e.message);
+			throw std::runtime_error(file.string() + ":" + std::to_string(line) + " element " + name + " " + e.message);
 		}
 	}
 

--- a/game/dancegraph.cc
+++ b/game/dancegraph.cc
@@ -2,7 +2,6 @@
 #include "song.hh"
 #include "i18n.hh"
 
-#include <boost/lexical_cast.hpp>
 #include <stdexcept>
 #include <algorithm>
 
@@ -124,7 +123,7 @@ void DanceGraph::setupJoinMenu() {
 		// Add difficulties to the option list
 		for (int level = 0; level < DIFFICULTYCOUNT; ++level) {
 			if (difficulty(DanceDifficulty(level), true)) {
-				ol.push_back(boost::lexical_cast<std::string>(level));
+				ol.push_back(std::to_string(level));
 				if (DanceDifficulty(level) == m_level) cur = i;
 				++i;
 			}
@@ -268,8 +267,8 @@ void DanceGraph::engine() {
 			difficulty_changed = true;
 			// See if anything changed
 			if (m_selectedTrack.so() != m_gamingMode) setTrack(m_selectedTrack.so());
-			else if (boost::lexical_cast<int>(m_selectedDifficulty.so()) != m_level)
-				difficulty(DanceDifficulty(boost::lexical_cast<int>(m_selectedDifficulty.so())));
+			else if (std::stoi(m_selectedDifficulty.so()) != m_level)
+				difficulty(DanceDifficulty(std::stoi(m_selectedDifficulty.so())));
 			else if (m_rejoin.b()) { unjoin(); setupJoinMenu(); m_dev->pushEvent(input::Event()); /* FIXME: HACK? */ }
 			// Sync dynamic stuff
 			updateJoinMenu();
@@ -318,7 +317,7 @@ void DanceGraph::engine() {
 	// Check if a long streak goal has been reached
 	if (m_streak >= getNextBigStreak(m_bigStreak)) {
 		m_bigStreak = getNextBigStreak(m_bigStreak);
-		m_popups.push_back(Popup(boost::lexical_cast<std::string>(unsigned(m_bigStreak)) + "\n" + _("Streak!"),
+		m_popups.push_back(Popup(std::to_string(unsigned(m_bigStreak)) + "\n" + _("Streak!"),
 		  Color(1.0, 0.0, 0.0), 1.0, m_popupText.get()));
 	}
 }
@@ -535,10 +534,10 @@ void DanceGraph::drawInfo(double /*time*/, Dimensions dimensions) {
 	if (!menuOpen()) {
 		// Draw scores
 		m_text.dimensions.screenBottom(-0.35).middle(0.32 * dimensions.w());
-		m_text.draw(boost::lexical_cast<std::string>(unsigned(getScore())));
+		m_text.draw(std::to_string(unsigned(getScore())));
 		m_text.dimensions.screenBottom(-0.32).middle(0.32 * dimensions.w());
-		m_text.draw(boost::lexical_cast<std::string>(unsigned(m_streak)) + "/"
-		  + boost::lexical_cast<std::string>(unsigned(m_longestStreak)));
+		m_text.draw(std::to_string(unsigned(m_streak)) + "/"
+		  + std::to_string(unsigned(m_longestStreak)));
 	}
 	drawPopups();
 }

--- a/game/game.cc
+++ b/game/game.cc
@@ -6,7 +6,6 @@
 #include "util.hh"
 
 #include <boost/thread.hpp>
-#include <boost/lexical_cast.hpp>
 #include <stdexcept>
 #include <cstdlib>
 
@@ -57,7 +56,7 @@ void Game::drawScreen() {
 
 void Game::loading(std::string const& message, float progress) {
 	// TODO: Create a better one, this is quite ugly
-	flashMessage(message + " " + boost::lexical_cast<std::string>(int(round(progress*100))) + "%", 0.0f, 0.5f, 0.2f);
+	flashMessage(message + " " + std::to_string(int(round(progress*100))) + "%", 0.0f, 0.5f, 0.2f);
 	m_loadingProgress = progress;
 	m_window.blank();
 	m_window.render(boost::bind(&Game::drawLoading, this));

--- a/game/guitargraph.cc
+++ b/game/guitargraph.cc
@@ -6,7 +6,6 @@
 #include <cmath>
 #include <cstdlib>
 #include <stdexcept>
-#include <boost/lexical_cast.hpp>
 #include <boost/format.hpp>
 
 namespace {
@@ -154,7 +153,7 @@ void GuitarGraph::setupJoinMenuDifficulty() {
 	// Add difficulties to the option list
 	for (int level = 0; level < DIFFICULTYCOUNT; ++level) {
 		if (difficulty(Difficulty(level), true)) {
-			ol.push_back(boost::lexical_cast<std::string>(level));
+			ol.push_back(std::to_string(level));
 			if (Difficulty(level) == m_level) cur = ol.size()-1;
 		}
 	}
@@ -342,8 +341,8 @@ void GuitarGraph::engine() {
 			}
 			// See if anything changed
 			if (!m_drums && m_selectedTrack.so() != m_track_index->first) setTrack(m_selectedTrack.so());
-			else if (boost::lexical_cast<int>(m_selectedDifficulty.so()) != m_level)
-				difficulty(Difficulty(boost::lexical_cast<int>(m_selectedDifficulty.so())));
+			else if (std::stoi(m_selectedDifficulty.so()) != m_level)
+				difficulty(Difficulty(std::stoi(m_selectedDifficulty.so())));
 			else if (m_rejoin.b()) { unjoin(); setupJoinMenu(); m_dev->pushEvent(input::Event()); /* FIXME: HACK! */ }
 			// Sync menu items & captions
 			updateJoinMenu();
@@ -390,7 +389,7 @@ void GuitarGraph::engine() {
 		if (m_solo) { m_soloScore += m_chordIt->score; m_soloTotal += m_chordIt->polyphony * points(0);
 		// Solo just ended?
 		} else if (m_soloTotal > 0) {
-			m_popups.push_back(Popup(boost::lexical_cast<std::string>(unsigned(m_soloScore / m_soloTotal * 100)) + " %",
+			m_popups.push_back(Popup(std::to_string(unsigned(m_soloScore / m_soloTotal * 100)) + " %",
 			  Color(0.0, 0.8, 0.0), 1.0, m_popupText.get()));
 			m_soloScore = 0;
 			m_soloTotal = 0;
@@ -447,7 +446,7 @@ void GuitarGraph::engine() {
 	if (m_streak >= getNextBigStreak(m_bigStreak)) {
 		m_bigStreak = getNextBigStreak(m_bigStreak);
 		m_starmeter += streakStarBonus;
-		m_popups.push_back(Popup(boost::lexical_cast<std::string>(unsigned(m_bigStreak)) + "\n" + _("Streak!"),
+		m_popups.push_back(Popup(std::to_string(unsigned(m_bigStreak)) + "\n" + _("Streak!"),
 		  Color(1.0, 0.0, 0.0), 1.0, m_popupText.get()));
 	}
 	// During GodMode, correctness is full, no matter what
@@ -1098,8 +1097,8 @@ void GuitarGraph::drawInfo(double time) {
 		// Draw streak counter
 		{
 			ColorTrans c(Color(0.6, 0.6, 0.7, 0.95));
-			m_streakText->render(boost::lexical_cast<std::string>(unsigned(m_streak)) + "/"
-			  + boost::lexical_cast<std::string>(unsigned(m_longestStreak)));
+			m_streakText->render(std::to_string(unsigned(m_streak)) + "/"
+			  + std::to_string(unsigned(m_longestStreak)));
 			m_streakText->dimensions().middle(-xcor).fixedHeight(h*0.75).screenBottom(-0.18);
 			m_streakText->draw();
 		}

--- a/game/hiscore.cc
+++ b/game/hiscore.cc
@@ -5,7 +5,6 @@
 #include <algorithm>
 #include <sstream>
 #include <stdexcept>
-#include <boost/lexical_cast.hpp>
 
 bool Hiscore::reachedHiscore(unsigned score, unsigned songid, std::string const& track) const {
 	if (score > 10000) throw std::logic_error("Invalid score value");
@@ -53,12 +52,12 @@ void Hiscore::load(xmlpp::NodeSet const& nodes) {
 		if (!a_songid) throw std::runtime_error("Attribute songid not found");
 		xmlpp::Attribute* a_track = element.get_attribute("track");
 
-		int playerid = boost::lexical_cast<int>(a_playerid->get_value());
-		int songid = boost::lexical_cast<int>(a_songid->get_value());
+		int playerid = std::stoi(a_playerid->get_value());
+		int songid = std::stoi(a_songid->get_value());
 
 		auto tn = xmlpp::get_first_child_text(element);
 		if (!tn) throw std::runtime_error("Score not found");
-		int score = boost::lexical_cast<int>(tn->get_content());
+		int score = std::stoi(tn->get_content());
 
 		addHiscore(score, playerid, songid, a_track ? a_track->get_value() : "vocals");
 	}
@@ -67,8 +66,8 @@ void Hiscore::load(xmlpp::NodeSet const& nodes) {
 void Hiscore::save(xmlpp::Element *hiscores) {
 	for (auto const& h: m_hiscore) {
 		xmlpp::Element* hiscore = xmlpp::add_child_element(hiscores, "hiscore");
-		hiscore->set_attribute("playerid", boost::lexical_cast<std::string>(h.playerid));
-		hiscore->set_attribute("songid", boost::lexical_cast<std::string>(h.songid));
+		hiscore->set_attribute("playerid", std::to_string(h.playerid));
+		hiscore->set_attribute("songid", std::to_string(h.songid));
 		hiscore->set_attribute("track", h.track);
 		hiscore->add_child_text(std::to_string(h.score));
 	}

--- a/game/instrumentgraph.cc
+++ b/game/instrumentgraph.cc
@@ -203,7 +203,7 @@ void InstrumentGraph::drawPopups() {
 void InstrumentGraph::handleCountdown(double time, double beginTime) {
 	if (!dead() && time < beginTime && time >= beginTime - m_countdown - 1) {
 		m_popups.push_back(Popup(m_countdown > 0 ?
-		  std::string("- ") +boost::lexical_cast<std::string>(unsigned(m_countdown))+" -" : "Rock On!",
+		  std::string("- ") +std::to_string(unsigned(m_countdown))+" -" : "Rock On!",
 		  Color(0.0, 0.0, 1.0), 2.0, m_popupText.get()));
 		  --m_countdown;
 	}

--- a/game/opengl_text.cc
+++ b/game/opengl_text.cc
@@ -2,7 +2,6 @@
 
 #include "libxml++-impl.hh"
 
-#include <boost/lexical_cast.hpp>
 #include "fontconfig/fontconfig.h"
 #include <pango/pangocairo.h>
 #include <cmath>
@@ -140,12 +139,12 @@ namespace {
 		auto n = dom.get_document()->get_root_node()->find("/svg:svg/@width",nsmap);
 		if (n.empty()) throw std::runtime_error("Unable to find text theme info width in "+themeFile.string());
 		xmlpp::Attribute& width = dynamic_cast<xmlpp::Attribute&>(*n[0]);
-		_width = boost::lexical_cast<double>(width.get_value());
+		_width = std::stod(width.get_value());
 		// Parse height attribute
 		n = dom.get_document()->get_root_node()->find("/svg:svg/@height",nsmap);
 		if (n.empty()) throw std::runtime_error("Unable to find text theme info height in "+themeFile.string());
 		xmlpp::Attribute& height = dynamic_cast<xmlpp::Attribute&>(*n[0]);
-		_height = boost::lexical_cast<double>(height.get_value());
+		_height = std::stod(height.get_value());
 		// Parse text style attribute (CSS rules)
 		n = dom.get_document()->get_root_node()->find("/svg:svg//svg:text/@style",nsmap);
 		if (n.empty()) throw std::runtime_error("Unable to find text theme info style in "+themeFile.string());
@@ -182,11 +181,11 @@ namespace {
 		n = dom.get_document()->get_root_node()->find("/svg:svg//svg:text/@x",nsmap);
 		if (n.empty()) throw std::runtime_error("Unable to find text theme info x in "+themeFile.string());
 		xmlpp::Attribute& x = dynamic_cast<xmlpp::Attribute&>(*n[0]);
-		_x = boost::lexical_cast<double>(x.get_value());
+		_x = std::stod(x.get_value());
 		n = dom.get_document()->get_root_node()->find("/svg:svg//svg:text/@y",nsmap);
 		if (n.empty()) throw std::runtime_error("Unable to find text theme info y in "+themeFile.string());
 		xmlpp::Attribute& y = dynamic_cast<xmlpp::Attribute&>(*n[0]);
-		_y = boost::lexical_cast<double>(y.get_value());
+		_y = std::stod(y.get_value());
 	}
 }
 

--- a/game/players.cc
+++ b/game/players.cc
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <boost/regex.hpp>
-#include <boost/lexical_cast.hpp>
 #include <unicode/stsearch.h>
 
 UErrorCode Players::m_icuError = U_ZERO_ERROR;
@@ -30,7 +29,7 @@ void Players::load(xmlpp::NodeSet const& n) {
 		xmlpp::Attribute* a_id = element.get_attribute("id");
 		if (!a_id) throw PlayersException("Attribute id not found");
 		int id = -1;
-		try {id = boost::lexical_cast<int>(a_id->get_value());} catch (boost::bad_lexical_cast const&) { }
+		try { id = std::stoi(a_id->get_value()); } catch (std::exception&) { }
 		xmlpp::NodeSet n2 = element.find("picture");
 		std::string picture;
 		if (!n2.empty()) // optional picture element

--- a/game/screen_sing.cc
+++ b/game/screen_sing.cc
@@ -19,7 +19,6 @@
 #include "screen_songs.hh"
 
 #include <boost/format.hpp>
-#include <boost/lexical_cast.hpp>
 #include <iostream>
 #include <stdexcept>
 #include <cmath>
@@ -595,7 +594,7 @@ void ScreenSing::drawMenu() {
 	th.bg.draw();
 	// Loop through menu items
 	w = 0;
-	int player = 0;
+	std::size_t player = 0;
 	boost::ptr_vector<Analyzer>& analyzers = m_audio.analyzers();
 	for (MenuOptions::const_iterator it = m_menu.begin(); it != m_menu.end(); ++it) {
 		// Pick the font object
@@ -606,7 +605,7 @@ void ScreenSing::drawMenu() {
 		txt->dimensions.middle(x).center(y);
 		txt->draw(it->getName());
 		if (it->value == &m_vocalTracks[player]) {
-					if(boost::lexical_cast<size_t>(player) < analyzers.size()) {
+			if (player < analyzers.size()) {
 				Color color = MicrophoneColor::get(analyzers[player].getId());
 				ColorTrans c(color);
 				m_player_icon->dimensions.right(x).fixedHeight(0.040).center(y);

--- a/game/songitems.cc
+++ b/game/songitems.cc
@@ -6,7 +6,6 @@
 #include <string>
 
 #include <boost/shared_ptr.hpp>
-#include <boost/lexical_cast.hpp>
 
 
 void SongItems::load(xmlpp::NodeSet const& n) {
@@ -22,7 +21,7 @@ void SongItems::load(xmlpp::NodeSet const& n) {
 		xmlpp::Attribute* a_title = element.get_attribute("title");
 		if (!a_title) throw SongItemsException("No attribute title");
 
-		addSongItem(a_artist->get_value(), a_title->get_value(), boost::lexical_cast<int>(a_id->get_value()));
+		addSongItem(a_artist->get_value(), a_title->get_value(), std::stoi(a_id->get_value()));
 	}
 }
 

--- a/game/songparser.cc
+++ b/game/songparser.cc
@@ -2,21 +2,20 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem/fstream.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/regex.hpp>
 
 
 namespace SongParserUtil {
 	void assign(int& var, std::string const& str) {
 		try {
-			var = boost::lexical_cast<int>(str);
+			var = std::stoi(str);
 		} catch (...) {
 			throw std::runtime_error("\"" + str + "\" is not valid integer value");
 		}
 	}
 	void assign(unsigned& var, std::string const& str) {
 		try {
-			var = boost::lexical_cast<int>(str);
+			var = std::stoi(str);
 		} catch (...) {
 			throw std::runtime_error("\"" + str + "\" is not valid unsigned integer value");
 		}
@@ -24,7 +23,7 @@ namespace SongParserUtil {
 	void assign(double& var, std::string str) {
 		std::replace(str.begin(), str.end(), ',', '.'); // Fix decimal separators
 		try {
-			var = boost::lexical_cast<double>(str);
+			var = std::stod(str);
 		} catch (...) {
 			throw std::runtime_error("\"" + str + "\" is not valid floating point value");
 		}

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -16,7 +16,6 @@
 #include <boost/bind.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/regex.hpp>
 #include <unicode/stsearch.h>
 

--- a/game/util.cc
+++ b/game/util.cc
@@ -1,0 +1,8 @@
+#include "util.hh"
+#include <string>
+
+// Only conversion types used in Performous are provided
+template <> int sconv(std::string const& s) { return std::stoi(s); }
+template <> unsigned int sconv(std::string const& s) { return std::stoul(s); }
+template <> double sconv(std::string const& s) { return std::stod(s); }
+template <> std::string sconv(std::string const& s) { return s; }

--- a/game/util.hh
+++ b/game/util.hh
@@ -5,6 +5,9 @@
 #include <vector>
 #include <stdexcept>
 
+/** Templated conversion functions for string to T, specializations defined in util.cc **/
+template <typename T> T sconv(std::string const& s);
+
 /** Limit val to range [min, max] **/
 template <typename T> T clamp(T val, T min = 0, T max = 1) {
 	if (min > max) throw std::logic_error("min > max");

--- a/game/webserver.cc
+++ b/game/webserver.cc
@@ -235,7 +235,7 @@ http_server::response WebServer::POSTresponse(const http_server::request &reques
 		}
 	} else if(request.destination == "/api/remove") {
 		try { // this is for those idiots that send text instead of numbers.
-			int songToDelete = boost::lexical_cast<int>(request.body);
+			int songToDelete = std::stoi(request.body);
 			gm->getCurrentPlayList().removeSong(songToDelete);
 			ScreenPlaylist* m_pp = dynamic_cast<ScreenPlaylist*>(gm->getScreen("Playlist"));
 			m_pp->triggerSongListUpdate(); //this way the screen_playlist does a live-update just like the screen_songs
@@ -266,15 +266,15 @@ http_server::response WebServer::POSTresponse(const http_server::request &reques
 					std::clog << "webserver/error: cannot parse Json Document" <<std::endl;
 					return http_server::response::stock_reply(http_server::response::ok, "No valid JSON.");
 				}
-				unsigned int songToMove = boost::lexical_cast<int>(root["songId"]);
-				unsigned int positionToMoveTo = boost::lexical_cast<int>(root["position"]);
+				unsigned int songToMove = root["songId"].asUInt();
+				unsigned int positionToMoveTo = root["position"].asUInt();
 
 				if(gm->getCurrentPlayList().getList().size() == 0) {
-					return http_server::response::stock_reply(http_server::response::ok, "Playlist is empty, can't move the song you've provided: " + boost::lexical_cast<std::string>(songToMove + 1));
+					return http_server::response::stock_reply(http_server::response::ok, "Playlist is empty, can't move the song you've provided: " + std::to_string(songToMove + 1));
 				}
 
 				if(songToMove > gm->getCurrentPlayList().getList().size() -1) {
-					return http_server::response::stock_reply(http_server::response::ok, "Not gonna move the unknown song you've provided: " + boost::lexical_cast<std::string>(songToMove + 1));
+					return http_server::response::stock_reply(http_server::response::ok, "Not gonna move the unknown song you've provided: " + std::to_string(songToMove + 1));
 				}
 
 				if(positionToMoveTo <= gm->getCurrentPlayList().getList().size() -1) {
@@ -282,9 +282,9 @@ http_server::response WebServer::POSTresponse(const http_server::request &reques
 					ScreenPlaylist* m_pp = dynamic_cast<ScreenPlaylist*>(gm->getScreen("Playlist"));
 					m_pp->triggerSongListUpdate();
 				} else {
-					return http_server::response::stock_reply(http_server::response::ok, "Not gonna move the song to "+ boost::lexical_cast<std::string>(positionToMoveTo + 1) + " since the list ain't that long.");
+					return http_server::response::stock_reply(http_server::response::ok, "Not gonna move the song to "+ std::to_string(positionToMoveTo + 1) + " since the list ain't that long.");
 				}
-			return http_server::response::stock_reply(http_server::response::ok, "Succesfuly moved the song from " + boost::lexical_cast<std::string>(songToMove + 1) + " to " + boost::lexical_cast<std::string>(positionToMoveTo + 1));
+			return http_server::response::stock_reply(http_server::response::ok, "Succesfuly moved the song from " + std::to_string(songToMove + 1) + " to " + std::to_string(positionToMoveTo + 1));
 		} catch(std::exception e) {
 			return http_server::response::stock_reply(http_server::response::ok, "failure");
 		}

--- a/game/webserver.hh
+++ b/game/webserver.hh
@@ -7,7 +7,6 @@ namespace http = boost::network::http;
 #include <boost/thread/mutex.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/shared_ptr.hpp>
-#include <boost/lexical_cast.hpp>
 #include <json/json.h>
 #include <string>
 #include "fs.hh"


### PR DESCRIPTION
Replace boost::lexical_cast by C++1x equivalents std::to_string and std::stod etc. Doing so avoids dependency on that Boost library, removes compiler warnings with Boost prior to 1.61 and fixes at least one rather sloppy case of lexical_cast being used where no cast at all was needed.

This is a big change done mostly by sed and thus requires thorough testing before merging.