### PR TITLE
Fix pause menu for instruments: no more duplicate players

### DIFF
--- a/game/controllers.cc
+++ b/game/controllers.cc
@@ -267,10 +267,6 @@ struct Controllers::Impl {
 	void enableEvents(bool state) {
 		m_eventsEnabled = state;
 		Hardware::enableKeyboardInstruments(state);
-		if (!state) {
-			m_orphans.clear();
-			m_devices.clear();
-		}
 	}
 	/// Do internal event processing (poll for MIDI events etc)
 	void process(Time now) {
@@ -377,7 +373,7 @@ struct Controllers::Impl {
 			// Emit Event and construct a new Device first if needed
 			DevicePtr ptr = m_devices[ev.source].lock();
 			if (!ptr) {
-				ptr = std::make_unique<Device>(ev.source, ev.devType);
+				ptr = std::make_shared<Device>(ev.source, ev.devType);
 				m_orphans[ev.source] = ptr;
 				m_devices[ev.source] = ptr;
 			}


### PR DESCRIPTION
This seems to fix the problem of instruments and dance players rejoining after pause menu is used. To reproduce:

1. Start guitar/drums/dance song
2. Join the game and wait until the song starts, then hit Esc
3. On the menu, choose Continue

Expected result: gameplay continues
Actual result: another player joins and the old one stays inactive; the controller controls the new one

This has been broken for years. This little change (not clearing existing devices/orphans) seems to fix it but more testing is needed to determine if that change also breaks something.
