### PR TITLE
Replace all volatile variables with std::atomic

### DIFF
--- a/game/audio.cc
+++ b/game/audio.cc
@@ -77,7 +77,7 @@ class AudioClock {
 	Time m_baseTime; ///< A reference time (corresponds to m_basePos)
 	Seconds m_basePos = 0.0s; ///< A reference position in song
 	double m_skew = 0.0; ///< The skew ratio applied to system time (since baseTime)
-	std::atomic<Seconds> m_max; ///< Maximum output value for the clock (end of the current audio block)
+	std::atomic<Seconds> m_max{ 0.0s }; ///< Maximum output value for the clock (end of the current audio block)
 	/// Get the current position (current time via parameter, no locking)
 	Seconds pos_internal(Time now) const {
 		Seconds t = m_basePos + (1.0 + m_skew) * (now - m_baseTime);
@@ -312,7 +312,7 @@ struct Output {
 	std::vector<Analyzer*> mics;  // Used for audio pass-through
 	std::unordered_map<std::string, std::unique_ptr<Sample>> samples;
 	std::vector<Command> commands;
-	std::atomic<bool> paused;
+	std::atomic<bool> paused{ false };
 	Output(): paused(false) {}
 
 	void callbackUpdate() {

--- a/game/audio.cc
+++ b/game/audio.cc
@@ -312,7 +312,7 @@ struct Output {
 	std::vector<Analyzer*> mics;  // Used for audio pass-through
 	std::unordered_map<std::string, std::unique_ptr<Sample>> samples;
 	std::vector<Command> commands;
-	volatile bool paused;
+	std::atomic<bool> paused;
 	Output(): paused(false) {}
 
 	void callbackUpdate() {

--- a/game/backgrounds.hh
+++ b/game/backgrounds.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "fs.hh"
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -10,8 +11,7 @@
 class Backgrounds: boost::noncopyable {
   public:
 	/// constructor
-	Backgrounds(): m_bgiter(0), m_dirty(false), m_loading(false)
-	{
+	Backgrounds() {
 		reload();
 	}
 	~Backgrounds() {
@@ -32,11 +32,11 @@ class Backgrounds: boost::noncopyable {
   private:
 	typedef std::vector<std::string> BGVector;
 	BGVector m_bgs;
-	int m_bgiter;
+	int m_bgiter = 0;
 	void reload_internal();
 	void reload_internal(fs::path const& p);
-	std::atomic<bool> m_dirty;
-	std::atomic<bool> m_loading;
+	std::atomic<bool> m_dirty{ false };
+	std::atomic<bool> m_loading{ false };
 	std::unique_ptr<std::thread> m_thread;
 	mutable std::mutex m_mutex;
 };

--- a/game/backgrounds.hh
+++ b/game/backgrounds.hh
@@ -35,8 +35,8 @@ class Backgrounds: boost::noncopyable {
 	int m_bgiter;
 	void reload_internal();
 	void reload_internal(fs::path const& p);
-	volatile bool m_dirty;
-	volatile bool m_loading;
+	std::atomic<bool> m_dirty;
+	std::atomic<bool> m_loading;
 	std::unique_ptr<std::thread> m_thread;
 	mutable std::mutex m_mutex;
 };

--- a/game/engine.hh
+++ b/game/engine.hh
@@ -12,7 +12,7 @@ class VocalTrack;
 class Engine {
 	Audio& m_audio;
 	double m_time;
-	volatile bool m_quit;
+	std::atomic<bool> m_quit;
 	Database& m_database;
 	std::unique_ptr<std::thread> m_thread;
 

--- a/game/engine.hh
+++ b/game/engine.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <thread>
 #include <vector>
@@ -12,7 +13,7 @@ class VocalTrack;
 class Engine {
 	Audio& m_audio;
 	double m_time;
-	std::atomic<bool> m_quit;
+	std::atomic<bool> m_quit{ false };
 	Database& m_database;
 	std::unique_ptr<std::thread> m_thread;
 

--- a/game/ffmpeg.cc
+++ b/game/ffmpeg.cc
@@ -47,10 +47,8 @@ namespace {
 
 
 FFmpeg::FFmpeg(fs::path const& _filename, unsigned int rate):
-  width(), height(), m_filename(_filename), m_rate(rate), m_quit(),
-  m_seekTarget(getNaN()), m_position(), m_duration(), m_streamId(-1),
+  m_filename(_filename), m_rate(rate),
   m_mediaType(rate ? AVMEDIA_TYPE_AUDIO : AVMEDIA_TYPE_VIDEO),
-  m_formatContext(), m_codecContext(), m_resampleContext(), m_swsContext(),
   m_thread(std::make_unique<std::thread>(std::ref(*this)))
 {
 	static bool versionChecked = false;

--- a/game/ffmpeg.hh
+++ b/game/ffmpeg.hh
@@ -152,7 +152,7 @@ class AudioBuffer {
 	int64_t m_posReq = 0;
 	unsigned m_sps = 0;
 	double m_duration = getNaN();
-	std::atomic<bool> m_quit;
+	std::atomic<bool> m_quit{ false };
 };
 
 // ffmpeg forward declarations
@@ -171,8 +171,8 @@ class FFmpeg {
 	FFmpeg(fs::path const& file, unsigned int rate = 0);
 	~FFmpeg();
 	void operator()(); ///< Thread runs here, don't call directly
-	unsigned width; ///< width of video
-	unsigned height; ///< height of video
+	unsigned width = 0; ///< width of video
+	unsigned height = 0; ///< height of video
 	/// queue for video
 	VideoFifo  videoQueue;
 	/// queue for audio
@@ -191,18 +191,18 @@ class FFmpeg {
 	void processVideo(AVFrame* frame);
 	void processAudio(AVFrame* frame);
 	fs::path m_filename;
-	unsigned int m_rate;
-	std::atomic<bool> m_quit;
-	std::atomic<double> m_seekTarget;
-	double m_position;
-	double m_duration;
+	unsigned int m_rate = 0;
+	std::atomic<bool> m_quit{ false };
+	std::atomic<double> m_seekTarget{ getNaN() };
+	double m_position = 0.0;
+	double m_duration = 0.0;
 	// libav-specific variables
-	int m_streamId;
+	int m_streamId = -1;
 	int m_mediaType;  // enum AVMediaType
-	AVFormatContext* m_formatContext;
-	AVCodecContext* m_codecContext;
-	AVAudioResampleContext* m_resampleContext;
-	SwsContext* m_swsContext;
+	AVFormatContext* m_formatContext = nullptr;
+	AVCodecContext* m_codecContext = nullptr;
+	AVAudioResampleContext* m_resampleContext = nullptr;
+	SwsContext* m_swsContext = nullptr;
 	// Make sure the thread starts only after initializing everything else
 	std::unique_ptr<std::thread> m_thread;
 	static std::mutex s_avcodec_mutex; // Used for avcodec_open/close (which use some static crap and are thus not thread-safe)

--- a/game/ffmpeg.hh
+++ b/game/ffmpeg.hh
@@ -192,8 +192,8 @@ class FFmpeg {
 	void processAudio(AVFrame* frame);
 	fs::path m_filename;
 	unsigned int m_rate;
-	volatile bool m_quit;
-	volatile double m_seekTarget;
+	std::atomic<bool> m_quit;
+	std::atomic<double> m_seekTarget;
 	double m_position;
 	double m_duration;
 	// libav-specific variables

--- a/game/main.cc
+++ b/game/main.cc
@@ -46,7 +46,7 @@ namespace { struct Nothing { char const* what() const { return NULL; } }; }
 #define EXCEPTION Nothing
 #endif
 
-volatile bool g_quit = false;
+std::atomic<bool> g_quit = false;
 
 bool g_take_screenshot = false;
 

--- a/game/main.cc
+++ b/game/main.cc
@@ -46,7 +46,7 @@ namespace { struct Nothing { char const* what() const { return NULL; } }; }
 #define EXCEPTION Nothing
 #endif
 
-std::atomic<bool> g_quit = false;
+std::atomic<bool> g_quit{ false };
 
 bool g_take_screenshot = false;
 

--- a/game/pitch.hh
+++ b/game/pitch.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <complex>
 #include <vector>
 #include <list>
@@ -63,7 +64,9 @@ public:
 private:
 	static unsigned modulo(unsigned idx) { return (SIZE + idx) % SIZE; }  ///< Modulo operation with proper rounding (handles slightly "negative" idx as well)
 	float m_buf[SIZE];
-	std::atomic<unsigned> m_read, m_write;  ///< The indices of the next read/write operations. read == write implies that buffer is empty.
+	// The indices of the next read/write operations. read == write implies that buffer is empty.
+	std::atomic<unsigned> m_read{ 0 };
+	std::atomic<unsigned> m_write{ 0 };
 };
 
 /// analyzer class

--- a/game/pitch.hh
+++ b/game/pitch.hh
@@ -63,7 +63,7 @@ public:
 private:
 	static unsigned modulo(unsigned idx) { return (SIZE + idx) % SIZE; }  ///< Modulo operation with proper rounding (handles slightly "negative" idx as well)
 	float m_buf[SIZE];
-	volatile size_t m_read, m_write;  ///< The indices of the next read/write operations. read == write implies that buffer is empty.
+	std::atomic<unsigned> m_read, m_write;  ///< The indices of the next read/write operations. read == write implies that buffer is empty.
 };
 
 /// analyzer class

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -19,7 +19,7 @@
 #include <regex>
 #include <unicode/stsearch.h>
 
-Songs::Songs(Database & database, std::string const& songlist): m_songlist(songlist), math_cover(), m_database(database), m_type(), m_order(config["songs/sort-order"].i()), m_dirty(false), m_loading(false) {
+Songs::Songs(Database & database, std::string const& songlist): m_songlist(songlist), m_database(database), m_order(config["songs/sort-order"].i()) {
 	if (U_FAILURE(UnicodeUtil::m_icuError)) std::clog << "songs/error: Error creating Unicode collator: " << u_errorName(UnicodeUtil::m_icuError) << std::endl;
 	m_updateTimer.setTarget(getInf()); // Using this as a simple timer counting seconds
 	reload();

--- a/game/songs.hh
+++ b/game/songs.hh
@@ -2,6 +2,7 @@
 
 #include "animvalue.hh"
 #include "fs.hh"
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <set>
@@ -69,8 +70,8 @@ class Songs: boost::noncopyable {
 	void sortSpecificChange(int sortOrder, bool descending = false);
 	/// parses file into Song &tmp
 	void parseFile(Song& tmp);
-	std::atomic<bool> doneLoading = false;
-	std::atomic<bool> displayedAlert = false;
+	std::atomic<bool> doneLoading{ false };
+	std::atomic<bool> displayedAlert{ false };
 	size_t loadedSongs() const { return m_songs.size(); }
 
   private:
@@ -82,15 +83,16 @@ class Songs: boost::noncopyable {
 	AnimAcceleration math_cover;
 	std::string m_filter;
 	Database & m_database;
-	int m_type, m_order;
+	int m_type = 0;
+	int m_order;  // Set by constructor
 	void dumpSongs_internal() const;
 	void reload_internal();
 	void reload_internal(fs::path const& p);
 	void randomize_internal();
 	void filter_internal();
 	void sort_internal(bool descending = false);
-	std::atomic<bool> m_dirty;
-	std::atomic<bool> m_loading;
+	std::atomic<bool> m_dirty{ false };
+	std::atomic<bool> m_loading{ false };
 	std::unique_ptr<std::thread> m_thread;
 	mutable std::mutex m_mutex;
 };

--- a/game/songs.hh
+++ b/game/songs.hh
@@ -69,8 +69,8 @@ class Songs: boost::noncopyable {
 	void sortSpecificChange(int sortOrder, bool descending = false);
 	/// parses file into Song &tmp
 	void parseFile(Song& tmp);
-	volatile bool doneLoading = false;
-	volatile bool displayedAlert = false;
+	std::atomic<bool> doneLoading = false;
+	std::atomic<bool> displayedAlert = false;
 	size_t loadedSongs() const { return m_songs.size(); }
 
   private:
@@ -89,8 +89,8 @@ class Songs: boost::noncopyable {
 	void randomize_internal();
 	void filter_internal();
 	void sort_internal(bool descending = false);
-	volatile bool m_dirty;
-	volatile bool m_loading;
+	std::atomic<bool> m_dirty;
+	std::atomic<bool> m_loading;
 	std::unique_ptr<std::thread> m_thread;
 	mutable std::mutex m_mutex;
 };

--- a/game/surface.cc
+++ b/game/surface.cc
@@ -51,7 +51,7 @@ class SurfaceLoader::Impl {
 			std::clog << "image/error: " << e.what() << std::endl;
 		}
 	}
-	volatile bool m_quit;
+	std::atomic<bool> m_quit;
 	std::mutex m_mutex;
 	std::condition_variable m_condition;
 	typedef std::map<void const*, Job> Jobs;

--- a/game/surface.cc
+++ b/game/surface.cc
@@ -6,6 +6,7 @@
 #include "svg.hh"
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/filesystem.hpp>
+#include <atomic>
 #include <cctype>
 #include <condition_variable>
 #include <stdexcept>
@@ -51,7 +52,7 @@ class SurfaceLoader::Impl {
 			std::clog << "image/error: " << e.what() << std::endl;
 		}
 	}
-	std::atomic<bool> m_quit;
+	std::atomic<bool> m_quit{ false };
 	std::mutex m_mutex;
 	std::condition_variable m_condition;
 	typedef std::map<void const*, Job> Jobs;

--- a/game/webcam.cc
+++ b/game/webcam.cc
@@ -18,8 +18,8 @@ namespace cv {
 #endif
 
 Webcam::Webcam(int cam_id):
-  m_thread(), m_capture(), m_writer(), m_frameAvailable(false), m_running(false), m_quit(false)
-  {
+  m_thread(), m_capture(), m_writer(), m_frameAvailable(false)
+{
 	#ifdef USE_OPENCV
 	// Initialize the capture device
 	m_capture.reset(new cv::VideoCapture(cam_id));

--- a/game/webcam.hh
+++ b/game/webcam.hh
@@ -45,8 +45,8 @@ class Webcam {
 	CamFrame m_frame;
 	Surface m_surface;
 	bool m_frameAvailable;
-	volatile bool m_running;
-	volatile bool m_quit;
+	std::atomic<bool> m_running;
+	std::atomic<bool> m_quit;
 
   public:
 	static bool enabled() {

--- a/game/webcam.hh
+++ b/game/webcam.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "surface.hh"
+#include <atomic>
 #include <mutex>
 #include <thread>
 #include <vector>
@@ -12,8 +13,8 @@ namespace cv {
 }
 
 struct CamFrame {
-	int width;
-	int height;
+	int width = 0;
+	int height = 0;
 	std::vector<boost::uint8_t> data;
 };
 
@@ -21,7 +22,6 @@ class Webcam {
   public:
 	/// cam_id -1 means pick any device
 	Webcam(int cam_id = -1);
-
 	~Webcam();
 
 	/// Thread runs here, don't call directly
@@ -45,8 +45,8 @@ class Webcam {
 	CamFrame m_frame;
 	Surface m_surface;
 	bool m_frameAvailable;
-	std::atomic<bool> m_running;
-	std::atomic<bool> m_quit;
+	std::atomic<bool> m_running{ false };
+	std::atomic<bool> m_quit{ false };
 
   public:
 	static bool enabled() {


### PR DESCRIPTION
# Changes
Replace all volatile variables with std::atomic, as one is supposed t…o do for standards-compliance when threaded access is involved.