### PR TITLE
Faster table clear

### DIFF
--- a/data/themes/default/www/database.html
+++ b/data/themes/default/www/database.html
@@ -12,7 +12,7 @@
 	<div class="col-sm-12">
 		<div class="table-responsive">
 			<table id="database-songs" class="table table-striped table-hover">
-				<tr id="database-table-header">
+				<tr id="table-header">
 					<th><a id="sort-by-artist" href="#" data-sort-ascending="true">artist<span class="glyphicon glyphicon-menu-down"></span></a></th>
 					<th><a id="sort-by-title" href="#" data-sort-ascending="true">title<span class="glyphicon glyphicon-menu-down"></span></a></th>
 					<th class="hidden-xs"><a id="sort-by-language" href="#" data-sort-ascending="true">language<span class="glyphicon glyphicon-menu-down"></span></a></th>

--- a/data/themes/default/www/js/database.js
+++ b/data/themes/default/www/js/database.js
@@ -13,7 +13,7 @@
 $("#refresh-database").click(function () {
     $.get("api/getDataBase.json", function (data) {
         var database = data;
-        clearTable("#database-songs > tbody");
+        clearTable("database-songs");
 
         var html = buildTable(database);
         $(html).appendTo("#database-songs");
@@ -44,7 +44,7 @@ $("a[id^='sort-by-']").click(function () {
     $.get(url, function (data) {
         var database = data;
 
-        clearTable("#database-songs > tbody");
+        clearTable("database-songs");
 
         var html = buildTable(database);
         $(html).appendTo("#database-songs");

--- a/data/themes/default/www/js/table.js
+++ b/data/themes/default/www/js/table.js
@@ -37,8 +37,9 @@ function buildTable(database) {
     This function is used within 'database.js'.
 */
 function clearTable(selector) {
-    var tbody = $(selector);
-    while (tbody.children().length > 1) {
-        tbody.children().last().remove();
-    }
+    var tbody = document.getElementById(selector).getElementsByTagName('tbody')[0];
+    var tbodyHeader = document.getElementById("table-header");
+    var newTbody = document.createElement('tbody');
+    newTbody.appendChild(tbodyHeader);
+    tbody.parentNode.replaceChild(newTbody, tbody);
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/performous/performous/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

At the frontend you may load your database and let it be shown on screen. However if you reload or sorted the list it'd be very slow. I made it way faster.

With 30k songs loaded clearing the tables takes less than a second, whereas it would take more than 10 seconds previously.
<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

N/A
<!-- List here all the issues closed by this pull request. -->

### Motivation

Speed of loading the frontend was slow.
<!-- What inspired you to submit this pull request? -->

### Additional Notes

I enhanced the method of clearing the table. I didn't enhance the way it's drawn to the screen.
Getting the data, clearing the table and filling the table (in memory) takes 1 till 2 seconds. Drawing it on screen with 30k songs loaded takes around 10-15 seconds. But that's purely the browser being slow on a single redraw of the screen.
<!-- Anything else we should know when reviewing? -->
