### PR TITLE
Bug fix/audio fixes

### DIFF
--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -144,6 +144,7 @@ if(UNIX AND NOT APPLE)
 endif()
 
 if(WIN32)
+	add_definitions("-DEPOXY_SHARED")
 	option(MXE_HACK "Features horrible hacks, but is able to compile a static performous.exe (that may not work)." OFF)
 	mark_as_advanced(MXE_HACK)
 	if(MXE_HACK)

--- a/game/audio.cc
+++ b/game/audio.cc
@@ -457,9 +457,23 @@ struct Audio::Impl {
 					if (!iss.eof()) throw std::runtime_error("Syntax error parsing device parameter " + key);
 				}
 				portaudio::AudioDevices ad(PaHostApiTypeId(PaHostApiNameToHostApiTypeId(selectedBackend)));
-				auto const& info = ad.find(params.dev);
-				std::clog << "audio/info: Trying audio device \"" << params.dev << "\", idx: " << info.idx
-					<< ", in: " << params.in << ", out: " << params.out << std::endl;
+					bool wantOutput = (params.in == 0) ? true : false;
+					unsigned num;
+					std::string msg = "audio/info: Device string empty; will look for a device with at least ";
+					if (wantOutput) {
+						msg += std::to_string(params.out) + " output channels.";
+						num = params.out;
+					}
+					else {
+						msg += std::to_string(params.in) + " input channels.";
+						num = params.in;
+					}
+					if (!params.dev.empty()) {
+					std::clog << "audio/debug: Will try to find device matching dev: " << params.dev << std::endl;
+					}
+					else { std::clog << msg << std::endl; }
+					portaudio::DeviceInfo const& info = ad.find(params.dev, wantOutput, num);
+					std::clog << "audio/info: Found: " << info.name << ", in: " << info.in << ", out: " << info.out << std::endl;
 				if (info.in < int(params.mics.size())) throw std::runtime_error("Device doesn't have enough input channels");
 				if (info.out < int(params.out)) throw std::runtime_error("Device doesn't have enough output channels");
 				// Match found if we got here, construct a device

--- a/game/audio.cc
+++ b/game/audio.cc
@@ -452,10 +452,10 @@ struct Audio::Impl {
 							++params.in;
 						}
 					}
-					if (params.mics.size() < params.in) { params.mics.resize(params.in); }
 					else throw std::runtime_error("Unknown device parameter " + key);
 					if (!iss.eof()) throw std::runtime_error("Syntax error parsing device parameter " + key);
 				}
+				if (params.mics.size() < params.in) { params.mics.resize(params.in); }
 				portaudio::AudioDevices ad(PaHostApiTypeId(PaHostApiNameToHostApiTypeId(selectedBackend)));
 					bool wantOutput = (params.in == 0) ? true : false;
 					unsigned num;

--- a/game/audio.cc
+++ b/game/audio.cc
@@ -448,14 +448,14 @@ struct Audio::Impl {
 					else if (key == "dev") std::getline(iss, params.dev);
 					else if (key == "mics") {
 						// Parse a comma-separated list of mics
-						for (std::string mic; std::getline(iss, mic, ','); params.mics.push_back(mic)) {}
+						for (std::string mic; std::getline(iss, mic, ','); params.mics.push_back(mic)) {
+							++params.in;
+						}
 					}
+					if (params.mics.size() < params.in) { params.mics.resize(params.in); }
 					else throw std::runtime_error("Unknown device parameter " + key);
 					if (!iss.eof()) throw std::runtime_error("Syntax error parsing device parameter " + key);
 				}
-				// Sync mics/in settings together
-				if (params.in == 0) params.in = params.mics.size();
-				else params.mics.resize(params.in);
 				portaudio::AudioDevices ad(PaHostApiTypeId(PaHostApiNameToHostApiTypeId(selectedBackend)));
 				auto const& info = ad.find(params.dev);
 				std::clog << "audio/info: Trying audio device \"" << params.dev << "\", idx: " << info.idx

--- a/game/audio.cc
+++ b/game/audio.cc
@@ -463,7 +463,7 @@ struct Audio::Impl {
 				if (info.in < int(params.mics.size())) throw std::runtime_error("Device doesn't have enough input channels");
 				if (info.out < int(params.out)) throw std::runtime_error("Device doesn't have enough output channels");
 				// Match found if we got here, construct a device
-				devices.emplace_back(params.in, params.out, params.rate, info.idx);
+				devices.emplace_back(params.in, params.out, params.rate, info.index);
 				Device& d = devices.back();
 				// Assign mics for all channels of the device
 				int assigned_mics = 0;

--- a/game/audio.hh
+++ b/game/audio.hh
@@ -34,7 +34,7 @@ struct Device {
 	/// Callback
 	int operator()(void const* input, void* output, unsigned long frames, const PaStreamCallbackTimeInfo*, PaStreamCallbackFlags);
 	/// Returns true if this device is opened for output
-	bool isOutput() const { return outptr != NULL; }
+	bool isOutput() const { return outptr != nullptr; }
 	/// Returns true if this device is assigned to the named channel (mic color or "OUT")
 	bool isChannel(std::string const& name) const {
 		if (name == "OUT") return isOutput();

--- a/game/libda/portaudio.hpp
+++ b/game/libda/portaudio.hpp
@@ -121,12 +121,10 @@ namespace portaudio {
 			throw std::runtime_error("No such device.");
 		}
 		DeviceInfo const& findByChannels(bool output, unsigned num) {
-			// Try name search with full match
 			for (auto const& dev: devices) {
-			unsigned reqChannels = output ? dev.out : dev.in;
-			if (reqChannels >= num) { return dev;  }
+				unsigned reqChannels = output ? dev.out : dev.in;
+				if (reqChannels >= num) { return dev;  }
 			}
-			// Try name search with partial/flexible match
 			throw std::runtime_error("No such device.");
 		}
 		DeviceInfos devices;

--- a/game/libda/portaudio.hpp
+++ b/game/libda/portaudio.hpp
@@ -36,7 +36,7 @@ namespace portaudio {
 	}
 
 	struct DeviceInfo {
-		DeviceInfo(int id, std::string n = std::string(), int i = 0, int o = 0): name(n), flex(n), idx(id), in(i), out(o) {}
+		DeviceInfo(int id, std::string n = std::string(), int i = 0, int o = 0, unsigned index = 0): name(n), flex(n), idx(id), in(i), out(o), index(index) {}
 		std::string desc() const {
 			std::ostringstream oss;
 			oss << name << " (";
@@ -50,6 +50,7 @@ namespace portaudio {
 		std::string flex;  ///< Modified name that is less specific but still unique (allow device numbers to change)
 		int idx;
 		int in, out;
+		unsigned index;
 	};
 		typedef std::vector<DeviceInfo> DeviceInfos;
 		struct AudioDevices {
@@ -82,7 +83,7 @@ namespace portaudio {
 					oss << name << " #" << ++num;
 					n = oss.str();
 				};
-				devices.push_back(DeviceInfo(i, name, info->maxInputChannels, info->maxOutputChannels));
+				devices.push_back(DeviceInfo(i, name, info->maxInputChannels, info->maxOutputChannels, Pa_HostApiDeviceIndexToDeviceIndex(backendIndex, i)));
 			}
 			for (auto& dev: devices) {
 				// Array of regex - replacement pairs

--- a/game/libda/portaudio.hpp
+++ b/game/libda/portaudio.hpp
@@ -97,7 +97,7 @@ namespace portaudio {
 					// Verify that flex doesn't find any wrong devices
 					bool fail = false;
 					try {
-						if (find(flex).idx != dev.idx) fail = true;
+						if (find(flex, false, 0).idx != dev.idx) fail = true;
 					} catch (...) {}  // Failure to find anything is success
 					if (!fail) dev.flex = flex;
 				}
@@ -109,7 +109,8 @@ namespace portaudio {
 			for (auto const& d: devices) { oss << "    #" << d.idx << " " << d.desc() << std::endl; }
 			return oss.str();
 		}
-		DeviceInfo const& find(std::string const& name) {
+		DeviceInfo const& find(std::string const& name, bool output, unsigned num) {
+			if (name.empty()) { return findByChannels(output, num); }
 			// Try name search with full match
 			for (auto const& dev: devices) { if (dev.name == name) { return dev;  } }
 			// Try name search with partial/flexible match
@@ -117,6 +118,15 @@ namespace portaudio {
 				if (dev.name.find(name) != std::string::npos) { return dev; }
 				if (dev.flex.find(name) != std::string::npos) { return dev; }
 			}
+			throw std::runtime_error("No such device.");
+		}
+		DeviceInfo const& findByChannels(bool output, unsigned num) {
+			// Try name search with full match
+			for (auto const& dev: devices) {
+			unsigned reqChannels = output ? dev.out : dev.in;
+			if (reqChannels >= num) { return dev;  }
+			}
+			// Try name search with partial/flexible match
 			throw std::runtime_error("No such device.");
 		}
 		DeviceInfos devices;

--- a/game/libda/portaudio.hpp
+++ b/game/libda/portaudio.hpp
@@ -229,9 +229,12 @@ namespace portaudio {
 		  double sampleRate,
 		  unsigned long framesPerBuffer = paFramesPerBufferUnspecified,
 		  PaStreamFlags flags = paNoFlag,
-		  PaStreamCallback* callback = NULL,
-		  void* userData = NULL)
+		  PaStreamCallback* callback = nullptr,
+		  void* userData = nullptr)
 		{
+			if (output != nullptr) {
+				if (output->channelCount > 0) { flags = paPrimeOutputBuffersUsingStreamCallback; }
+			}
 			PORTAUDIO_CHECKED(Pa_OpenStream, (&m_handle, input, output, sampleRate, framesPerBuffer, flags, callback, userData));
 		}
 		/// Construct stream using a C++ functor as callback


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/performous/performous/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

Chiefly, fixes the issue with Pa_OpenStream reporting invalid number of channels in windows. But it also fixes a couple other things I found along the way.

Succintly:

- Implement an additional member to the Devices to make sure we refer to them by their global index, instead of the one relative to their respective backend.
- Change the way the "mics" parameter is parsed from the schema.
- Correct a bug that would result in always using the first device when a schema or config entry did not have a "dev" parameter.
- Eliminate (I think) the audio artifacts when starting/restarting playback.

<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

#327 (at least, I think)

<!-- List here all the issues closed by this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
