### PR TITLE
Changed throw error to log line.

### DIFF
--- a/game/songparser-txt.cc
+++ b/game/songparser-txt.cc
@@ -168,7 +168,7 @@ bool SongParser::txtParseNote(std::string line) {
 		{
 			unsigned int length = 0;
 			if (!(iss >> ts >> length >> n.note)) throw std::runtime_error("Invalid note line format");
-			if (length < 1) throw std::runtime_error("Notes must have positive durations.");
+			if (length < 1) std::clog << "songparser/info: Notes must have positive durations." << std::endl;
 			n.notePrev = n.note; // No slide notes in TXT yet.
 			if (m_relative) ts += m_txt.relativeShift;
 			if (iss.get() == ' ') std::getline(iss, n.syllable);


### PR DESCRIPTION
# Issues

Closes #351 

# Changes
Instead of throwing an error we casually let this specific check slide through, as the same happens in USDX. The notes with length of 0 are displayed on screen as 'overlapping notes'.  

The song is still playable even though the length is 0