### PR TITLE
Catch crash related to locale.

### DIFF
--- a/game/i18n.hh
+++ b/game/i18n.hh
@@ -13,7 +13,12 @@ public:
 		boost::locale::generator gen;
 		gen.add_messages_path(getLocaleDir().string());
 		gen.add_messages_domain(package);
-		std::locale::global(gen(""));
+		try {
+			std::locale::global(gen(""));
+		} catch (...) {
+			std::clog << "locale/warning: Unable to detect locale, will try to fallback to en_US.UTF-8" << std::endl;
+			std::locale::global(gen("en_US.UTF-8"));
+		}
 	};
 	static bool enabled() {
 		return true;


### PR DESCRIPTION
We’ve had this uncaught exception for a while now, we can get rid of it by specifying a default locale.