### PR TITLE
Added metadata caching

### DIFF
--- a/game/song.cc
+++ b/game/song.cc
@@ -10,6 +10,28 @@ extern "C" {
 #include AVCODEC_INCLUDE
 }
 
+Song::Song(web::json::value const& song): dummyVocal(TrackName::LEAD_VOCAL), randomIdx(rand()) {
+	path = song.has_field("TxtFileFolder") ? fs::path(song.at("TxtFileFolder").as_string().substr(0, song.at("TxtFileFolder").as_string().find_last_of("/\\"))) : "";
+	filename = song.has_field("TxtFile") ? fs::path(song.at("TxtFile").as_string()) : "";
+	artist = song.has_field("Artist") ? song.at("Artist").as_string() : "";
+	title = song.has_field("Title") ? song.at("Title").as_string() : "";
+	language = song.has_field("Language") ? song.at("Language").as_string() : "";
+	edition = song.has_field("Edition") ? song.at("Edition").as_string() : "";
+	creator = song.has_field("Creator") ? song.at("Creator").as_string() : "";
+	genre = song.has_field("Genre") ? song.at("Genre").as_string() : "";
+	cover = song.has_field("Cover") ? song.at("Cover").as_string() : "";
+	background = song.has_field("Background") ? song.at("Background").as_string() : "";
+	video = song.has_field("VideoFile") ? fs::path(song.at("VideoFile").as_string()) : "";
+	videoGap = song.has_field("VideoGap") ? song.at("VideoGap").as_number().to_double() : 0.0;
+	start = song.has_field("Start") ? song.at("Start").as_number().to_double() : 0.0;
+	preview_start = song.has_field("PreviewStart") ? song.at("PreviewStart").as_number().to_double() : 0.0;
+	m_duration = song.has_field("Duration") ? song.at("Duration").as_number().to_double() : 0.0;
+	music["background"] = song.has_field("SongFile") ? fs::path(song.at("SongFile").as_string()) : "";
+	music["vocals"] = song.has_field("Vocals") ? fs::path(song.at("Vocals").as_string()) : "";
+	loadStatus = Song::LoadStatus::HEADER;
+	collateUpdate();
+}
+
 Song::Song(fs::path const& path, fs::path const& filename):
   dummyVocal(TrackName::LEAD_VOCAL), path(path), filename(filename), randomIdx(rand())
 {

--- a/game/song.hh
+++ b/game/song.hh
@@ -8,6 +8,8 @@
 #include <stdexcept>
 #include <string>
 
+#include "cpprest/json.h"
+
 class SongParser;
 
 namespace TrackName {
@@ -78,7 +80,7 @@ public:
 	int randomIdx = 0; ///< sorting index used for random order
 
 	// Functions only below this line
-
+	Song(web::json::value const& song);  ///< Load song from cache.
 	Song(fs::path const& path, fs::path const& filename);  ///< Load song from specified path and filename
 	void reload(bool errorIgnore = true);  ///< Reset and reload the entire song from file
 	void loadNotes(bool errorIgnore = true);  ///< Load note data (called when entering singing screen, headers preloaded).

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -19,6 +19,9 @@
 #include <regex>
 #include <unicode/stsearch.h>
 
+#include "cpprest/json.h"
+#include <sys/stat.h>
+
 Songs::Songs(Database & database, std::string const& songlist): m_songlist(songlist), m_database(database), m_order(config["songs/sort-order"].i()) {
 	if (U_FAILURE(UnicodeUtil::m_icuError)) std::clog << "songs/error: Error creating Unicode collator: " << u_errorName(UnicodeUtil::m_icuError) << std::endl;
 	m_updateTimer.setTarget(getInf()); // Using this as a simple timer counting seconds
@@ -48,6 +51,9 @@ void Songs::reload_internal() {
 		m_songs.clear();
 		m_dirty = true;
 	}
+	LoadCache();
+	std::clog << "songs/notice: Done loading the cache. You now have " << m_songs.size() << " songs in your list." << std::endl;
+	std::clog << "songs/notice: Starting to load all songs from disk, to update the cache." << std::endl;
 	Profiler prof("songloader");
 	Paths paths = getPathsConfig("paths/songs");
 	for (auto it = paths.begin(); m_loading && it != paths.end(); ++it) { //loop through stored directories from config
@@ -67,7 +73,116 @@ void Songs::reload_internal() {
 	std::clog << std::flush;
 	m_loading = false;
 	std::clog << "songs/notice: Done Loading. Loaded " << m_songs.size() << " Songs." << std::endl;
+	CacheSonglist();
+	std::clog << "songs/notice: Done Caching." << std::endl;
 	doneLoading = true;
+}
+
+void Songs::LoadCache() {
+	fs::path songsMetaFile = getCacheDir() / "Songs-Metadata.json";
+	std::ifstream file(songsMetaFile.string());
+	web::json::value jsonRoot;
+    if (file)
+    {
+    	try {
+	        std::stringstream buffer;
+	        buffer << file.rdbuf();
+	        file.close();
+	        jsonRoot = web::json::value::parse(buffer);
+    	} catch(std::exception const& e) {
+			std::clog << "songs/error: " << e.what() << std::endl;
+			return;
+    	}
+    } else {
+    	std::clog << "songs/info: Could not open songs meta cache file " << songsMetaFile.string() << std::endl;
+    	return;
+    }
+
+    for(auto const& song : jsonRoot.as_array()) {
+    	struct stat buffer;
+    	if(stat(song.at("TxtFile").as_string().c_str(), &buffer) == 0) {
+    		std::shared_ptr<Song> realSong(new Song(song));
+    		m_songs.push_back(realSong);
+    	}  	
+    }
+}
+
+void Songs::CacheSonglist() {
+    web::json::value jsonRoot = web::json::value::array();
+    auto i = 0;
+	for (auto const& song : m_songs)
+    {  
+        web::json::value songObject = web::json::value::object();
+        if(!song->path.string().empty()) {
+        	songObject["TxtFileFolder"] = web::json::value::string(song->path.string());
+        }
+        if(!song->filename.string().empty()) {
+        	songObject["TxtFile"] = web::json::value::string(song->filename.string());
+        }
+        if(!song->title.empty()) {
+        	songObject["Title"] = web::json::value::string(song->title);
+    	}
+		if(!song->artist.empty()) {
+        	songObject["Artist"] = web::json::value::string(song->artist);
+    	}
+        if(!song->edition.empty()) {
+        	songObject["Edition"] = web::json::value::string(song->edition);
+    	}
+    	if(!song->language.empty()) {
+        	songObject["Language"] = web::json::value::string(song->language);
+        }
+        if(!song->creator.empty()) {
+        	songObject["Creator"] = web::json::value::string(song->creator);
+    	}
+    	if(!song->genre.empty()) {
+        	songObject["Genre"] = web::json::value::string(song->genre);
+    	}
+    	if(!song->cover.string().empty()) {
+        	songObject["Cover"] = web::json::value::string(song->cover.string());
+    	}
+    	if(!song->background.string().empty()) {
+	        songObject["Background"] = web::json::value::string(song->background.string());
+	    }
+    	if(!song->music["background"].string().empty()) {
+	        songObject["SongFile"] = web::json::value::string(song->music["background"].string());
+	    }
+    	if(!song->video.string().empty()) {
+	        songObject["VideoFile"] = web::json::value::string(song->video.string());
+	    }
+    	if(!std::isnan(song->start)) {
+	        songObject["Start"] = web::json::value(song->start);
+	    }
+    	if(!std::isnan(song->videoGap)) {
+	        songObject["VideoGap"] = web::json::value(song->videoGap);
+	    }
+    	if(!std::isnan(song->preview_start)) {
+	        songObject["PreviewStart"] = web::json::value::number(song->preview_start);
+	    }
+    	if(!song->music["vocals"].string().empty()) {
+	        songObject["Vocals"] = web::json::value::string(song->music["vocals"].string());
+	    }
+    	auto duration = song->getDurationSeconds();
+    	if(!std::isnan(duration)) {
+	    	songObject["Duration"] = web::json::value(duration);
+	    }
+	    if(songObject != web::json::value::object()) {
+        	jsonRoot[i] = songObject;
+        	i++;
+    	}
+	}
+
+	fs::path cacheDir = getCacheDir() / "Songs-Metadata.json";
+
+	try {
+		std::stringstream stream;
+		jsonRoot.serialize(stream);
+		std::ofstream outFile(cacheDir.string());
+    	outFile << stream.rdbuf();
+    	outFile.close();
+	} catch (std::exception const& e) {
+		std::clog << "songs/error: Could not save " + cacheDir.string() + ": " + e.what() << std::endl;
+		return;
+	}
 }
 
 void Songs::reload_internal(fs::path const& parent) {
@@ -79,6 +194,17 @@ void Songs::reload_internal(fs::path const& parent) {
 			if (fs::is_directory(p)) { reload_internal(p); continue; } //if the file is a folder redo this function with this folder as path
 			if (!regex_search(p.filename().string(), expression)) continue; //if the folder does not contain any of the requested files, ignore it
 			try { //found song file, make a new song with it.
+				auto it = std::find_if(m_songs.begin(), m_songs.end(), [p](std::shared_ptr<Song> n) {
+					return n->filename == p;
+				});
+				auto alreadyInCache = it != m_songs.end();
+
+				if(alreadyInCache) { 
+					continue;
+				}
+
+				std::clog << "songs/notice: Found song not which was not in the cache: " << p.string() << std::endl;
+
 				std::shared_ptr<Song>s(new Song(p.parent_path(), p));
 				std::lock_guard<std::mutex> l(m_mutex);
 				int AdditionalFileIndex = -1;
@@ -88,7 +214,8 @@ void Songs::reload_internal(fs::path const& parent) {
 						std::clog << "songs/info: >>> Found additional song file: " << s->filename << " for: " << m_songs[i]->filename << std::endl;
 						AdditionalFileIndex = i;
 					}
-				}
+				}				
+
 				if(AdditionalFileIndex > 0) { //TODO: add it to existing song
 					std::clog << "songs/info: >>> not yet implemented " << std::endl;
 					s->getDurationSeconds();

--- a/game/songs.hh
+++ b/game/songs.hh
@@ -75,6 +75,9 @@ class Songs: boost::noncopyable {
 	size_t loadedSongs() const { return m_songs.size(); }
 
   private:
+  	void LoadCache();
+	void CacheSonglist();
+
 	class RestoreSel;
 	typedef std::vector<std::shared_ptr<Song> > SongVector;
 	std::string m_songlist;


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/performous/performous/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

This PR adds caching to performous. It caches all the metadata available of the song in a json file (cpprestsdk).
The cache is kept up to date so if you add a new song, it'll be added to the cache aswell. If you remove a song it'll be removed aswell. This is done by completely overwriting the cache file after we loaded all the files.

Building the cache with 30830 songs takes 36 minutes now.
Running performous the 2nd time with this same songlibrary, makes performous load all those songs in just 25 seconds.
<!-- A brief description of the change being made with this pull request. -->

### Motivation
Performous was crashing on me and i didn't want to wait for around 20 minutes to load my complete library again.
<!-- What inspired you to submit this pull request? -->
