### PR TITLE
Capture stderr output into logger system

### DIFF
--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -62,7 +62,7 @@ set(SOURCES ${SOURCE_FILES} ${HEADER_FILES} ${RESOURCE_FILES})
 
 # Libraries
 
-find_package(Boost 1.36 REQUIRED COMPONENTS program_options filesystem system locale)
+find_package(Boost 1.36 REQUIRED COMPONENTS program_options filesystem iostreams system locale)
 include_directories(${Boost_INCLUDE_DIRS})
 list(APPEND LIBS ${Boost_LIBRARIES})
 


### PR DESCRIPTION
This avoids spam from ffmpeg, alsa or other libraries that might write their own messages directly to stderr. We replace stderr with a pipe and rewrite everything as log messages to std::clog (using stderr/info log level). Additionally, std::cerr is changed to use normal stderr so that any messages printed to it actually go straight to stderr.
