### PR TITLE
Another attempt at fixing indents (into tabs).

### DIFF
--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -43,7 +43,7 @@ if(WIN32)
 		# windres foo.rc foores.o
 		# gcc -o foo.exe foo.o foores.o
 		find_library(WSOCK32_LIBRARY wsock32)
-    		find_library(WS2_32_LIBRARY ws2_32)
+		find_library(WS2_32_LIBRARY ws2_32)
 		if(NOT CMAKE_RC_COMPILER)
 			find_program(CMAKE_RC_COMPILER windres)
 		endif()

--- a/game/audio.cc
+++ b/game/audio.cc
@@ -141,7 +141,7 @@ class Music {
 		FFmpeg mpeg;
 		float fadeLevel;
 		float pitchFactor;
-        Track(fs::path const& filename, unsigned int sr): mpeg(filename, sr), fadeLevel(1.0f), pitchFactor(0.0f) {}
+		Track(fs::path const& filename, unsigned int sr): mpeg(filename, sr), fadeLevel(1.0f), pitchFactor(0.0f) {}
 	};
 	std::unordered_map<std::string, std::unique_ptr<Track>> tracks; ///< Audio decoders
 	double srate; ///< Sample rate
@@ -397,11 +397,9 @@ struct Output {
 
 Device::Device(unsigned int in, unsigned int out, double rate, unsigned int dev):
   in(in), out(out), rate(rate), dev(dev),
-  stream(
-    *this,
-    portaudio::Params().channelCount(in).device(dev).suggestedLatency(config["audio/latency"].f()),
-	portaudio::Params().channelCount(out).device(dev).suggestedLatency(config["audio/latency"].f()),
-	rate),
+  stream(*this,
+  portaudio::Params().channelCount(in).device(dev).suggestedLatency(config["audio/latency"].f()),
+  portaudio::Params().channelCount(out).device(dev).suggestedLatency(config["audio/latency"].f()), rate),
   mics(in, nullptr),
   outptr()
 {}

--- a/game/configuration.cc
+++ b/game/configuration.cc
@@ -28,43 +28,43 @@ ConfigItem::ConfigItem(OptionList opts): m_type("option_list"), m_value(opts), m
 
 
 ConfigItem& ConfigItem::incdec(int dir) {
-    if (m_type == "int") {
-        int& val = boost::get<int>(m_value);
-        int step = boost::get<int>(m_step);
-        val = clamp(((val + dir * step)/ step) * step, boost::get<int>(m_min), boost::get<int>(m_max));
-    } else if (m_type == "float") {
-        double& val = boost::get<double>(m_value);
-        double step = boost::get<double>(m_step);
-        val = clamp(round((val + dir * step) / step) * step, boost::get<double>(m_min), boost::get<double>(m_max));
-    } else if (m_type == "bool") {
-        bool& val = boost::get<bool>(m_value);
-        val = !val;
-    } else if (m_type == "option_list") {
-        size_t s = boost::get<OptionList>(m_value).size();
-        m_sel = (m_sel + dir + s) % s;
-    }
-    return *this;
+	if (m_type == "int") {
+		int& val = boost::get<int>(m_value);
+		int step = boost::get<int>(m_step);
+		val = clamp(((val + dir * step)/ step) * step, boost::get<int>(m_min), boost::get<int>(m_max));
+	} else if (m_type == "float") {
+		double& val = boost::get<double>(m_value);
+		double step = boost::get<double>(m_step);
+		val = clamp(round((val + dir * step) / step) * step, boost::get<double>(m_min), boost::get<double>(m_max));
+	} else if (m_type == "bool") {
+		bool& val = boost::get<bool>(m_value);
+		val = !val;
+	} else if (m_type == "option_list") {
+		size_t s = boost::get<OptionList>(m_value).size();
+		m_sel = (m_sel + dir + s) % s;
+	}
+	return *this;
 }
 
 bool ConfigItem::isDefaultImpl(ConfigItem::Value const& defaultValue) const {
-    if (m_type == "bool") return boost::get<bool>(m_value) == boost::get<bool>(defaultValue);
-    if (m_type == "int") return boost::get<int>(m_value) == boost::get<int>(defaultValue);
-    if (m_type == "float") return boost::get<double>(m_value) == boost::get<double>(defaultValue);
-    if (m_type == "string") return boost::get<std::string>(m_value) == boost::get<std::string>(defaultValue);
-    if (m_type == "string_list") return boost::get<StringList>(m_value) == boost::get<StringList>(defaultValue);
-    if (m_type == "option_list") return boost::get<OptionList>(m_value) == boost::get<OptionList>(defaultValue);
-    throw std::logic_error("ConfigItem::is_default doesn't know type '" + m_type + "'");
+	if (m_type == "bool") return boost::get<bool>(m_value) == boost::get<bool>(defaultValue);
+	if (m_type == "int") return boost::get<int>(m_value) == boost::get<int>(defaultValue);
+	if (m_type == "float") return boost::get<double>(m_value) == boost::get<double>(defaultValue);
+	if (m_type == "string") return boost::get<std::string>(m_value) == boost::get<std::string>(defaultValue);
+	if (m_type == "string_list") return boost::get<StringList>(m_value) == boost::get<StringList>(defaultValue);
+	if (m_type == "option_list") return boost::get<OptionList>(m_value) == boost::get<OptionList>(defaultValue);
+	throw std::logic_error("ConfigItem::is_default doesn't know type '" + m_type + "'");
 }
 
 void ConfigItem::verifyType(std::string const& type) const {
-    if (type == m_type) return;
-    std::string name = "unknown";
-    // Try to find this item in the config map
-    for (Config::const_iterator it = config.begin(); it != config.end(); ++it) {
-        if (&it->second == this) { name = it->first; break; }
-    }
-    if (m_type.empty()) throw std::logic_error("Config item " + name + ", requested_type=" + type + " used in C++ but missing from config schema");
-    throw std::logic_error("Config item type mismatch: item=" + name + ", type=" + m_type + ", requested=" + type);
+	if (type == m_type) return;
+	std::string name = "unknown";
+	// Try to find this item in the config map
+	for (Config::const_iterator it = config.begin(); it != config.end(); ++it) {
+		if (&it->second == this) { name = it->first; break; }
+	}
+	if (m_type.empty()) throw std::logic_error("Config item " + name + ", requested_type=" + type + " used in C++ but missing from config schema");
+	throw std::logic_error("Config item type mismatch: item=" + name + ", type=" + m_type + ", requested=" + type);
 }
 
 int& ConfigItem::i() { verifyType("int"); return boost::get<int>(m_value); }
@@ -79,353 +79,353 @@ std::string& ConfigItem::so() { verifyType("option_list"); return boost::get<Opt
 void ConfigItem::select(int i) { verifyType("option_list"); m_sel = clamp<int>(i, 0, boost::get<OptionList>(m_value).size()-1); }
 
 namespace {
-    template <typename T, typename VariantAll, typename VariantNum> std::string numericFormat(VariantAll const& value, VariantNum const& multiplier, VariantNum const& step) {
-        T m = boost::get<T>(multiplier);
-        // Find suitable precision (not very useful for integers, but this code is generic...)
-        T s = std::abs(m * boost::get<T>(step));
-        unsigned precision = 0;
-        while (s > 0.0 && (s *= 10) < 10) ++precision;
-        // Format the output
-        boost::format fmter("%f");
-        fmter % boost::io::group(std::setprecision(precision), double(m) * boost::get<T>(value));
-        return fmter.str();
-    }
+	template <typename T, typename VariantAll, typename VariantNum> std::string numericFormat(VariantAll const& value, VariantNum const& multiplier, VariantNum const& step) {
+		T m = boost::get<T>(multiplier);
+		// Find suitable precision (not very useful for integers, but this code is generic...)
+		T s = std::abs(m * boost::get<T>(step));
+		unsigned precision = 0;
+		while (s > 0.0 && (s *= 10) < 10) ++precision;
+		// Format the output
+		boost::format fmter("%f");
+		fmter % boost::io::group(std::setprecision(precision), double(m) * boost::get<T>(value));
+		return fmter.str();
+	}
 
-    std::string getText(xmlpp::Element const& elem) {
-        auto n = xmlpp::get_first_child_text(elem);  // Returns NULL if there is no text
-        return n ? std::string(n->get_content()) : std::string();
-    }
+	std::string getText(xmlpp::Element const& elem) {
+		auto n = xmlpp::get_first_child_text(elem);  // Returns NULL if there is no text
+		return n ? std::string(n->get_content()) : std::string();
+	}
 
-    std::string getText(xmlpp::Element const& elem, std::string const& path) {
-        auto ns = elem.find(path);
-        if (ns.empty()) return std::string();
-        return getText(dynamic_cast<xmlpp::Element const&>(*ns[0]));
-    }
+	std::string getText(xmlpp::Element const& elem, std::string const& path) {
+		auto ns = elem.find(path);
+		if (ns.empty()) return std::string();
+		return getText(dynamic_cast<xmlpp::Element const&>(*ns[0]));
+	}
 }
 
 std::string const ConfigItem::getValue() const {
-    if (this->getShortDesc() == config["audio/backend"].getShortDesc()) {
-        int AutoBackendType = 1337;
-        static int val = boost::get<int>(m_value);
-        if (val != boost::get<int>(m_value)) val = PaHostApiNameToHostApiTypeId(this->getEnumName()); // In the case of the audio backend, val is the real value while m_value is the enum case for its cosmetic name.
-        std::clog << "audio/debug: Value of selected audio backend in config.xml is: " << val << std::endl;
-        int hostApi = Pa_HostApiTypeIdToHostApiIndex(PaHostApiTypeId(val));
-        std::ostringstream oss;
-        oss << "audio/debug: Trying the selected Portaudio backend...";
-        if (val != AutoBackendType) {
-            oss << " found at index: " << hostApi;
-        }
-        else {
-            oss << " not found; but this is normal when Auto is selected."; // Auto is not a real PaHostApiTypeId, so it will always return paHostApiNotFound
-        }
-        oss << std::endl;
-        std::clog << oss.str();
-        if ((hostApi != paHostApiNotFound) || (val == AutoBackendType)) {
-            std::string backendName = (val != AutoBackendType) ? Pa_GetHostApiInfo(hostApi)->name : "Auto";
-            std::clog << "audio/info: Currently selected audio backend is: " << backendName << std::endl;
-            return backendName;
-        }
-        else std::clog << "audio/warning: Currently selected audio backend is unavailable on this system, will default to Auto." << std::endl;
-        return "Auto";
-    }
-    if (m_type == "int") {
-        int val = boost::get<int>(m_value);
-        if (val >= 0 && val < int(m_enums.size())) return m_enums[val];
-        return numericFormat<int>(m_value, m_multiplier, m_step) + m_unit;
-    }
-    if (m_type == "float") return numericFormat<double>(m_value, m_multiplier, m_step) + m_unit;
-    if (m_type == "bool") return boost::get<bool>(m_value) ? _("Enabled") : _("Disabled");
-    if (m_type == "string") return boost::get<std::string>(m_value);
-    if (m_type == "string_list") {
-        StringList const& sl = boost::get<StringList>(m_value);
-        return sl.size() == 1 ? "{" + sl[0] + "}" : (boost::format(_("%d items")) % sl.size()).str();
-    }
-    if (m_type == "option_list") return boost::get<OptionList>(m_value).at(m_sel);
-    throw std::logic_error("ConfigItem::getValue doesn't know type '" + m_type + "'");
+	if (this->getShortDesc() == config["audio/backend"].getShortDesc()) {
+		int AutoBackendType = 1337;
+		static int val = boost::get<int>(m_value);
+		if (val != boost::get<int>(m_value)) val = PaHostApiNameToHostApiTypeId(this->getEnumName()); // In the case of the audio backend, val is the real value while m_value is the enum case for its cosmetic name.
+		std::clog << "audio/debug: Value of selected audio backend in config.xml is: " << val << std::endl;
+		int hostApi = Pa_HostApiTypeIdToHostApiIndex(PaHostApiTypeId(val));
+		std::ostringstream oss;
+		oss << "audio/debug: Trying the selected Portaudio backend...";
+		if (val != AutoBackendType) {
+			oss << " found at index: " << hostApi;
+		}
+		else {
+			oss << " not found; but this is normal when Auto is selected."; // Auto is not a real PaHostApiTypeId, so it will always return paHostApiNotFound
+		}
+		oss << std::endl;
+		std::clog << oss.str();
+		if ((hostApi != paHostApiNotFound) || (val == AutoBackendType)) {
+			std::string backendName = (val != AutoBackendType) ? Pa_GetHostApiInfo(hostApi)->name : "Auto";
+			std::clog << "audio/info: Currently selected audio backend is: " << backendName << std::endl;
+			return backendName;
+		}
+		else std::clog << "audio/warning: Currently selected audio backend is unavailable on this system, will default to Auto." << std::endl;
+		return "Auto";
+	}
+	if (m_type == "int") {
+		int val = boost::get<int>(m_value);
+		if (val >= 0 && val < int(m_enums.size())) return m_enums[val];
+		return numericFormat<int>(m_value, m_multiplier, m_step) + m_unit;
+	}
+	if (m_type == "float") return numericFormat<double>(m_value, m_multiplier, m_step) + m_unit;
+	if (m_type == "bool") return boost::get<bool>(m_value) ? _("Enabled") : _("Disabled");
+	if (m_type == "string") return boost::get<std::string>(m_value);
+	if (m_type == "string_list") {
+		StringList const& sl = boost::get<StringList>(m_value);
+		return sl.size() == 1 ? "{" + sl[0] + "}" : (boost::format(_("%d items")) % sl.size()).str();
+	}
+	if (m_type == "option_list") return boost::get<OptionList>(m_value).at(m_sel);
+	throw std::logic_error("ConfigItem::getValue doesn't know type '" + m_type + "'");
 }
 
 namespace {
-    struct XMLError {
-        XMLError(xmlpp::Element& e, std::string msg): elem(e), message(msg) {}
-        xmlpp::Element& elem;
-        std::string message;
-    };
-    std::string getAttribute(xmlpp::Element& elem, std::string const& attr) {
-        xmlpp::Attribute* a = elem.get_attribute(attr);
-        if (!a) throw XMLError(elem, "attribute " + attr + " not found");
-        return a->get_value();
-    }
-    template <typename T, typename V> void setLimits(xmlpp::Element& e, V& min, V& max, V& step) {
-        xmlpp::Attribute* a = e.get_attribute("min");
-        if (a) min = sconv<T>(a->get_value());
-        a = e.get_attribute("max");
-        if (a) max = sconv<T>(a->get_value());
-        a = e.get_attribute("step");
-        if (a) step = sconv<T>(a->get_value());
-    }
+	struct XMLError {
+		XMLError(xmlpp::Element& e, std::string msg): elem(e), message(msg) {}
+		xmlpp::Element& elem;
+		std::string message;
+	};
+	std::string getAttribute(xmlpp::Element& elem, std::string const& attr) {
+		xmlpp::Attribute* a = elem.get_attribute(attr);
+		if (!a) throw XMLError(elem, "attribute " + attr + " not found");
+		return a->get_value();
+	}
+	template <typename T, typename V> void setLimits(xmlpp::Element& e, V& min, V& max, V& step) {
+		xmlpp::Attribute* a = e.get_attribute("min");
+		if (a) min = sconv<T>(a->get_value());
+		a = e.get_attribute("max");
+		if (a) max = sconv<T>(a->get_value());
+		a = e.get_attribute("step");
+		if (a) step = sconv<T>(a->get_value());
+	}
 }
 
 void ConfigItem::addEnum(std::string name) {
-    verifyType("int");
-    if (find(m_enums.begin(),m_enums.end(),name) == m_enums.end()) {
-        m_enums.push_back(name);
-    }
-    m_min = 0;
-    m_max = int(m_enums.size() - 1);
-    m_step = 1;
+	verifyType("int");
+	if (find(m_enums.begin(),m_enums.end(),name) == m_enums.end()) {
+		m_enums.push_back(name);
+	}
+	m_min = 0;
+	m_max = int(m_enums.size() - 1);
+	m_step = 1;
 }
 
 void ConfigItem::selectEnum(std::string const& name) {
-    auto it = std::find(m_enums.begin(), m_enums.end(), name);
-    if (it == m_enums.end()) throw std::runtime_error("Enum value " + name + " not found in " + m_shortDesc);
-    i() = it - m_enums.begin();
+	auto it = std::find(m_enums.begin(), m_enums.end(), name);
+	if (it == m_enums.end()) throw std::runtime_error("Enum value " + name + " not found in " + m_shortDesc);
+	i() = it - m_enums.begin();
 }
 
 
 std::string const ConfigItem::getEnumName() const {
-    int const& val = i();
-    if (val >= 0 && val < int(m_enums.size())) { return m_enums[val]; }
-    else { return std::string(); }
+	int const& val = i();
+	if (val >= 0 && val < int(m_enums.size())) { return m_enums[val]; }
+	else { return std::string(); }
 }
 
 template <typename T> void ConfigItem::updateNumeric(xmlpp::Element& elem, int mode) {
-    auto ns = elem.find("limits");
-    if (!ns.empty()) setLimits<T>(dynamic_cast<xmlpp::Element&>(*ns[0]), m_min, m_max, m_step);
-    else if (mode == 0) throw XMLError(elem, "child element limits missing");
-    ns = elem.find("ui");
-    // Default values
-    if (mode == 0) {
-        m_unit.clear();
-        m_multiplier = static_cast<T>(1);
-    }
-    if (!ns.empty()) {
-        xmlpp::Element& e = dynamic_cast<xmlpp::Element&>(*ns[0]);
-        try { m_unit = getAttribute(e, "unit"); } catch (...) {}
-        std::string m;
-        try {
-            m = getAttribute(e, "multiplier");
-            m_multiplier = sconv<T>(m);
-        } catch (XMLError&) {}
-        catch (std::exception&) { throw XMLError(e, "attribute multiplier='" + m + "' value invalid"); }
-    }
+	auto ns = elem.find("limits");
+	if (!ns.empty()) setLimits<T>(dynamic_cast<xmlpp::Element&>(*ns[0]), m_min, m_max, m_step);
+	else if (mode == 0) throw XMLError(elem, "child element limits missing");
+	ns = elem.find("ui");
+	// Default values
+	if (mode == 0) {
+		m_unit.clear();
+		m_multiplier = static_cast<T>(1);
+	}
+	if (!ns.empty()) {
+		xmlpp::Element& e = dynamic_cast<xmlpp::Element&>(*ns[0]);
+		try { m_unit = getAttribute(e, "unit"); } catch (...) {}
+		std::string m;
+		try {
+			m = getAttribute(e, "multiplier");
+			m_multiplier = sconv<T>(m);
+		} catch (XMLError&) {}
+		catch (std::exception&) { throw XMLError(e, "attribute multiplier='" + m + "' value invalid"); }
+	}
 }
 
 
 void ConfigItem::update(xmlpp::Element& elem, int mode) try {
-    if (mode == 0) {
-        m_type = getAttribute(elem, "type");
-        if (m_type.empty()) throw std::runtime_error("Entry type attribute is missing");
-        // Menu text
-        m_shortDesc = getText(elem, "short");
-        m_longDesc = getText(elem, "long");
-    } else {
-        std::string type = getAttribute(elem, "type");
-        if (!type.empty() && type != m_type) throw std::runtime_error("Entry type mismatch: " + getAttribute(elem, "name") + ": schema type = " + m_type + ", config type = " + type);
-    }
-    if (m_type == "bool") {
-        std::string value_string = getAttribute(elem, "value");
-        bool value;
-        if (value_string == "true") value = true;
-            else if (value_string == "false") value = false;
-                else throw std::runtime_error("Invalid boolean value '" + value_string + "'");
-        m_value = value;
-    } else if (m_type == "int") {
-        std::string value_string = getAttribute(elem, "value");
-        if (!value_string.empty()) m_value = std::stoi(value_string);
-            // Enum handling
-            if (mode == 0) {
-                auto n2 = elem.find("limits/enum");
-                if (!n2.empty()) {
-                    for (auto it2 = n2.begin(), end2 = n2.end(); it2 != end2; ++it2) {
-                        xmlpp::Element& elem2 = dynamic_cast<xmlpp::Element&>(**it2);
-                        m_enums.push_back(getText(elem2));
-                    }
-                    m_min = 0;
-                    m_max = int(m_enums.size() - 1);
-                    m_step = 1;
-                }
-            }
-        updateNumeric<int>(elem, mode);
-    } else if (m_type == "float") {
-        std::string value_string = getAttribute(elem, "value");
-        if (!value_string.empty()) m_value = std::stod(value_string);
-            updateNumeric<double>(elem, mode);
-            } else if (m_type == "string") {
-                m_value = getText(elem, "stringvalue");
-            } else if (m_type == "string_list" || m_type == "option_list") {
-                //TODO: Option list should also update selection (from attribute?)
-                std::vector<std::string> value;
-                auto n2 = elem.find("stringvalue");
-                for (auto it2 = n2.begin(), end2 = n2.end(); it2 != end2; ++it2) {
-                    value.push_back(getText(dynamic_cast<xmlpp::Element const&>(**it2)));
-                }
-                m_value = value;
-            } else if (!m_type.empty()) throw std::runtime_error("Invalid value type in config schema: " + m_type);
-    // Schema sets all defaults, system config sets the system default
-    if (mode < 1) m_factoryDefaultValue = m_defaultValue = m_value;
-        if (mode < 2) m_defaultValue = m_value;
-            } catch (std::exception& e) {
-                int line = elem.get_line();
-                throw std::runtime_error(std::to_string(line) + ": Error while reading entry: " + e.what());
-            }
+	if (mode == 0) {
+		m_type = getAttribute(elem, "type");
+		if (m_type.empty()) throw std::runtime_error("Entry type attribute is missing");
+		// Menu text
+		m_shortDesc = getText(elem, "short");
+		m_longDesc = getText(elem, "long");
+	} else {
+		std::string type = getAttribute(elem, "type");
+		if (!type.empty() && type != m_type) throw std::runtime_error("Entry type mismatch: " + getAttribute(elem, "name") + ": schema type = " + m_type + ", config type = " + type);
+	}
+	if (m_type == "bool") {
+		std::string value_string = getAttribute(elem, "value");
+		bool value;
+		if (value_string == "true") value = true;
+			else if (value_string == "false") value = false;
+				else throw std::runtime_error("Invalid boolean value '" + value_string + "'");
+		m_value = value;
+	} else if (m_type == "int") {
+		std::string value_string = getAttribute(elem, "value");
+		if (!value_string.empty()) m_value = std::stoi(value_string);
+			// Enum handling
+			if (mode == 0) {
+				auto n2 = elem.find("limits/enum");
+				if (!n2.empty()) {
+					for (auto it2 = n2.begin(), end2 = n2.end(); it2 != end2; ++it2) {
+						xmlpp::Element& elem2 = dynamic_cast<xmlpp::Element&>(**it2);
+						m_enums.push_back(getText(elem2));
+					}
+					m_min = 0;
+					m_max = int(m_enums.size() - 1);
+					m_step = 1;
+				}
+			}
+		updateNumeric<int>(elem, mode);
+	} else if (m_type == "float") {
+		std::string value_string = getAttribute(elem, "value");
+		if (!value_string.empty()) m_value = std::stod(value_string);
+			updateNumeric<double>(elem, mode);
+			} else if (m_type == "string") {
+				m_value = getText(elem, "stringvalue");
+			} else if (m_type == "string_list" || m_type == "option_list") {
+				//TODO: Option list should also update selection (from attribute?)
+				std::vector<std::string> value;
+				auto n2 = elem.find("stringvalue");
+				for (auto it2 = n2.begin(), end2 = n2.end(); it2 != end2; ++it2) {
+					value.push_back(getText(dynamic_cast<xmlpp::Element const&>(**it2)));
+				}
+				m_value = value;
+			} else if (!m_type.empty()) throw std::runtime_error("Invalid value type in config schema: " + m_type);
+	// Schema sets all defaults, system config sets the system default
+	if (mode < 1) m_factoryDefaultValue = m_defaultValue = m_value;
+		if (mode < 2) m_defaultValue = m_value;
+			} catch (std::exception& e) {
+				int line = elem.get_line();
+				throw std::runtime_error(std::to_string(line) + ": Error while reading entry: " + e.what());
+			}
 
 // These are set in readConfig, once the paths have been bootstrapped.
 fs::path systemConfFile;
 fs::path userConfFile;
 
 void writeConfig(Audio& m_audio, bool system) {
-    xmlpp::Document doc;
-    auto nodeRoot = doc.create_root_node("performous");
-    bool dirty = false;
-    for (auto& elem: config) {
-        ConfigItem& item = elem.second;
-        std::string name = elem.first;
-        if (item.isDefault(system)) continue; // No need to save settings with default values
-        dirty = true;
-        xmlpp::Element* entryNode = xmlpp::add_child_element(nodeRoot, "entry");
-        entryNode->set_attribute("name", name);
-        std::string type = item.get_type();
-        entryNode->set_attribute("type", type);
-        if (name == "audio/backend") {
-            int newValue = PaHostApiNameToHostApiTypeId(item.getEnumName());
-            std::clog << "audio/debug: Will now change value of audio backend. New Value: " << newValue << std::endl;
-            entryNode->set_attribute("value", std::to_string(newValue));
-            std::clog << "audio/info: Audio backend changed; will now restart audio subsystem." << std::endl;
+	xmlpp::Document doc;
+	auto nodeRoot = doc.create_root_node("performous");
+	bool dirty = false;
+	for (auto& elem: config) {
+		ConfigItem& item = elem.second;
+		std::string name = elem.first;
+		if (item.isDefault(system)) continue; // No need to save settings with default values
+		dirty = true;
+		xmlpp::Element* entryNode = xmlpp::add_child_element(nodeRoot, "entry");
+		entryNode->set_attribute("name", name);
+		std::string type = item.get_type();
+		entryNode->set_attribute("type", type);
+		if (name == "audio/backend") {
+			int newValue = PaHostApiNameToHostApiTypeId(item.getEnumName());
+			std::clog << "audio/debug: Will now change value of audio backend. New Value: " << newValue << std::endl;
+			entryNode->set_attribute("value", std::to_string(newValue));
+			std::clog << "audio/info: Audio backend changed; will now restart audio subsystem." << std::endl;
 
-            Audio::backendConfig().selectEnum(item.getEnumName());
-            boost::thread audiokiller(boost::bind(&Audio::close, boost::ref(m_audio)));
-            if (!audiokiller.timed_join(boost::posix_time::milliseconds(2500)))
-                Game::getSingletonPtr()->fatalError("Audio hung for some reason.\nPlease restart Performous.");
-            m_audio.restart();
-            m_audio.playMusic(findFile("menu.ogg"), true); // Start music again
-        }
-        else if (type == "int") entryNode->set_attribute("value",std::to_string(item.i()));
-        else if (type == "bool") entryNode->set_attribute("value", item.b() ? "true" : "false");
-        else if (type == "float") entryNode->set_attribute("value",std::to_string(item.f()));
-        else if (item.get_type() == "string") xmlpp::add_child_element(entryNode, "stringvalue")->add_child_text(item.s());
-        else if (item.get_type() == "string_list") {
-            for (auto const& str: item.sl()) xmlpp::add_child_element(entryNode, "stringvalue")->add_child_text(str);
-        }
-        else if (item.get_type() == "option_list") {
-            //TODO: Write selected also (as attribute?)
-            for (auto const& str: item.ol()) xmlpp::add_child_element(entryNode, "stringvalue")->add_child_text(str);
-        }
-    }
-    fs::path const& conf = system ? systemConfFile : userConfFile;
-    std::string tmp = conf.string() + "tmp";
-    try {
-        create_directories(conf.parent_path());
-        if (dirty) doc.write_to_file_formatted(tmp, "UTF-8");
-        if (exists(conf)) remove(conf);
-        if (dirty) {
-            rename(tmp, conf);
-            std::cerr << "Saved configuration to " << conf << std::endl;
-        } else {
-            std::cerr << "Using default settings, no configuration file needed." << std::endl;
-        }
-    } catch (...) {
-        throw std::runtime_error("Unable to save " + conf.string());
-    }
-    if (!system) return;
-    // Tell the items that we have changed the system default
-    for (auto& elem: config) elem.second.makeSystem();
-    // User config is no longer needed
-    if (exists(userConfFile)) remove(userConfFile);
+			Audio::backendConfig().selectEnum(item.getEnumName());
+			boost::thread audiokiller(boost::bind(&Audio::close, boost::ref(m_audio)));
+			if (!audiokiller.timed_join(boost::posix_time::milliseconds(2500)))
+				Game::getSingletonPtr()->fatalError("Audio hung for some reason.\nPlease restart Performous.");
+			m_audio.restart();
+			m_audio.playMusic(findFile("menu.ogg"), true); // Start music again
+		}
+		else if (type == "int") entryNode->set_attribute("value",std::to_string(item.i()));
+		else if (type == "bool") entryNode->set_attribute("value", item.b() ? "true" : "false");
+		else if (type == "float") entryNode->set_attribute("value",std::to_string(item.f()));
+		else if (item.get_type() == "string") xmlpp::add_child_element(entryNode, "stringvalue")->add_child_text(item.s());
+		else if (item.get_type() == "string_list") {
+			for (auto const& str: item.sl()) xmlpp::add_child_element(entryNode, "stringvalue")->add_child_text(str);
+		}
+		else if (item.get_type() == "option_list") {
+			//TODO: Write selected also (as attribute?)
+			for (auto const& str: item.ol()) xmlpp::add_child_element(entryNode, "stringvalue")->add_child_text(str);
+		}
+	}
+	fs::path const& conf = system ? systemConfFile : userConfFile;
+	std::string tmp = conf.string() + "tmp";
+	try {
+		create_directories(conf.parent_path());
+		if (dirty) doc.write_to_file_formatted(tmp, "UTF-8");
+		if (exists(conf)) remove(conf);
+		if (dirty) {
+			rename(tmp, conf);
+			std::cerr << "Saved configuration to " << conf << std::endl;
+		} else {
+			std::cerr << "Using default settings, no configuration file needed." << std::endl;
+		}
+	} catch (...) {
+		throw std::runtime_error("Unable to save " + conf.string());
+	}
+	if (!system) return;
+	// Tell the items that we have changed the system default
+	for (auto& elem: config) elem.second.makeSystem();
+	// User config is no longer needed
+	if (exists(userConfFile)) remove(userConfFile);
 }
 
 ConfigMenu configMenu;
 
 void readMenuXML(xmlpp::Node* node) {
-    xmlpp::Element& elem = dynamic_cast<xmlpp::Element&>(*node);
-    MenuEntry me;
-    me.name = getAttribute(elem, "name");
-    me.shortDesc = getText(elem, "short");
-    me.longDesc = getText(elem, "long");
-    configMenu.push_back(me);
+	xmlpp::Element& elem = dynamic_cast<xmlpp::Element&>(*node);
+	MenuEntry me;
+	me.name = getAttribute(elem, "name");
+	me.shortDesc = getText(elem, "short");
+	me.longDesc = getText(elem, "long");
+	configMenu.push_back(me);
 }
 
 void readConfigXML(fs::path const& file, int mode) {
-    if (!fs::exists(file)) {
-        std::clog << "config/info: Skipping " << file << " (not found)" << std::endl;
-        return;
-    }
-    std::clog << "config/info: Parsing " << file << std::endl;
-    xmlpp::DomParser domParser(file.string());
-    try {
-        auto n = domParser.get_document()->get_root_node()->find("/performous/menu/entry");
-        if (!n.empty()) {
-            configMenu.clear();
-            std::for_each(n.begin(), n.end(), readMenuXML);
-        }
-        n = domParser.get_document()->get_root_node()->find("/performous/entry");
-        for (auto nodeit = n.begin(), end = n.end(); nodeit != end; ++nodeit) {
-            xmlpp::Element& elem = dynamic_cast<xmlpp::Element&>(**nodeit);
-            std::string name = getAttribute(elem, "name");
-            if (name.empty()) throw std::runtime_error(file.string() + " element Entry missing name attribute");
-            auto it = config.find(name);
-            if (mode == 0) { // Schema
-                if (it != config.end()) throw std::runtime_error("Configuration schema contains the same value twice: " + name);
-                config[name].update(elem, 0);
-                // Add the item to menu, if not hidden
-                bool hidden = false;
-                try { if (getAttribute(elem, "hidden") == "true") hidden = true; } catch (XMLError&) {}
-                if (!hidden) {
-                    for (auto& elem: configMenu) {
-                        std::string prefix = elem.name + '/';
-                        if (name.substr(0, prefix.size()) == prefix) { elem.items.push_back(name); break; }
-                    }
-                }
-            } else {
-                if (it == config.end()) {
-                    std::clog << "config/warning:   Entry " << name << " ignored (does not exist in config schema)." << std::endl;
-                    continue;
-                }
-                it->second.update(elem, mode);
-            }
-        }
-    } catch (XMLError& e) {
-        int line = e.elem.get_line();
-        std::string name = e.elem.get_name();
-        throw std::runtime_error(file.string() + ":" + std::to_string(line) + " element " + name + " " + e.message);
-    } catch (std::exception& e) {
-        throw std::runtime_error(file.string() + ":" + e.what());
-    }
+	if (!fs::exists(file)) {
+		std::clog << "config/info: Skipping " << file << " (not found)" << std::endl;
+		return;
+	}
+	std::clog << "config/info: Parsing " << file << std::endl;
+	xmlpp::DomParser domParser(file.string());
+	try {
+		auto n = domParser.get_document()->get_root_node()->find("/performous/menu/entry");
+		if (!n.empty()) {
+			configMenu.clear();
+			std::for_each(n.begin(), n.end(), readMenuXML);
+		}
+		n = domParser.get_document()->get_root_node()->find("/performous/entry");
+		for (auto nodeit = n.begin(), end = n.end(); nodeit != end; ++nodeit) {
+			xmlpp::Element& elem = dynamic_cast<xmlpp::Element&>(**nodeit);
+			std::string name = getAttribute(elem, "name");
+			if (name.empty()) throw std::runtime_error(file.string() + " element Entry missing name attribute");
+			auto it = config.find(name);
+			if (mode == 0) { // Schema
+				if (it != config.end()) throw std::runtime_error("Configuration schema contains the same value twice: " + name);
+				config[name].update(elem, 0);
+				// Add the item to menu, if not hidden
+				bool hidden = false;
+				try { if (getAttribute(elem, "hidden") == "true") hidden = true; } catch (XMLError&) {}
+				if (!hidden) {
+					for (auto& elem: configMenu) {
+						std::string prefix = elem.name + '/';
+						if (name.substr(0, prefix.size()) == prefix) { elem.items.push_back(name); break; }
+					}
+				}
+			} else {
+				if (it == config.end()) {
+					std::clog << "config/warning:   Entry " << name << " ignored (does not exist in config schema)." << std::endl;
+					continue;
+				}
+				it->second.update(elem, mode);
+			}
+		}
+	} catch (XMLError& e) {
+		int line = e.elem.get_line();
+		std::string name = e.elem.get_name();
+		throw std::runtime_error(file.string() + ":" + std::to_string(line) + " element " + name + " " + e.message);
+	} catch (std::exception& e) {
+		throw std::runtime_error(file.string() + ":" + e.what());
+	}
 }
 
 int PaHostApiNameToHostApiTypeId (const std::string& name) {
-    if (name == "Auto") return 1337;
-    if (name == "Windows DirectSound") return 1;
-    if (name == "MME") return 2;
-    if (name == "ASIO") return 3;
-    if (name == "Core Audio" || name == "CoreAudio") return 5;
-    if (name == "OSS") return 7; // Not an error, stupid PortAudio.
-    if (name == "ALSA") return 8;
-    if (name == "Windows WDM-KS") return 11;
-    if (name == "JACK Audio Connection Kit") return 12;
-    if (name == "Windows WASAPI") return 13;
-    throw std::runtime_error("Invalid PortAudio HostApiTypeId Specified.");
+	if (name == "Auto") return 1337;
+	if (name == "Windows DirectSound") return 1;
+	if (name == "MME") return 2;
+	if (name == "ASIO") return 3;
+	if (name == "Core Audio" || name == "CoreAudio") return 5;
+	if (name == "OSS") return 7; // Not an error, stupid PortAudio.
+	if (name == "ALSA") return 8;
+	if (name == "Windows WDM-KS") return 11;
+	if (name == "JACK Audio Connection Kit") return 12;
+	if (name == "Windows WASAPI") return 13;
+	throw std::runtime_error("Invalid PortAudio HostApiTypeId Specified.");
 }
 
 
 void readConfig() {
-    // Find config schema
-    fs::path schemaFile = getSchemaFilename();
-    systemConfFile = getSysConfigDir() / "config.xml";
-    userConfFile = getConfigDir() / "config.xml";
-    readConfigXML(schemaFile, 0);  // Read schema and defaults
-    readConfigXML(systemConfFile, 1);  // Update defaults with system config
-    readConfigXML(userConfFile, 2);  // Read user settings
-    pathInit();
-    // Populate themes
-    ConfigItem& ci = config["game/theme"];
-    for (std::string const& theme: getThemes()) ci.addEnum(theme);
-    if (ci.i() == -1) ci.selectEnum("default");  // Select the default theme if nothing is selected
+	// Find config schema
+	fs::path schemaFile = getSchemaFilename();
+	systemConfFile = getSysConfigDir() / "config.xml";
+	userConfFile = getConfigDir() / "config.xml";
+	readConfigXML(schemaFile, 0);  // Read schema and defaults
+	readConfigXML(systemConfFile, 1);  // Update defaults with system config
+	readConfigXML(userConfFile, 2);  // Read user settings
+	pathInit();
+	// Populate themes
+	ConfigItem& ci = config["game/theme"];
+	for (std::string const& theme: getThemes()) ci.addEnum(theme);
+	if (ci.i() == -1) ci.selectEnum("default");  // Select the default theme if nothing is selected
 }
 
 void populateBackends (const std::list<std::string>& backendList) {
-    ConfigItem& backendConfig = config["audio/backend"];
-    for (std::string const& backend: backendList) backendConfig.addEnum(backend);
-    static std::string selectedBackend = std::string();
-    selectedBackend = backendConfig.getValue();
-    backendConfig.selectEnum(selectedBackend);
+	ConfigItem& backendConfig = config["audio/backend"];
+	for (std::string const& backend: backendList) backendConfig.addEnum(backend);
+	static std::string selectedBackend = std::string();
+	selectedBackend = backendConfig.getValue();
+	backendConfig.selectEnum(selectedBackend);
 }

--- a/game/ffmpeg.cc
+++ b/game/ffmpeg.cc
@@ -216,9 +216,9 @@ void FFmpeg::decodePacket() {
 			if (av_read_frame(s, this) < 0) throw FFmpeg::eof_error();
 		}
 #if LIBAVCODEC_VERSION_INT > (AV_VERSION_INT(55, 0, 0))
-        ~ReadFramePacket() { av_packet_unref(this); } //YES THEY DID IT AGAIN
+		~ReadFramePacket() { av_packet_unref(this); } //YES THEY DID IT AGAIN
 #else
-        ~ReadFramePacket() { av_free_packet(this); }
+		~ReadFramePacket() { av_free_packet(this); }
 #endif
 	};
 

--- a/game/ffmpeg.hh
+++ b/game/ffmpeg.hh
@@ -173,8 +173,8 @@ class FFmpeg {
 	FFmpeg(fs::path const& file, unsigned int rate = 0);
 	~FFmpeg();
 	void operator()(); ///< Thread runs here, don't call directly
-	unsigned width, ///< width of video
-	         height; ///< height of video
+	unsigned width; ///< width of video
+	unsigned height; ///< height of video
 	/// queue for video
 	VideoFifo  videoQueue;
 	/// queue for audio

--- a/game/fs.cc
+++ b/game/fs.cc
@@ -67,35 +67,32 @@ namespace {
 
 void copyDirectoryRecursively(const fs::path& sourceDir, const fs::path& destinationDir)
 {
-    if (!fs::exists(sourceDir) || !fs::is_directory(sourceDir))
-    {
-        throw std::runtime_error("Source directory " + sourceDir.string() + " does not exist or is not a directory");
-    }
-    if (!fs::create_directory(destinationDir) && !fs::exists(destinationDir))
-    {
-        throw std::runtime_error("Cannot create destination directory " + destinationDir.string());
-    }
+	if (!fs::exists(sourceDir) || !fs::is_directory(sourceDir)) {
+		throw std::runtime_error("Source directory " + sourceDir.string() + " does not exist or is not a directory");
+	}
+	if (!fs::create_directory(destinationDir) && !fs::exists(destinationDir)) {
+		throw std::runtime_error("Cannot create destination directory " + destinationDir.string());
+	}
 #if ((BOOST_VERSION / 100 % 1000) >= 55)
-    for (const auto& dirEnt : fs::recursive_directory_iterator{sourceDir})
+	for (const auto& dirEnt : fs::recursive_directory_iterator{sourceDir})
 #else
-    for (fs::recursive_directory_iterator dirEnt(sourceDir); dirEnt !=fs::recursive_directory_iterator(); ++dirEnt)
+	for (fs::recursive_directory_iterator dirEnt(sourceDir); dirEnt !=fs::recursive_directory_iterator(); ++dirEnt)
 #endif
-    {
-    #if ((BOOST_VERSION / 100 % 1000) >= 55)
-        const auto& path = dirEnt.path();
-    #else
-        const auto& path = dirEnt->path();    
-    #endif
-        auto relativePathStr = path.string();
-        boost::algorithm::replace_first(relativePathStr, sourceDir.string(), "");
-        try { 
-        if (!fs::is_directory(path)) { fs::copy_file(path, destinationDir / relativePathStr); }
-        else { fs::copy_directory(path, destinationDir / relativePathStr); }
-        }
-        catch (...) {
-        throw std::runtime_error("Cannot copy file " + path.string() + ", because it already exists in the destination folder.");
-        }
-    }
+	{
+#if ((BOOST_VERSION / 100 % 1000) >= 55)
+		const auto& path = dirEnt.path();
+#else
+		const auto& path = dirEnt->path();
+#endif
+		auto relativePathStr = path.string();
+		boost::algorithm::replace_first(relativePathStr, sourceDir.string(), "");
+		try { 
+			if (!fs::is_directory(path)) { fs::copy_file(path, destinationDir / relativePathStr); }
+			else { fs::copy_directory(path, destinationDir / relativePathStr); }
+		} catch (...) {
+			throw std::runtime_error("Cannot copy file " + path.string() + ", because it already exists in the destination folder.");
+		}
+	}
 }
 
 void pathBootstrap() { Lock l(mutex); cache.pathBootstrap(); }

--- a/game/game.cc
+++ b/game/game.cc
@@ -145,15 +145,15 @@ void Game::drawNotifications() {
 
 void Game::finished()
 {
-    m_finished = true;
+	m_finished = true;
 }
  
 Game::~Game()
 {
-    if (currentScreen) currentScreen->exit();
+	if (currentScreen) currentScreen->exit();
 }
  
 bool Game::isFinished()
 {
-    return m_finished;
+	return m_finished;
 }

--- a/game/hiscore.hh
+++ b/game/hiscore.hh
@@ -29,8 +29,8 @@ public:
 
 	  @param score is a value between 0 and 10000. values below 2000 will lead to instant disqualification.
 	  @return true if the score make it into the list
-	  @return false if addNewHiscore does not make sense
-	    for that score.*/
+	  @return false if addNewHiscore does not make sense for that score.
+	  */
 	bool reachedHiscore(unsigned score, unsigned songid, std::string const& track) const;
 
 	/**Add a specific highscore into the list.

--- a/game/notes.hh
+++ b/game/notes.hh
@@ -9,8 +9,8 @@
 
 /// stores duration of a note
 struct Duration {
-	double begin, ///< beginning timestamp in seconds
-	       end;   ///< ending timestamp in seconds
+	double begin; ///< beginning timestamp in seconds
+	double end;   ///< ending timestamp in seconds
 	Duration();
 	/// create a new Duration object and initialize begin and end
 	Duration(double b, double e): begin(b), end(e) {}
@@ -51,8 +51,8 @@ static inline bool isTrackInside(InstrumentTracks const& track_map, std::string 
 /// note read from songfile
 struct Note {
 	Note();
-	double begin, ///< begin time
-	       end; ///< end time
+	double begin; ///< begin time
+	double end; ///< end time
 	double phase; /// Position within a measure, [0, 1)
 	// FIXME: Remove gameplay variables from here (Note should be immutable).
 	/// power of note (how well it is being hit right now)

--- a/game/playlist.hh
+++ b/game/playlist.hh
@@ -10,7 +10,7 @@
 class PlayList
 {
 public:
-    //needs function that returns the song properties in a list for display on screen
+	//needs function that returns the song properties in a list for display on screen
 
 	typedef std::vector< boost::shared_ptr<Song> > SongList;
 

--- a/game/screen.hh
+++ b/game/screen.hh
@@ -46,8 +46,8 @@ class Screen {
 class Game: public Singleton <Game> {
   public:
 	/// constructor
-    Game(Window& window);
-    ~Game();
+	Game(Window& window);
+	~Game();
 	/// Adds a screen to the manager
 	void addScreen(Screen* s) { std::string tmp = s->getName(); screens.insert(tmp, s); }
 	/// Switches active screen

--- a/game/screen_sing.cc
+++ b/game/screen_sing.cc
@@ -167,7 +167,7 @@ void ScreenSing::reloadGL() {
 }
 
 void ScreenSing::exit() {
-    Game::getSingletonPtr()->controllers.enableEvents(false);
+	Game::getSingletonPtr()->controllers.enableEvents(false);
 	m_engine.reset();
 	m_score_window.reset();
 	m_menu.clear();
@@ -182,7 +182,7 @@ void ScreenSing::exit() {
 	m_song->dropNotes();
 	m_menuTheme.reset();
 	theme.reset();
-    m_audio.fadeout(0);
+	m_audio.fadeout(0);
 	if (m_audio.isPaused()) m_audio.togglePause();
 	Game::getSingletonPtr()->showLogo();
 }
@@ -256,7 +256,7 @@ void ScreenSing::activateNextScreen()
 	m_database.addSong(m_song);
 	if (m_database.scores.empty() || !m_database.reachedHiscore(m_song)) {
 		// if no highscore reached..
-	    gm->activateScreen("Playlist");
+		gm->activateScreen("Playlist");
 	}
 
 	// Score window visible -> Enter quits to Players Screen

--- a/game/screen_songs.cc
+++ b/game/screen_songs.cc
@@ -381,7 +381,7 @@ void ScreenSongs::drawCovers() {
 		s.draw();
 	}
 	// Draw the playlist
-    Game* gm = Game::getSingletonPtr();
+	Game* gm = Game::getSingletonPtr();
 	auto const& playlist = gm->getCurrentPlayList().getList();
 	double c = (m_menuPos == 0 /* Playlist */ ? beat : 1.0);
 	ColorTrans c1(Color(c, c, c));

--- a/game/songparser-txt.cc
+++ b/game/songparser-txt.cc
@@ -11,222 +11,222 @@ using namespace SongParserUtil;
 
 /// 'Magick' to check if this file looks like correct format
 bool SongParser::txtCheck(std::string const& data) const {
-    return data[0] == '#' && data[1] >= 'A' && data[1] <= 'Z';
+	return data[0] == '#' && data[1] >= 'A' && data[1] <= 'Z';
 }
 
 /// Parse header data for Songs screen
 void SongParser::txtParseHeader() {
-    Song& s = m_song;
-    std::string line;
-    s.insertVocalTrack(TrackName::LEAD_VOCAL, VocalTrack(TrackName::LEAD_VOCAL)); // Dummy note to indicate there is a track
-    while (getline(line) && txtParseField(line)) {}
-    if (s.title.empty() || s.artist.empty()) throw std::runtime_error("Required header fields missing");
-    if (m_bpm != 0.0) addBPM(0, m_bpm);
+	Song& s = m_song;
+	std::string line;
+	s.insertVocalTrack(TrackName::LEAD_VOCAL, VocalTrack(TrackName::LEAD_VOCAL)); // Dummy note to indicate there is a track
+	while (getline(line) && txtParseField(line)) {}
+	if (s.title.empty() || s.artist.empty()) throw std::runtime_error("Required header fields missing");
+	if (m_bpm != 0.0) addBPM(0, m_bpm);
 }
 
 /// Parse notes
 void SongParser::txtParse() {
-    std::string line;
-    m_curSinger = P1;
-    m_song.insertVocalTrack(TrackName::LEAD_VOCAL, VocalTrack(TrackName::LEAD_VOCAL));
-    m_song.insertVocalTrack(DUET_P2, VocalTrack(DUET_P2));
-    while (getline(line) && txtParseField(line)) {} // Parse the header again
-    resetNoteParsingState();
-    while (txtParseNote(line) && getline(line)) {} // Parse notes
-    // Workaround for the terminating : 1 0 0 line, written by some converters
-    // FIXME: Should we do this for all tracks?	
-    
-    for (auto const& name: { TrackName::LEAD_VOCAL, DUET_P2 }) {
-        Notes& notes = m_song.getVocalTrack(name).notes;
-        auto it = notes.rbegin();
-        if (!notes.empty() && it->type != Note::SLEEP && it->begin == it->end) notes.pop_back();
-        if (notes.empty()) m_song.eraseVocalTrack(name);
-    }
-    
-    if (m_song.hasDuet()) {
-        bool skip;
-        Notes s1, s2, merged, finalDuet;
-        s1 = m_song.getVocalTrack(TrackName::LEAD_VOCAL).notes;
-        s2 = m_song.getVocalTrack(SongParserUtil::DUET_P2).notes;
-        std::merge(s1.begin(), s1.end(), s2.begin(), s2.end(), std::back_inserter(merged), Note::ltBegin);
-        VocalTracks const& tracks = m_song.vocalTracks;
-        std::string duetName = tracks.at(TrackName::LEAD_VOCAL).name + " & " + tracks.at(SongParserUtil::DUET_P2).name;
-        m_song.insertVocalTrack(SongParserUtil::DUET_BOTH, duetName);
-        VocalTrack& duetTrack = m_song.getVocalTrack(SongParserUtil::DUET_BOTH);
-        Notes& duetNotes = duetTrack.notes;
-        duetNotes.clear();
-        
-        for (auto currentNote: merged) {
-            skip = false;
-            if (!finalDuet.empty()) { 
-                if (currentNote.type == Note::SLEEP) {
-                    auto prevToLast = ++(finalDuet.rbegin());
-                    if (prevToLast->type == Note::SLEEP) {
-                        std::clog << "songparser/info: Phrase formed by a single syllable is most likely our fault, We'll skip the break." << std::endl;
-                        skip = true;
-                    }
-                }
-                else {
-                    if (Note::overlapping(finalDuet.back(),currentNote)) {
-                        std::clog << "songparser/info: Will try to fix overlap (most likely between both singers) with a linebreak." << std::endl;
-                        Note lineBreak = Note();
-                        lineBreak.type = Note::SLEEP;
-                        double beatDur = getBPM(finalDuet.back().begin).step;
-                        double newEnd = (currentNote.begin - 2*beatDur);
-                        lineBreak.begin = lineBreak.end = newEnd;
-                        if (finalDuet.back().type != Note::SLEEP) {
-                            finalDuet.back().end = newEnd;
-                            if (currentNote.type == Note::SLEEP) { skip = true; }
-                            if (!skip) { finalDuet.push_back(lineBreak); }
-                        }
-                    }
-                }	
-            }
-            if (!skip) { finalDuet.push_back(currentNote); }
-        }
-        auto finalNote = std::unique(finalDuet.begin(), finalDuet.end(), Note::equal);
-        finalDuet.erase(finalNote, finalDuet.end());
-        duetNotes.swap(finalDuet);
-        duetTrack.noteMin = std::min(m_song.getVocalTrack(TrackName::LEAD_VOCAL).noteMin, m_song.getVocalTrack(SongParserUtil::DUET_P2).noteMin);
-        duetTrack.noteMax = std::max(m_song.getVocalTrack(TrackName::LEAD_VOCAL).noteMax, m_song.getVocalTrack(SongParserUtil::DUET_P2).noteMax);
-    } 
+	std::string line;
+	m_curSinger = P1;
+	m_song.insertVocalTrack(TrackName::LEAD_VOCAL, VocalTrack(TrackName::LEAD_VOCAL));
+	m_song.insertVocalTrack(DUET_P2, VocalTrack(DUET_P2));
+	while (getline(line) && txtParseField(line)) {} // Parse the header again
+	resetNoteParsingState();
+	while (txtParseNote(line) && getline(line)) {} // Parse notes
+	// Workaround for the terminating : 1 0 0 line, written by some converters
+	// FIXME: Should we do this for all tracks?	
+	
+	for (auto const& name: { TrackName::LEAD_VOCAL, DUET_P2 }) {
+		Notes& notes = m_song.getVocalTrack(name).notes;
+		auto it = notes.rbegin();
+		if (!notes.empty() && it->type != Note::SLEEP && it->begin == it->end) notes.pop_back();
+		if (notes.empty()) m_song.eraseVocalTrack(name);
+	}
+	
+	if (m_song.hasDuet()) {
+		bool skip;
+		Notes s1, s2, merged, finalDuet;
+		s1 = m_song.getVocalTrack(TrackName::LEAD_VOCAL).notes;
+		s2 = m_song.getVocalTrack(SongParserUtil::DUET_P2).notes;
+		std::merge(s1.begin(), s1.end(), s2.begin(), s2.end(), std::back_inserter(merged), Note::ltBegin);
+		VocalTracks const& tracks = m_song.vocalTracks;
+		std::string duetName = tracks.at(TrackName::LEAD_VOCAL).name + " & " + tracks.at(SongParserUtil::DUET_P2).name;
+		m_song.insertVocalTrack(SongParserUtil::DUET_BOTH, duetName);
+		VocalTrack& duetTrack = m_song.getVocalTrack(SongParserUtil::DUET_BOTH);
+		Notes& duetNotes = duetTrack.notes;
+		duetNotes.clear();
+		
+		for (auto currentNote: merged) {
+			skip = false;
+			if (!finalDuet.empty()) { 
+				if (currentNote.type == Note::SLEEP) {
+					auto prevToLast = ++(finalDuet.rbegin());
+					if (prevToLast->type == Note::SLEEP) {
+						std::clog << "songparser/info: Phrase formed by a single syllable is most likely our fault, We'll skip the break." << std::endl;
+						skip = true;
+					}
+				}
+				else {
+					if (Note::overlapping(finalDuet.back(),currentNote)) {
+						std::clog << "songparser/info: Will try to fix overlap (most likely between both singers) with a linebreak." << std::endl;
+						Note lineBreak = Note();
+						lineBreak.type = Note::SLEEP;
+						double beatDur = getBPM(finalDuet.back().begin).step;
+						double newEnd = (currentNote.begin - 2*beatDur);
+						lineBreak.begin = lineBreak.end = newEnd;
+						if (finalDuet.back().type != Note::SLEEP) {
+							finalDuet.back().end = newEnd;
+							if (currentNote.type == Note::SLEEP) { skip = true; }
+							if (!skip) { finalDuet.push_back(lineBreak); }
+						}
+					}
+				}	
+			}
+			if (!skip) { finalDuet.push_back(currentNote); }
+		}
+		auto finalNote = std::unique(finalDuet.begin(), finalDuet.end(), Note::equal);
+		finalDuet.erase(finalNote, finalDuet.end());
+		duetNotes.swap(finalDuet);
+		duetTrack.noteMin = std::min(m_song.getVocalTrack(TrackName::LEAD_VOCAL).noteMin, m_song.getVocalTrack(SongParserUtil::DUET_P2).noteMin);
+		duetTrack.noteMax = std::max(m_song.getVocalTrack(TrackName::LEAD_VOCAL).noteMax, m_song.getVocalTrack(SongParserUtil::DUET_P2).noteMax);
+	} 
 }
 
 bool SongParser::txtParseField(std::string const& line) {
-    if (line.empty()) return true;
-    if (line[0] != '#') return false;
-    std::string::size_type pos = line.find(':');
-    if (pos == std::string::npos) throw std::runtime_error("Invalid txt format, should be #key:value");
-    std::string key = boost::trim_copy(line.substr(1, pos - 1));
-    std::string value = boost::trim_copy(line.substr(pos + 1));
-    if (value.empty()) return true;
-    
-    // Parse header data that is stored in SongParser rather than in song (and thus needs to be read every time)
-    if (key == "BPM") assign(m_bpm, value);
-    else if (key == "RELATIVE") assign(m_relative, value);
-    else if (key == "GAP") { assign(m_gap, value); m_gap *= 1e-3; }
-    else if (key == "DUETSINGERP1" || key == "P1") m_song.insertVocalTrack(TrackName::LEAD_VOCAL, VocalTrack(value.substr(value.find_first_not_of(" "))));
-    // Strong hint that this is a duet, so it will be readily displayed with two singers in browser and properly filtered
-    else if (key == "DUETSINGERP2" || key == "P2") m_song.insertVocalTrack(DUET_P2, VocalTrack(value.substr(value.find_first_not_of(" "))));
-    
-    if (m_song.loadStatus >= Song::HEADER) return true;  // Only re-parsing now, skip any other data
-    
-    // Parse header data that is directly stored in m_song
-    if (key == "TITLE") m_song.title = value.substr(value.find_first_not_of(" :"));
-    else if (key == "ARTIST") m_song.artist = value.substr(value.find_first_not_of(" "));
-    else if (key == "EDITION") m_song.edition = value.substr(value.find_first_not_of(" "));
-    else if (key == "GENRE") m_song.genre = value.substr(value.find_first_not_of(" "));
-    else if (key == "CREATOR") m_song.creator = value.substr(value.find_first_not_of(" "));
-    else if (key == "COVER") m_song.cover = fs::absolute(value, m_song.path);
-    else if (key == "MP3") m_song.music["background"] = fs::absolute(value, m_song.path);
-    else if (key == "VOCALS") m_song.music["vocals"] = fs::absolute(value, m_song.path);
-    else if (key == "VIDEO") m_song.video = fs::absolute(value, m_song.path);
-    else if (key == "BACKGROUND") m_song.background = fs::absolute(value, m_song.path);
-    else if (key == "START") assign(m_song.start, value);
-    else if (key == "VIDEOGAP") assign(m_song.videoGap, value);
-    else if (key == "PREVIEWSTART") assign(m_song.preview_start, value);
-    else if (key == "LANGUAGE") m_song.language = value.substr(value.find_first_not_of(" "));
-    return true;
+	if (line.empty()) return true;
+	if (line[0] != '#') return false;
+	std::string::size_type pos = line.find(':');
+	if (pos == std::string::npos) throw std::runtime_error("Invalid txt format, should be #key:value");
+	std::string key = boost::trim_copy(line.substr(1, pos - 1));
+	std::string value = boost::trim_copy(line.substr(pos + 1));
+	if (value.empty()) return true;
+	
+	// Parse header data that is stored in SongParser rather than in song (and thus needs to be read every time)
+	if (key == "BPM") assign(m_bpm, value);
+	else if (key == "RELATIVE") assign(m_relative, value);
+	else if (key == "GAP") { assign(m_gap, value); m_gap *= 1e-3; }
+	else if (key == "DUETSINGERP1" || key == "P1") m_song.insertVocalTrack(TrackName::LEAD_VOCAL, VocalTrack(value.substr(value.find_first_not_of(" "))));
+	// Strong hint that this is a duet, so it will be readily displayed with two singers in browser and properly filtered
+	else if (key == "DUETSINGERP2" || key == "P2") m_song.insertVocalTrack(DUET_P2, VocalTrack(value.substr(value.find_first_not_of(" "))));
+	
+	if (m_song.loadStatus >= Song::HEADER) return true;  // Only re-parsing now, skip any other data
+	
+	// Parse header data that is directly stored in m_song
+	if (key == "TITLE") m_song.title = value.substr(value.find_first_not_of(" :"));
+	else if (key == "ARTIST") m_song.artist = value.substr(value.find_first_not_of(" "));
+	else if (key == "EDITION") m_song.edition = value.substr(value.find_first_not_of(" "));
+	else if (key == "GENRE") m_song.genre = value.substr(value.find_first_not_of(" "));
+	else if (key == "CREATOR") m_song.creator = value.substr(value.find_first_not_of(" "));
+	else if (key == "COVER") m_song.cover = fs::absolute(value, m_song.path);
+	else if (key == "MP3") m_song.music["background"] = fs::absolute(value, m_song.path);
+	else if (key == "VOCALS") m_song.music["vocals"] = fs::absolute(value, m_song.path);
+	else if (key == "VIDEO") m_song.video = fs::absolute(value, m_song.path);
+	else if (key == "BACKGROUND") m_song.background = fs::absolute(value, m_song.path);
+	else if (key == "START") assign(m_song.start, value);
+	else if (key == "VIDEOGAP") assign(m_song.videoGap, value);
+	else if (key == "PREVIEWSTART") assign(m_song.preview_start, value);
+	else if (key == "LANGUAGE") m_song.language = value.substr(value.find_first_not_of(" "));
+	return true;
 }
 
 bool SongParser::txtParseNote(std::string line) {
-    if (line.empty() || line == "\r") return true;
-    if (line[0] == '#') throw std::runtime_error("Key found in the middle of notes");
-    if (line[line.size() - 1] == '\r') line.erase(line.size() - 1);
-    if (line[0] == 'E') return false;
-    std::istringstream iss(line);
-    if (line[0] == 'B') {
-        unsigned int ts;
-        double bpm;
-        iss.ignore();
-        if (!(iss >> ts >> bpm)) throw std::runtime_error("Invalid BPM line format");
-        addBPM(ts, bpm);
-        return true;
-    }
-    if (line[0] == 'P') {
-        if (m_relative) // FIXME?
-            throw std::runtime_error("Relative note timing not supported with multiple singers");
-        if (line.size() < 2) throw std::runtime_error("Invalid player info line [too short]: " + line);
-        else if (line[1] == '1') m_curSinger = P1;
-        else if (line[1] == '2') m_curSinger = P2;
-        else if (line[1] == '3') m_curSinger = BOTH;
-        else if (line.size() < 3) throw std::runtime_error("Invalid player info line [too short]: " + line);
-        else if (line[2] == '1') m_curSinger = P1;
-        else if (line[2] == '2') m_curSinger = P2;
-        else if (line[2] == '3') m_curSinger = BOTH;
-        else throw std::runtime_error("Invalid player info line [malformed]: " + line);
-        resetNoteParsingState();
-        return true;
-    }
-    Note n;
-    n.type = Note::Type(iss.get());
-    unsigned int ts = m_prevts;
-    switch (n.type) {
-        case Note::NORMAL:
-        case Note::FREESTYLE:
-        case Note::GOLDEN:
-        {
-            unsigned int length = 0;
-            if (!(iss >> ts >> length >> n.note)) throw std::runtime_error("Invalid note line format");
-            if (length < 1) throw std::runtime_error("Notes must have positive durations.");
-            n.notePrev = n.note; // No slide notes in TXT yet.
-            if (m_relative) ts += m_relativeShift;
-            if (iss.get() == ' ') std::getline(iss, n.syllable);
-            n.end = tsTime(ts + length);
-        }
-            break;
-        case Note::SLEEP:
-        {
-            unsigned int end;
-            if (!(iss >> ts >> end)) end = ts;
-            if (m_relative) {
-                ts += m_relativeShift;
-                end += m_relativeShift;
-                m_relativeShift = end;
-            }
-            n.end = tsTime(end);
-        }
-            break;
-        default: throw std::runtime_error("Unknown note type");
-    }
-    n.begin = tsTime(ts);
-    VocalTrack& vocal = (m_curSinger & P1)
-    ? m_song.getVocalTrack(TrackName::LEAD_VOCAL)
-    : m_song.getVocalTrack(DUET_P2);
-    Notes& notes = vocal.notes;
-    if (m_relative && notes.empty()) m_relativeShift = ts;
-    m_prevts = ts;
-    // FIXME: These work-arounds don't work for P3 (both singers) case
-    if (n.begin < m_prevtime) {
-        // Oh no, overlapping notes (b0rked file)
-        // Can't do this because too many songs are b0rked: throw std::runtime_error("Note overlaps with previous note");
-        if (notes.size() >= 1) {
-            Note& p = notes.back();
-            if (p.begin > n.begin) {
-                std::string msg = "Skipped overlapping notes:\n" + p.syllable + ", " + n.syllable + "\n";
-                m_song.b0rked += msg;
-                std::clog << "songparser/notice: " + m_song.filename.string() + ": " + msg << std::endl;
-                return true;
-            }
-        } else throw std::runtime_error("The first note has negative timestamp");
-    }
-    double prevtime = m_prevtime;
-    m_prevtime = n.end;
-    if (n.type != Note::SLEEP && n.end > n.begin) {
-        vocal.noteMin = std::min(vocal.noteMin, n.note);
-        vocal.noteMax = std::max(vocal.noteMax, n.note);
-    }
-    if (n.type == Note::SLEEP) {
-        if (notes.empty()) return true; // Ignore sleeps at song beginning
-        else {
-            Note& p = notes.back();
-            n.begin = n.end = prevtime; // Normalize sleep notes
-            
-            if (p.type == Note::SLEEP) return true; // Ignore consecutive sleeps
-        }
-    }
-    notes.push_back(n);
-    if (m_curSinger == BOTH) { m_song.getVocalTrack(DUET_P2).notes.push_back(n); }
-    return true;
+	if (line.empty() || line == "\r") return true;
+	if (line[0] == '#') throw std::runtime_error("Key found in the middle of notes");
+	if (line[line.size() - 1] == '\r') line.erase(line.size() - 1);
+	if (line[0] == 'E') return false;
+	std::istringstream iss(line);
+	if (line[0] == 'B') {
+		unsigned int ts;
+		double bpm;
+		iss.ignore();
+		if (!(iss >> ts >> bpm)) throw std::runtime_error("Invalid BPM line format");
+		addBPM(ts, bpm);
+		return true;
+	}
+	if (line[0] == 'P') {
+		if (m_relative) // FIXME?
+			throw std::runtime_error("Relative note timing not supported with multiple singers");
+		if (line.size() < 2) throw std::runtime_error("Invalid player info line [too short]: " + line);
+		else if (line[1] == '1') m_curSinger = P1;
+		else if (line[1] == '2') m_curSinger = P2;
+		else if (line[1] == '3') m_curSinger = BOTH;
+		else if (line.size() < 3) throw std::runtime_error("Invalid player info line [too short]: " + line);
+		else if (line[2] == '1') m_curSinger = P1;
+		else if (line[2] == '2') m_curSinger = P2;
+		else if (line[2] == '3') m_curSinger = BOTH;
+		else throw std::runtime_error("Invalid player info line [malformed]: " + line);
+		resetNoteParsingState();
+		return true;
+	}
+	Note n;
+	n.type = Note::Type(iss.get());
+	unsigned int ts = m_prevts;
+	switch (n.type) {
+		case Note::NORMAL:
+		case Note::FREESTYLE:
+		case Note::GOLDEN:
+		{
+			unsigned int length = 0;
+			if (!(iss >> ts >> length >> n.note)) throw std::runtime_error("Invalid note line format");
+			if (length < 1) throw std::runtime_error("Notes must have positive durations.");
+			n.notePrev = n.note; // No slide notes in TXT yet.
+			if (m_relative) ts += m_relativeShift;
+			if (iss.get() == ' ') std::getline(iss, n.syllable);
+			n.end = tsTime(ts + length);
+		}
+			break;
+		case Note::SLEEP:
+		{
+			unsigned int end;
+			if (!(iss >> ts >> end)) end = ts;
+			if (m_relative) {
+				ts += m_relativeShift;
+				end += m_relativeShift;
+				m_relativeShift = end;
+			}
+			n.end = tsTime(end);
+		}
+			break;
+		default: throw std::runtime_error("Unknown note type");
+	}
+	n.begin = tsTime(ts);
+	VocalTrack& vocal = (m_curSinger & P1)
+	? m_song.getVocalTrack(TrackName::LEAD_VOCAL)
+	: m_song.getVocalTrack(DUET_P2);
+	Notes& notes = vocal.notes;
+	if (m_relative && notes.empty()) m_relativeShift = ts;
+	m_prevts = ts;
+	// FIXME: These work-arounds don't work for P3 (both singers) case
+	if (n.begin < m_prevtime) {
+		// Oh no, overlapping notes (b0rked file)
+		// Can't do this because too many songs are b0rked: throw std::runtime_error("Note overlaps with previous note");
+		if (notes.size() >= 1) {
+			Note& p = notes.back();
+			if (p.begin > n.begin) {
+				std::string msg = "Skipped overlapping notes:\n" + p.syllable + ", " + n.syllable + "\n";
+				m_song.b0rked += msg;
+				std::clog << "songparser/notice: " + m_song.filename.string() + ": " + msg << std::endl;
+				return true;
+			}
+		} else throw std::runtime_error("The first note has negative timestamp");
+	}
+	double prevtime = m_prevtime;
+	m_prevtime = n.end;
+	if (n.type != Note::SLEEP && n.end > n.begin) {
+		vocal.noteMin = std::min(vocal.noteMin, n.note);
+		vocal.noteMax = std::max(vocal.noteMax, n.note);
+	}
+	if (n.type == Note::SLEEP) {
+		if (notes.empty()) return true; // Ignore sleeps at song beginning
+		else {
+			Note& p = notes.back();
+			n.begin = n.end = prevtime; // Normalize sleep notes
+			
+			if (p.type == Note::SLEEP) return true; // Ignore consecutive sleeps
+		}
+	}
+	notes.push_back(n);
+	if (m_curSinger == BOTH) { m_song.getVocalTrack(DUET_P2).notes.push_back(n); }
+	return true;
 }
 

--- a/game/songparser.cc
+++ b/game/songparser.cc
@@ -6,36 +6,36 @@
 
 
 namespace SongParserUtil {
-    void assign(int& var, std::string const& str) {
-        try {
-            var = std::stoi(str);
-        } catch (...) {
-            throw std::runtime_error("\"" + str + "\" is not valid integer value");
-        }
-    }
-    void assign(unsigned& var, std::string const& str) {
-        try {
-            var = std::stoi(str);
-        } catch (...) {
-            throw std::runtime_error("\"" + str + "\" is not valid unsigned integer value");
-        }
-    }
-    void assign(double& var, std::string str) {
-        std::replace(str.begin(), str.end(), ',', '.'); // Fix decimal separators
-        try {
-            var = std::stod(str);
-        } catch (...) {
-            throw std::runtime_error("\"" + str + "\" is not valid floating point value");
-        }
-    }
-    void assign(bool& var, std::string const& str) {
-        if (str == "YES" || str == "yes" || str == "1") var = true;
-        else if (str == "NO" || str == "no" || str == "0") var = false;
-        else throw std::runtime_error("Invalid boolean value: " + str);
-    }
-    void eraseLast(std::string& s, char ch) {
-        if (!s.empty() && *s.rbegin() == ch) s.erase(s.size() - 1);
-    }
+	void assign(int& var, std::string const& str) {
+		try {
+			var = std::stoi(str);
+		} catch (...) {
+			throw std::runtime_error("\"" + str + "\" is not valid integer value");
+		}
+	}
+	void assign(unsigned& var, std::string const& str) {
+		try {
+			var = std::stoi(str);
+		} catch (...) {
+			throw std::runtime_error("\"" + str + "\" is not valid unsigned integer value");
+		}
+	}
+	void assign(double& var, std::string str) {
+		std::replace(str.begin(), str.end(), ',', '.'); // Fix decimal separators
+		try {
+			var = std::stod(str);
+		} catch (...) {
+			throw std::runtime_error("\"" + str + "\" is not valid floating point value");
+		}
+	}
+	void assign(bool& var, std::string const& str) {
+		if (str == "YES" || str == "yes" || str == "1") var = true;
+		else if (str == "NO" || str == "no" || str == "0") var = false;
+		else throw std::runtime_error("Invalid boolean value: " + str);
+	}
+	void eraseLast(std::string& s, char ch) {
+		if (!s.empty() && *s.rbegin() == ch) s.erase(s.size() - 1);
+	}
 }
 
 
@@ -52,224 +52,224 @@ m_relativeShift(),
 m_tsPerBeat(),
 m_tsEnd()
 {
-    try {
-        enum { NONE, TXT, XML, INI, SM } type = NONE;
-        // Read the file, determine the type and do some initial validation checks
-        {
-            fs::ifstream f(s.filename, std::ios::binary);
-            if (!f.is_open()) throw SongParserException(s, "Could not open song file", 0);
-            m_ss << f.rdbuf();
-            int size = m_ss.str().length();
-            if (size < 10 || size > 100000) throw SongParserException(s, "Does not look like a song file (wrong size)", 1, true);
-            // Convert m_ss; filename supplied for possible warning messages
-            if (xmlCheck(m_ss.str())) type = XML; // XMLPP should deal with encoding so we don't have to.
-            else {
-                convertToUTF8(m_ss, s.filename.string());
-                if (smCheck(m_ss.str())) type = SM;
-                else if (txtCheck(m_ss.str())) type = TXT;
-                else if (iniCheck(m_ss.str())) type = INI;
-                else throw SongParserException(s, "Does not look like a song file (wrong header)", 1, true);
-            }
-        }
-        // Header already parsed?
-        if (s.loadStatus == Song::HEADER) {
-            if (type == TXT) txtParse();
-            else if (type == INI) midParse();  // INI doesn't contain notes, parse those from MIDI
-            else if (type == XML) xmlParse();
-            else if (type == SM) smParse();
-            finalize(); // Do some adjusting to the notes
-            s.loadStatus = Song::FULL;
-            return;
-        }
-        // Parse only header to speed up loading and conserve memory
-        if (type == TXT) txtParseHeader();
-        else if (type == INI) iniParseHeader();
-        else if (type == XML) xmlParseHeader();
-        else if (type == SM) { smParseHeader(); s.dropNotes(); } // Hack: drop notes here
-        // Default for preview position if none was specified in header
-        if (s.preview_start != s.preview_start) s.preview_start = (type == INI ? 5.0 : 30.0);  // 5 s for band mode, 30 s for others
-        
-        guessFiles();
-        if (!m_song.midifilename.empty()) midParseHeader();
-        
-        s.loadStatus = Song::HEADER;
-    } catch (SongParserException&) {
-        throw;
-    } catch (std::runtime_error& e) {
-        throw SongParserException(m_song, e.what(), m_linenum);
-    } catch (std::exception& e) {
-        throw SongParserException(m_song, "Internal error: " + std::string(e.what()), m_linenum);
-    }
+	try {
+		enum { NONE, TXT, XML, INI, SM } type = NONE;
+		// Read the file, determine the type and do some initial validation checks
+		{
+			fs::ifstream f(s.filename, std::ios::binary);
+			if (!f.is_open()) throw SongParserException(s, "Could not open song file", 0);
+			m_ss << f.rdbuf();
+			int size = m_ss.str().length();
+			if (size < 10 || size > 100000) throw SongParserException(s, "Does not look like a song file (wrong size)", 1, true);
+			// Convert m_ss; filename supplied for possible warning messages
+			if (xmlCheck(m_ss.str())) type = XML; // XMLPP should deal with encoding so we don't have to.
+			else {
+				convertToUTF8(m_ss, s.filename.string());
+				if (smCheck(m_ss.str())) type = SM;
+				else if (txtCheck(m_ss.str())) type = TXT;
+				else if (iniCheck(m_ss.str())) type = INI;
+				else throw SongParserException(s, "Does not look like a song file (wrong header)", 1, true);
+			}
+		}
+		// Header already parsed?
+		if (s.loadStatus == Song::HEADER) {
+			if (type == TXT) txtParse();
+			else if (type == INI) midParse();  // INI doesn't contain notes, parse those from MIDI
+			else if (type == XML) xmlParse();
+			else if (type == SM) smParse();
+			finalize(); // Do some adjusting to the notes
+			s.loadStatus = Song::FULL;
+			return;
+		}
+		// Parse only header to speed up loading and conserve memory
+		if (type == TXT) txtParseHeader();
+		else if (type == INI) iniParseHeader();
+		else if (type == XML) xmlParseHeader();
+		else if (type == SM) { smParseHeader(); s.dropNotes(); } // Hack: drop notes here
+		// Default for preview position if none was specified in header
+		if (s.preview_start != s.preview_start) s.preview_start = (type == INI ? 5.0 : 30.0);  // 5 s for band mode, 30 s for others
+		
+		guessFiles();
+		if (!m_song.midifilename.empty()) midParseHeader();
+		
+		s.loadStatus = Song::HEADER;
+	} catch (SongParserException&) {
+		throw;
+	} catch (std::runtime_error& e) {
+		throw SongParserException(m_song, e.what(), m_linenum);
+	} catch (std::exception& e) {
+		throw SongParserException(m_song, "Internal error: " + std::string(e.what()), m_linenum);
+	}
 }
 
 void SongParser::guessFiles() {
-    // List of fields containing filenames, and auto-matching regexps, in order of priority
-    const std::vector<std::pair<fs::path*, char const*>> fields = {
-        { &m_song.cover, R"((cover|album|label|banner|bn|\[co\])\.(png|jpeg|jpg|svg)$)" },
-        { &m_song.background, R"((background|bg|\[bg\])\.(png|jpeg|jpg|svg)$)" },
-        { &m_song.cover, R"(\.(png|jpeg|jpg|svg)$)" },
-        { &m_song.background, R"(\.(png|jpeg|jpg|svg)$)" },
-        { &m_song.video, R"(\.(avi|mpg|mpeg|flv|mov|mp4|mkv|m4v)$)" },
-        { &m_song.midifilename, R"(^notes\.mid$)" },
-        { &m_song.midifilename, R"(\.mid$)" },
-        { &m_song.music[TrackName::PREVIEW], R"(^preview\.(mp3|ogg|aac)$)" },
-        { &m_song.music[TrackName::GUITAR], R"(^guitar\.(mp3|ogg|aac)$)" },
-        { &m_song.music[TrackName::BASS], R"(^rhythm\.(mp3|ogg|aac)$)" },
-        { &m_song.music[TrackName::DRUMS], R"(^drums\.(mp3|ogg|aac)$)" },
-        { &m_song.music[TrackName::KEYBOARD], R"(^keyboard\.(mp3|ogg|aac)$)" },
-        { &m_song.music[TrackName::GUITAR_COOP], R"(^guitar_coop\.(mp3|ogg|aac)$)"},
-        { &m_song.music[TrackName::GUITAR_RHYTHM], R"(^guitar_rhythm\.(mp3|ogg|aac)$)"},
-        { &m_song.music[TrackName::LEAD_VOCAL], R"(^vocals\.(mp3|ogg|aac)$)" },
-        { &m_song.music[TrackName::BGMUSIC], R"(^song\.(mp3|ogg|aac)$)" },
-        { &m_song.music[TrackName::BGMUSIC], R"(\.(mp3|ogg|aac)$)" },
-    };
-    
-    std::string logMissing, logFound;
-    
-    // Run checks, remove bogus values and construct regexps
-    std::vector<boost::regex> regexps;
-    bool missing = false;
-    for (auto const& p: fields) {
-        fs::path& file = *p.first;
-        if (!file.empty() && !is_regular_file(file)) {
-            logMissing += "  " + file.filename().string();
-            file.clear();
-        }
-        if (file.empty()) missing = true;
-        regexps.emplace_back(p.second, boost::regex_constants::icase);
-    }
-    
-    if (!missing) return;  // All OK!
-    
-    // Try matching all files in song folder with any field
-    std::set<fs::path> files(fs::directory_iterator{m_song.path}, fs::directory_iterator{});
-    for (unsigned i = 0; i < fields.size(); ++i) {
-        fs::path& field = *fields[i].first;
-        if (field.empty()) for (fs::path const& f: files) {
-            std::string name = f.filename().string(); // File basename
-            if (!regex_search(name, regexps[i])) continue;  // No match for current file
-            field = f;
-            logFound += "  " + name;
-        }
-        files.erase(field);  // Remove from available options
-    }
-    
-    m_song.music[TrackName::PREVIEW].clear();  // We don't currently support preview tracks (TODO: proper handling in audio.cc).
-    
-    if (logFound.empty() && logMissing.empty()) return;
-    std::clog << "songparser/" << (logMissing.empty() ? "debug" : "notice") << ": " + m_song.filename.string() + ":\n";
-    if (!logMissing.empty()) std::clog << "  Not found:    " + logMissing + "\n";
-    if (!logFound.empty()) std::clog << "  Autodetected: " + logFound + "\n";
-    std::clog << std::flush;
-    
+	// List of fields containing filenames, and auto-matching regexps, in order of priority
+	const std::vector<std::pair<fs::path*, char const*>> fields = {
+		{ &m_song.cover, R"((cover|album|label|banner|bn|\[co\])\.(png|jpeg|jpg|svg)$)" },
+		{ &m_song.background, R"((background|bg|\[bg\])\.(png|jpeg|jpg|svg)$)" },
+		{ &m_song.cover, R"(\.(png|jpeg|jpg|svg)$)" },
+		{ &m_song.background, R"(\.(png|jpeg|jpg|svg)$)" },
+		{ &m_song.video, R"(\.(avi|mpg|mpeg|flv|mov|mp4|mkv|m4v)$)" },
+		{ &m_song.midifilename, R"(^notes\.mid$)" },
+		{ &m_song.midifilename, R"(\.mid$)" },
+		{ &m_song.music[TrackName::PREVIEW], R"(^preview\.(mp3|ogg|aac)$)" },
+		{ &m_song.music[TrackName::GUITAR], R"(^guitar\.(mp3|ogg|aac)$)" },
+		{ &m_song.music[TrackName::BASS], R"(^rhythm\.(mp3|ogg|aac)$)" },
+		{ &m_song.music[TrackName::DRUMS], R"(^drums\.(mp3|ogg|aac)$)" },
+		{ &m_song.music[TrackName::KEYBOARD], R"(^keyboard\.(mp3|ogg|aac)$)" },
+		{ &m_song.music[TrackName::GUITAR_COOP], R"(^guitar_coop\.(mp3|ogg|aac)$)"},
+		{ &m_song.music[TrackName::GUITAR_RHYTHM], R"(^guitar_rhythm\.(mp3|ogg|aac)$)"},
+		{ &m_song.music[TrackName::LEAD_VOCAL], R"(^vocals\.(mp3|ogg|aac)$)" },
+		{ &m_song.music[TrackName::BGMUSIC], R"(^song\.(mp3|ogg|aac)$)" },
+		{ &m_song.music[TrackName::BGMUSIC], R"(\.(mp3|ogg|aac)$)" },
+	};
+	
+	std::string logMissing, logFound;
+	
+	// Run checks, remove bogus values and construct regexps
+	std::vector<boost::regex> regexps;
+	bool missing = false;
+	for (auto const& p: fields) {
+		fs::path& file = *p.first;
+		if (!file.empty() && !is_regular_file(file)) {
+			logMissing += "  " + file.filename().string();
+			file.clear();
+		}
+		if (file.empty()) missing = true;
+		regexps.emplace_back(p.second, boost::regex_constants::icase);
+	}
+	
+	if (!missing) return;  // All OK!
+	
+	// Try matching all files in song folder with any field
+	std::set<fs::path> files(fs::directory_iterator{m_song.path}, fs::directory_iterator{});
+	for (unsigned i = 0; i < fields.size(); ++i) {
+		fs::path& field = *fields[i].first;
+		if (field.empty()) for (fs::path const& f: files) {
+			std::string name = f.filename().string(); // File basename
+			if (!regex_search(name, regexps[i])) continue;  // No match for current file
+			field = f;
+			logFound += "  " + name;
+		}
+		files.erase(field);  // Remove from available options
+	}
+	
+	m_song.music[TrackName::PREVIEW].clear();  // We don't currently support preview tracks (TODO: proper handling in audio.cc).
+	
+	if (logFound.empty() && logMissing.empty()) return;
+	std::clog << "songparser/" << (logMissing.empty() ? "debug" : "notice") << ": " + m_song.filename.string() + ":\n";
+	if (!logMissing.empty()) std::clog << "  Not found:	" + logMissing + "\n";
+	if (!logFound.empty()) std::clog << "  Autodetected: " + logFound + "\n";
+	std::clog << std::flush;
+	
 }
 
 void SongParser::resetNoteParsingState() {
-    m_prevtime = 0;
-    m_prevts = 0;
-    m_relativeShift = 0;
-    m_tsPerBeat = 0;
-    m_tsEnd = 0;
-    m_bpms.clear();
-    if (m_bpm != 0.0) addBPM(0, m_bpm);
+	m_prevtime = 0;
+	m_prevts = 0;
+	m_relativeShift = 0;
+	m_tsPerBeat = 0;
+	m_tsEnd = 0;
+	m_bpms.clear();
+	if (m_bpm != 0.0) addBPM(0, m_bpm);
 }
 
 void SongParser::vocalsTogether() {
-    auto togetherIt = m_song.vocalTracks.find("Together");
-    if (togetherIt == m_song.vocalTracks.end()) return;
-    Notes& together = togetherIt->second.notes;
-    if (!together.empty()) return;
-    Notes notes;
-    // Collect usable vocal tracks
-    struct TrackInfo {
-        typedef Notes::const_iterator It;
-        It it, end;
-        TrackInfo(It begin, It end): it(begin), end(end) {}
-    };
-    std::vector<TrackInfo> tracks;
-    for (auto& nt: m_song.vocalTracks) {
-        togetherIt->second.noteMin = std::min(togetherIt->second.noteMin, nt.second.noteMin);
-        togetherIt->second.noteMax = std::max(togetherIt->second.noteMax, nt.second.noteMax);
-        
-        Notes& n = nt.second.notes;
-        if (!n.empty()) tracks.push_back(TrackInfo(n.begin(), n.end()));
-    }
-    if (tracks.empty()) return;
-    // Combine notes
-    // FIXME: This should do combining on sentence level rather than note-by-note
-    TrackInfo* trk = &tracks.front();
-    while (trk) {
-        Note const& n = *trk->it;
-        //std::cerr << " " << n.syllable << ": " << n.begin << "-" << n.end << std::endl;
-        notes.push_back(n);
-        ++trk->it;
-        trk = nullptr;
-        // Iterate all tracks past the processed note and find the new earliest track
-        for (TrackInfo& trk2: tracks) {
-            // Skip until a sentence that begins after the note ended
-            while (trk2.it != trk2.end && trk2.it->begin < n.end) ++trk2.it;
-            if (trk2.it == trk2.end) continue;
-            if (!trk || trk2.it->begin < trk->it->begin) trk = &trk2;
-        }
-    }
-    together.swap(notes);
+	auto togetherIt = m_song.vocalTracks.find("Together");
+	if (togetherIt == m_song.vocalTracks.end()) return;
+	Notes& together = togetherIt->second.notes;
+	if (!together.empty()) return;
+	Notes notes;
+	// Collect usable vocal tracks
+	struct TrackInfo {
+		typedef Notes::const_iterator It;
+		It it, end;
+		TrackInfo(It begin, It end): it(begin), end(end) {}
+	};
+	std::vector<TrackInfo> tracks;
+	for (auto& nt: m_song.vocalTracks) {
+		togetherIt->second.noteMin = std::min(togetherIt->second.noteMin, nt.second.noteMin);
+		togetherIt->second.noteMax = std::max(togetherIt->second.noteMax, nt.second.noteMax);
+		
+		Notes& n = nt.second.notes;
+		if (!n.empty()) tracks.push_back(TrackInfo(n.begin(), n.end()));
+	}
+	if (tracks.empty()) return;
+	// Combine notes
+	// FIXME: This should do combining on sentence level rather than note-by-note
+	TrackInfo* trk = &tracks.front();
+	while (trk) {
+		Note const& n = *trk->it;
+		//std::cerr << " " << n.syllable << ": " << n.begin << "-" << n.end << std::endl;
+		notes.push_back(n);
+		++trk->it;
+		trk = nullptr;
+		// Iterate all tracks past the processed note and find the new earliest track
+		for (TrackInfo& trk2: tracks) {
+			// Skip until a sentence that begins after the note ended
+			while (trk2.it != trk2.end && trk2.it->begin < n.end) ++trk2.it;
+			if (trk2.it == trk2.end) continue;
+			if (!trk || trk2.it->begin < trk->it->begin) trk = &trk2;
+		}
+	}
+	together.swap(notes);
 }
 
 void SongParser::finalize() {
-    vocalsTogether();
-    for (auto& nt: m_song.vocalTracks) {
-        VocalTrack& vocal = nt.second;
-        // Remove empty sentences
-        {
-            Note::Type lastType = Note::NORMAL;
-            std::clog << "songparser/debug: In " << m_song.artist << " - " << m_song.title << std::endl;
-            for (auto itn = vocal.notes.begin(); itn != vocal.notes.end();) {
-                if (itn->type == Note::SLEEP) { itn->end = itn->begin; ++itn; continue; }
-                auto next = (itn +1);
-                
-                // Try to fix overlapping syllables.
-                if (next != vocal.notes.end() && Note::overlapping(*itn, *next)) {
-                    double beatDur = getBPM(itn->begin).step;
-                    double newEnd = (next->begin - beatDur);
-                    std::clog << "songparser/info: Trying to correct duration of overlapping notes (" << itn->syllable << " & " << next->syllable << ")..." << std::endl;
-                    std::clog << "songparser/info: Changing ending to: " << newEnd << ", will give a length of: " << (newEnd - (itn->begin)) << std::endl;
-                    if ((newEnd - itn->begin) >= beatDur) { itn->end = newEnd; }
-                    else if (next->type != Note::SLEEP) {
-                        std::clog << "songparser/info: Resulting note would be too short, will combine them instead." << std::endl;
-                        itn->syllable += std::string("-") += next->syllable;
-                        itn->end = next->end;
-                        vocal.notes.erase(next);
-                    }
-                    else { next->begin = next->end = itn->end; }
-                }
-                Note::Type type = itn->type;
-                if(type == Note::SLEEP && lastType == Note::SLEEP) {
-                    std::clog << "songparser/info: " + m_song.filename.string() + ": Discarding empty sentence" << std::endl;
-                    itn = vocal.notes.erase(itn);
-                } else { ++itn; }
-                lastType = type;
-            }
-        }
-        // Adjust negative notes
-        if (vocal.noteMin <= 0) {
-            unsigned int shift = (1 - vocal.noteMin / 12) * 12;
-            vocal.noteMin += shift;
-            vocal.noteMax += shift;
-            for (auto& elem: vocal.notes) {
-                elem.note += shift;
-                elem.notePrev += shift;
-            }
-        }
-        // Set begin/end times
-        if (!vocal.notes.empty()) vocal.beginTime = vocal.notes.front().begin, vocal.endTime = vocal.notes.back().end;
-        else vocal.beginTime = vocal.endTime = 0.0;
-        // Compute maximum score
-        double max_score = 0.0;
-        for (auto& note: vocal.notes) max_score += note.maxScore();
-        vocal.m_scoreFactor = 1.0 / max_score;
-    }
-    if (m_tsPerBeat) {
-        // Add song beat markers
-        for (unsigned ts = 0; ts < m_tsEnd; ts += m_tsPerBeat) m_song.beats.push_back(tsTime(ts));
-    }
+	vocalsTogether();
+	for (auto& nt: m_song.vocalTracks) {
+		VocalTrack& vocal = nt.second;
+		// Remove empty sentences
+		{
+			Note::Type lastType = Note::NORMAL;
+			std::clog << "songparser/debug: In " << m_song.artist << " - " << m_song.title << std::endl;
+			for (auto itn = vocal.notes.begin(); itn != vocal.notes.end();) {
+				if (itn->type == Note::SLEEP) { itn->end = itn->begin; ++itn; continue; }
+				auto next = (itn +1);
+				
+				// Try to fix overlapping syllables.
+				if (next != vocal.notes.end() && Note::overlapping(*itn, *next)) {
+					double beatDur = getBPM(itn->begin).step;
+					double newEnd = (next->begin - beatDur);
+					std::clog << "songparser/info: Trying to correct duration of overlapping notes (" << itn->syllable << " & " << next->syllable << ")..." << std::endl;
+					std::clog << "songparser/info: Changing ending to: " << newEnd << ", will give a length of: " << (newEnd - (itn->begin)) << std::endl;
+					if ((newEnd - itn->begin) >= beatDur) { itn->end = newEnd; }
+					else if (next->type != Note::SLEEP) {
+						std::clog << "songparser/info: Resulting note would be too short, will combine them instead." << std::endl;
+						itn->syllable += std::string("-") += next->syllable;
+						itn->end = next->end;
+						vocal.notes.erase(next);
+					}
+					else { next->begin = next->end = itn->end; }
+				}
+				Note::Type type = itn->type;
+				if(type == Note::SLEEP && lastType == Note::SLEEP) {
+					std::clog << "songparser/info: " + m_song.filename.string() + ": Discarding empty sentence" << std::endl;
+					itn = vocal.notes.erase(itn);
+				} else { ++itn; }
+				lastType = type;
+			}
+		}
+		// Adjust negative notes
+		if (vocal.noteMin <= 0) {
+			unsigned int shift = (1 - vocal.noteMin / 12) * 12;
+			vocal.noteMin += shift;
+			vocal.noteMax += shift;
+			for (auto& elem: vocal.notes) {
+				elem.note += shift;
+				elem.notePrev += shift;
+			}
+		}
+		// Set begin/end times
+		if (!vocal.notes.empty()) vocal.beginTime = vocal.notes.front().begin, vocal.endTime = vocal.notes.back().end;
+		else vocal.beginTime = vocal.endTime = 0.0;
+		// Compute maximum score
+		double max_score = 0.0;
+		for (auto& note: vocal.notes) max_score += note.maxScore();
+		vocal.m_scoreFactor = 1.0 / max_score;
+	}
+	if (m_tsPerBeat) {
+		// Add song beat markers
+		for (unsigned ts = 0; ts < m_tsEnd; ts += m_tsPerBeat) m_song.beats.push_back(tsTime(ts));
+	}
 }

--- a/game/songparser.hh
+++ b/game/songparser.hh
@@ -8,18 +8,18 @@
 #include <boost/filesystem.hpp>
 
 namespace SongParserUtil {
-    const std::string DUET_P2 = "Duet singer"; // FIXME
-    const std::string DUET_BOTH = "Both singers"; // FIXME
-    /// Parse an int from string and assign it to a variable
-    void assign(int& var, std::string const& str);
-    /// Parse an unsigned int from string and assign it to a variable
-    void assign(unsigned& var, std::string const& str);
-    /// Parse a double from string and assign it to a variable
-    void assign(double& var, std::string str);
-    /// Parse a boolean from string and assign it to a variable
-    void assign(bool& var, std::string const& str);
-    /// Erase last character if it matches
-    void eraseLast(std::string& s, char ch = ' ');
+	const std::string DUET_P2 = "Duet singer"; // FIXME
+	const std::string DUET_BOTH = "Both singers"; // FIXME
+	/// Parse an int from string and assign it to a variable
+	void assign(int& var, std::string const& str);
+	/// Parse an unsigned int from string and assign it to a variable
+	void assign(unsigned& var, std::string const& str);
+	/// Parse a double from string and assign it to a variable
+	void assign(double& var, std::string str);
+	/// Parse a boolean from string and assign it to a variable
+	void assign(bool& var, std::string const& str);
+	/// Erase last character if it matches
+	void eraseLast(std::string& s, char ch = ' ');
 }
 
 /// parses songfiles

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -187,7 +187,7 @@ namespace {
 		CmpByField(Field Song::* field): m_field(field) {}
 		/// Compare left < right
 		bool operator()(Song const& left , Song const& right) {
-		    return left.*m_field < right.*m_field;
+			return left.*m_field < right.*m_field;
 		}
 		/// Compare *left < *right
 		bool operator()(boost::shared_ptr<Song> const& left, boost::shared_ptr<Song> const& right) {

--- a/game/surface.hh
+++ b/game/surface.hh
@@ -95,10 +95,10 @@ class Dimensions {
 
 /// texture coordinates
 struct TexCoords {
-	float x1, ///< left
-	      y1, ///< top
-	      x2, ///< right
-	      y2; ///< bottom
+	float x1; ///< left
+	float y1; ///< top
+	float x2; ///< right
+	float y2; ///< bottom
 	/// constructor
 	TexCoords(float x1_ = 0.0, float y1_ = 0.0, float x2_ = 1.0, float y2_ = 1.0):
 	  x1(x1_), y1(y1_), x2(x2_), y2(y2_) {}

--- a/game/unicode.cc
+++ b/game/unicode.cc
@@ -12,70 +12,70 @@ UErrorCode UnicodeUtil::m_icuError = U_ZERO_ERROR;
 icu::RuleBasedCollator UnicodeUtil::m_dummyCollator(icu::UnicodeString(""), icu::Collator::PRIMARY, m_icuError);
 
 MatchResult UnicodeUtil::getCharset (std::string const& str) {
-    MatchResult retval;
-    LocalUCharsetDetectorPointer m_chardet(ucsdet_open(&UnicodeUtil::m_icuError));
-    ucsdet_enableInputFilter(m_chardet.getAlias(), true); 
-    auto string = str.c_str();
-    ucsdet_setText(m_chardet.getAlias(), string, -1, &m_icuError);
-    if (U_FAILURE(UnicodeUtil::m_icuError)) {
-        std::string err = std::string("unicode/error: Couldn't pass text to CharsetDetector: ");
-        err += u_errorName(m_icuError);
-        throw std::runtime_error(err);
-    }
-    else {
-        const UCharsetMatch* match = ucsdet_detect(m_chardet.getAlias(), &m_icuError);
-        return std::pair<std::string,int>(ucsdet_getName(match, &m_icuError), ucsdet_getConfidence(match, &m_icuError));
-    }
+	MatchResult retval;
+	LocalUCharsetDetectorPointer m_chardet(ucsdet_open(&UnicodeUtil::m_icuError));
+	ucsdet_enableInputFilter(m_chardet.getAlias(), true); 
+	auto string = str.c_str();
+	ucsdet_setText(m_chardet.getAlias(), string, -1, &m_icuError);
+	if (U_FAILURE(UnicodeUtil::m_icuError)) {
+		std::string err = std::string("unicode/error: Couldn't pass text to CharsetDetector: ");
+		err += u_errorName(m_icuError);
+		throw std::runtime_error(err);
+	}
+	else {
+		const UCharsetMatch* match = ucsdet_detect(m_chardet.getAlias(), &m_icuError);
+		return std::pair<std::string,int>(ucsdet_getName(match, &m_icuError), ucsdet_getConfidence(match, &m_icuError));
+	}
 }
 
 void convertToUTF8(std::stringstream &_stream, std::string _filename) {
-    std::string data = _stream.str();
-    MatchResult match;
-    if (!_filename.empty()) {
-        match = UnicodeUtil::getCharset(data);
-    }
-    else {
-        match = std::pair<std::string,int>("UTF-8",100); // If there's no filename, assume it's internal text and thus utf-8.
-    }
-    icu::UnicodeString ustring;
+	std::string data = _stream.str();
+	MatchResult match;
+	if (!_filename.empty()) {
+		match = UnicodeUtil::getCharset(data);
+	}
+	else {
+		match = std::pair<std::string,int>("UTF-8",100); // If there's no filename, assume it's internal text and thus utf-8.
+	}
+	icu::UnicodeString ustring;
 	// Test for UTF-8 BOM (a three-byte sequence at the beginning of a file)
-    if (data.substr(0, 3) == "\xEF\xBB\xBF") {
-        match.first = "UTF-8";
-        match.second = 100;
-        _stream.str(data.substr(3)); // Remove BOM if there is one
-    }
-    if (match.second > 10 && match.second < 50) { // 50 is a really good match, 10 means an encoding that could be conceivably used to display the text.
-        if (match.first == "ISO-8859-1" || match.first == "ISO-8859-2") {
-            match.first = "UTF-8";
-            match.second = 75;	// Mostly western characters. Let's treat it as a UTF-8 false-negative.
-        }
-    }
-    if (match.second >= 50) { // fairly good match?
-        std::string charset = match.first;
-        if (charset != "UTF-8") {
-            if (!_filename.empty()) { std::clog << "unicode/warning: " << _filename << " does not appear to be UTF-8... (" << charset << ") detected." << std::endl; }
-            std::string _str;
-            const char* tmp = data.c_str();
-            icu::UnicodeString ustring = icu::UnicodeString(tmp, charset.c_str());
-            _stream.str(ustring.toUTF8String(_str));
-        }
-    }
+	if (data.substr(0, 3) == "\xEF\xBB\xBF") {
+		match.first = "UTF-8";
+		match.second = 100;
+		_stream.str(data.substr(3)); // Remove BOM if there is one
+	}
+	if (match.second > 10 && match.second < 50) { // 50 is a really good match, 10 means an encoding that could be conceivably used to display the text.
+		if (match.first == "ISO-8859-1" || match.first == "ISO-8859-2") {
+			match.first = "UTF-8";
+			match.second = 75;	// Mostly western characters. Let's treat it as a UTF-8 false-negative.
+		}
+	}
+	if (match.second >= 50) { // fairly good match?
+		std::string charset = match.first;
+		if (charset != "UTF-8") {
+			if (!_filename.empty()) { std::clog << "unicode/warning: " << _filename << " does not appear to be UTF-8... (" << charset << ") detected." << std::endl; }
+			std::string _str;
+			const char* tmp = data.c_str();
+			icu::UnicodeString ustring = icu::UnicodeString(tmp, charset.c_str());
+			_stream.str(ustring.toUTF8String(_str));
+		}
+	}
 }
 
 std::string convertToUTF8(std::string const& str) {
-    std::stringstream ss(str);
-    convertToUTF8(ss, std::string());
-    return ss.str();
+	std::stringstream ss(str);
+	convertToUTF8(ss, std::string());
+	return ss.str();
 }
 
 std::string unicodeCollate(std::string const& str) {
-    ConfigItem::StringList termsToCollate = config["game/sorting_ignore"].sl();
-    std::string pattern = std::string("^((");
-    for (auto term: termsToCollate) {
-        if (term != termsToCollate.front()) { pattern += std::string("|"); }
-        pattern += term;
-        if (term == termsToCollate.back()) { pattern += std::string(")\\s(.+))$"); }
-    }	
-    std::string collated = std::regex_replace(convertToUTF8(str), std::regex(pattern, std::regex_constants::icase), "\\3 \\2");
-    return collated;
+	ConfigItem::StringList termsToCollate = config["game/sorting_ignore"].sl();
+	std::string pattern = std::string("^((");
+	for (auto term: termsToCollate) {
+		if (term != termsToCollate.front()) { pattern += std::string("|"); }
+		pattern += term;
+		if (term == termsToCollate.back()) { pattern += std::string(")\\s(.+))$"); }
+	}	
+	std::string collated = std::regex_replace(convertToUTF8(str), std::regex(pattern, std::regex_constants::icase), "\\3 \\2");
+	return collated;
 }

--- a/game/unicode.hh
+++ b/game/unicode.hh
@@ -14,14 +14,11 @@ std::string unicodeCollate(std::string const& str);
 typedef std::pair<std::string, int> MatchResult;
 
 struct UnicodeUtil {
-    
-    UnicodeUtil() {};
-    ~UnicodeUtil() {};
-    friend class Songs;
-    
-    static MatchResult getCharset(std::string const& str);
-    
-private:
-    static UErrorCode m_icuError;
-    static icu::RuleBasedCollator m_dummyCollator;
+	UnicodeUtil() {};
+	~UnicodeUtil() {};
+	friend class Songs;
+	static MatchResult getCharset(std::string const& str);
+  private:
+	static UErrorCode m_icuError;
+	static icu::RuleBasedCollator m_dummyCollator;
 };

--- a/game/webserver.cc
+++ b/game/webserver.cc
@@ -184,9 +184,8 @@ http_server::response WebServer::GETresponse(const http_server::request &request
 			boost::to_lower(key);
 			jsonRoot[key] = kv.second;
 		}
-        return http_server::response::stock_reply(http_server::response::ok, jsonRoot.toStyledString());
-}
-	else {
+		return http_server::response::stock_reply(http_server::response::ok, jsonRoot.toStyledString());
+	} else {
 		//other text files
 		try {
 			std::string destination = request.destination;
@@ -295,56 +294,55 @@ http_server::response WebServer::POSTresponse(const http_server::request &reques
 
 std::map<std::string, std::string> WebServer::GenerateLocaleDict() {
 	std::vector<std::string> translationKeys = GetTranslationKeys();
-    
-    std::map<std::string, std::string> localeMap;
-    for (auto const &translationKey : translationKeys) {
+	std::map<std::string, std::string> localeMap;
+	for (auto const &translationKey : translationKeys) {
 		localeMap[translationKey] = _(translationKey);
 	}
-    return localeMap;
+	return localeMap;
 }
 
 std::vector<std::string> WebServer::GetTranslationKeys() {
 	std::vector<std::string> tranlationKeys = { 
 		translate_noop("Performous web frontend"),
-	    translate_noop("View database"),
-	    translate_noop("View playlist"),
-	    translate_noop("Search and Add"),
-	    translate_noop("Sort by"),
-	    translate_noop("Artist"),
-	    translate_noop("Title"),
-	    translate_noop("Language"),
-	    translate_noop("Edition"),
-	    translate_noop("Creator"),
-	    translate_noop("Sort order"),
-	    translate_noop("Normal"),
-	    translate_noop("Inverted"),
-	    translate_noop("Update every 10 sec"),
-	    translate_noop("Refresh database"),
-	    translate_noop("Upcoming songs"),
-	    translate_noop("Refresh playlist"),
-	    translate_noop("Web interface by Niek Nooijens and Arjan Speiard, for full credits regarding Performous see /docs/Authors.txt"),
-	    translate_noop("Search"),
-	    translate_noop("Available songs"),
-	    translate_noop("Search for songs"),
-	    translate_noop("Yes"),
-	    translate_noop("No"),
-	    translate_noop("Move up"),
-	    translate_noop("Move down"),
-	    translate_noop("Set position"),
-	    translate_noop("Remove song"),
-	    translate_noop("Desired position of song"),
-	    translate_noop("Cancel"),
-	    translate_noop("Successfully removed song from playlist"),
-	    translate_noop("Failed removing song from playlist"),
-	    translate_noop("Successfully changed position of song"),
-	    translate_noop("Failed changing position of song"),
-	    translate_noop("Successfully moved song up"),
-	    translate_noop("Failed moving song up"),
-	    translate_noop("Successfully moved song down"),
-	    translate_noop("Failed moving song down"),
-	    translate_noop("Successfully added song to the playlist"),
-	    translate_noop("Failed adding song to the playlist"),
-	    translate_noop("No songs found with current filter")
+		translate_noop("View database"),
+		translate_noop("View playlist"),
+		translate_noop("Search and Add"),
+		translate_noop("Sort by"),
+		translate_noop("Artist"),
+		translate_noop("Title"),
+		translate_noop("Language"),
+		translate_noop("Edition"),
+		translate_noop("Creator"),
+		translate_noop("Sort order"),
+		translate_noop("Normal"),
+		translate_noop("Inverted"),
+		translate_noop("Update every 10 sec"),
+		translate_noop("Refresh database"),
+		translate_noop("Upcoming songs"),
+		translate_noop("Refresh playlist"),
+		translate_noop("Web interface by Niek Nooijens and Arjan Speiard, for full credits regarding Performous see /docs/Authors.txt"),
+		translate_noop("Search"),
+		translate_noop("Available songs"),
+		translate_noop("Search for songs"),
+		translate_noop("Yes"),
+		translate_noop("No"),
+		translate_noop("Move up"),
+		translate_noop("Move down"),
+		translate_noop("Set position"),
+		translate_noop("Remove song"),
+		translate_noop("Desired position of song"),
+		translate_noop("Cancel"),
+		translate_noop("Successfully removed song from playlist"),
+		translate_noop("Failed removing song from playlist"),
+		translate_noop("Successfully changed position of song"),
+		translate_noop("Failed changing position of song"),
+		translate_noop("Successfully moved song up"),
+		translate_noop("Failed moving song up"),
+		translate_noop("Successfully moved song down"),
+		translate_noop("Failed moving song down"),
+		translate_noop("Successfully added song to the playlist"),
+		translate_noop("Failed adding song to the playlist"),
+		translate_noop("No songs found with current filter")
 	};
 
 	return tranlationKeys;


### PR DESCRIPTION
Includes minor reformatting to comply with Performous coding style.
The removal of indentation in audio.cc initlist is ugly but intentional.

Made by hand from current master (rather than issue/indentation) because it was easier without auto-indent invoked on the other branch. Additionally, in another branch there was a commit changing all comments into Doxygen style. Only comments that document functions or classes in Doxygen syntax should use /// or /**...
