### PR TITLE
Revert UTF-8 Warning removal

### DIFF
--- a/data/config/schema.xml
+++ b/data/config/schema.xml
@@ -39,6 +39,10 @@ to save the current settings to XML.
 	</menu>
 
 	<!-- Gameplay preferences -->
+	<entry name="game/bom_warnings" type="bool" value="false">
+		<short>Warn about UTF-8 BOM.</short>
+		<long>Dump warnings to game log when a BOM is present.</long>
+	</entry>
 	<entry name="game/karaoke_mode" type="int" value="0">
 		<limits>
 			<enum>Off</enum>

--- a/game/unicode.cc
+++ b/game/unicode.cc
@@ -38,8 +38,10 @@ void convertToUTF8(std::stringstream &_stream, std::string _filename) {
         match = std::pair<std::string,int>("UTF-8",100); // If there's no filename, assume it's internal text and thus utf-8.
     }
     icu::UnicodeString ustring;
-	// Test for UTF-8 BOM (a three-byte sequence at the beginning of a file)
     if (data.substr(0, 3) == "\xEF\xBB\xBF") {
+        if (config["game/bom_warnings"].b()) {
+            std::clog << "unicode/warning: " << _filename << " UTF-8 BOM ignored. Please avoid editors that add a BOM to UTF-8 (e.g. Notepad)." << std::endl;
+        }
         match.first = "UTF-8";
         match.second = 100;
         _stream.str(data.substr(3)); // Remove BOM if there is one


### PR DESCRIPTION
I'd love to revert this commit by @Tronic d7240e07accbf0a3dba126870c1761c3023b495b

Reasons:
1. Dev's can check their logs to see if they are dealing with UTF8+BOM or not
2. I used it for correctly formatting my txt files
3. Currently i have no option (within performous) to check if my files are UTF-8 with or without bom.
4. I'd love to revert this since the change made by @Tronic hasn't been peer reviewed by others. Comitting directly to master should be considered a bad practice imho.

As discussed at discord / github we implemented a bool to either turn it on or off as per #310 