### PR TITLE
schema.xml: Hide audio/devices from user interface

### DIFF
--- a/data/config/schema.xml
+++ b/data/config/schema.xml
@@ -303,7 +303,7 @@ to save the current settings to XML.
 		<short>Audio/controller latency</short>
 		<long>Affects instruments and dancing only. The total of USB (guitar or dance pad) latency combined with audio output latency. Adjust so that you can hit the notes best when playing by ear (not looking on screen). Use Ctrl+F5/F6 to adjust while performing.</long>
 	</entry>
-	<entry name="audio/devices" type="string_list">
+	<entry name="audio/devices" type="string_list" hidden="true">
 		<stringvalue>dev="USBMIC" mics="blue,red"</stringvalue><!-- SingStar mics -->
 		<stringvalue>dev="Microphone" mics="*"</stringvalue><!-- Rock Band branded Logitech mic -->
 		<stringvalue>mics="blue"</stringvalue><!-- Any other microphone (only if blue is still free) -->


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/performous/performous/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

Hides an entry that is used for internal guesses about devices we can use. It has no business being in the interface, as it only ends up confusing people.

<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

#393 

<!-- List here all the issues closed by this pull request. -->

### Motivation

Somebody flustered about being unable to get performous to work because they were looking at this entry instead of the Audio Devices screen.

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
