### PR TITLE
Fix star.svg's and star_glow.svg's incorrect usage of comma as decimal separator

### DIFF
--- a/data/themes/default/star.svg
+++ b/data/themes/default/star.svg
@@ -106,18 +106,18 @@
       <feGaussianBlur
          id="feGaussianBlur3088"
          in="SourceAlpha"
-         stdDeviation="4,000000"
+         stdDeviation="4.000000"
          result="blur" />
       <feColorMatrix
          id="feColorMatrix3090"
          result="bluralpha"
          type="matrix"
-         values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 0,500000 0 " />
+         values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 0.500000 0 " />
       <feOffset
          id="feOffset3092"
          in="bluralpha"
-         dx="0,000000"
-         dy="0,000000"
+         dx="0.000000"
+         dy="0.000000"
          result="offsetBlur" />
       <feMerge
          id="feMerge3094">

--- a/data/themes/default/star_glow.svg
+++ b/data/themes/default/star_glow.svg
@@ -98,18 +98,18 @@
       <feGaussianBlur
          id="feGaussianBlur3088"
          in="SourceAlpha"
-         stdDeviation="4,000000"
+         stdDeviation="4.000000"
          result="blur" />
       <feColorMatrix
          id="feColorMatrix3090"
          result="bluralpha"
          type="matrix"
-         values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 0,500000 0 " />
+         values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 0.500000 0 " />
       <feOffset
          id="feOffset3092"
          in="bluralpha"
-         dx="0,000000"
-         dy="0,000000"
+         dx="0.000000"
+         dy="0.000000"
          result="offsetBlur" />
       <feMerge
          id="feMerge3094"


### PR DESCRIPTION
### What does this PR do?

`star.svg` and `star_glow.svg` incorrectly used comma as decimal separator, triggering crashes when using librsvg version between 2.41 and 2.42.4 (inclusive). Fixed in 2.42.5, but there's no reason to keep broken SVGs around.

### Closes Issue(s)

Fixes #373