### PR TITLE
Improved warning message and handling of non-stereo3d-capable GPUs.

### DIFF
--- a/game/video_driver.cc
+++ b/game/video_driver.cc
@@ -180,10 +180,15 @@ void Window::render(boost::function<void (void)> drawFunc) {
 	bool stereo = config["graphic/stereo3d"].b();
 	int type = config["graphic/stereo3dtype"].i();
 
+	static bool warn3d = false;
+	if (!stereo) warn3d = false;
 	if (stereo && !epoxy_has_gl_extension("GL_ARB_viewport_array")) {
-		config["graphic/stereo3d"].b() = stereo = false;
-		std::clog << "video/warning: Your GPU does not support Stereo3D mode (OpenGL extension ARB_viewport_array is required)" << std::endl;
-		// TODO: Flash message on UI?
+		stereo = false;
+		if (!warn3d) {
+			warn3d = true;
+			std::clog << "video/warning: Your GPU does not support Stereo3D mode (OpenGL extension ARB_viewport_array is required)" << std::endl;
+			Game::getSingletonPtr()->flashMessage("Your GPU does not support Stereo3D mode");
+		}
 	}
 
 	// Over/under only available in fullscreen


### PR DESCRIPTION
Doesn't force the config setting anymore but instead displays a flash message whenever the config option is enabled on a system that doesn't support it.