### PR TITLE
Fix crash due to trying to join thread twice.

### DIFF
--- a/game/engine.hh
+++ b/game/engine.hh
@@ -24,7 +24,10 @@ class Engine {
 	Engine(Audio& audio, VocalTrackPtrs vocals, Database& database);
 	~Engine() { kill(); }
 	/// Terminates processing
-	void kill() { m_quit = true; m_thread->join(); }
+	void kill() { 
+		m_quit = true;
+		if (m_thread->joinable()) m_thread->join();
+		}
 	/** Used internally for std::thread. Do not call this yourself. (std::thread requires this to be public). **/
 	void operator()();
 };


### PR DESCRIPTION
It might be a good idea to add a ```joinable()``` check in other places where we are calling ```join()```, I at least haven't encountered other crashes relating to this. (I wanted to play here at work the other day and it proved impossible due to this bug.)