### PR TITLE
Removed boost::noncopyable and replaced with c++11 variant

### DIFF
--- a/game/3dobject.hh
+++ b/game/3dobject.hh
@@ -2,7 +2,6 @@
 
 #include "fs.hh"
 #include "glutil.hh"
-#include <boost/noncopyable.hpp>
 #include <memory>
 #include <string>
 
@@ -13,13 +12,15 @@ class Surface;
 
 /// A class representing 3d object
 /// Non-copyable because of display lists getting messed up
-class Object3d: boost::noncopyable {
+class Object3d {
   private:
 	glutil::VertexArray m_va;
 	std::unique_ptr<Surface> m_texture; /// texture
 	/// load a Wavefront .obj 3d object file
 	void loadWavefrontObj(fs::path const& filepath, float scale = 1.0);
   public:
+  	Object3d(const Object3d&) = delete;
+  	const Object3d& operator=(const Object3d&) = delete;
 	Object3d() {}
 	Object3d(fs::path const& filepath, fs::path const& texturepath = fs::path(), float scale = 1.0) {
 		load(filepath, texturepath, scale);

--- a/game/backgrounds.hh
+++ b/game/backgrounds.hh
@@ -8,9 +8,11 @@
 #include <vector>
 
 /// songs class for songs screen
-class Backgrounds: boost::noncopyable {
+class Backgrounds {
   public:
 	/// constructor
+	Backgrounds(const Backgrounds&) = delete;
+  	const Backgrounds& operator=(const Backgrounds&) = delete;
 	Backgrounds() {
 		reload();
 	}

--- a/game/controllers.hh
+++ b/game/controllers.hh
@@ -3,7 +3,6 @@
 #include "chrono.hh"
 #include "configuration.hh"
 #include "util.hh"
-#include <boost/noncopyable.hpp>
 #include <SDL2/SDL_events.h>
 #include <climits>
 #include <deque>
@@ -81,10 +80,12 @@ namespace input {
 	};
 	
 	/// A handle for receiving device events
-	class Device: boost::noncopyable {
+	class Device {
 		typedef std::deque<Event> Events;
 		Events m_events;
 	public:
+		Device(const Device&) = delete;
+  		const Device& operator=(const Device&) = delete;
 		const SourceId source;
 		const DevType type;
 		Device(SourceId const& source, DevType type): source(source), type(type) {}
@@ -94,8 +95,10 @@ namespace input {
 	typedef std::shared_ptr<Device> DevicePtr;
 
 	/// The main controller class that contains everything
-	class Controllers: boost::noncopyable {
+	class Controllers {
 	public:
+		Controllers(const Controllers&) = delete;
+  		const Controllers& operator=(const Controllers&) = delete;
 		Controllers();
 		~Controllers();
 		/// Return true and a nav event if there are any in queue. Otherwise return false.
@@ -114,10 +117,13 @@ namespace input {
 	};
 
 	/// Base class for different types of hardware backends.
-	class Hardware: boost::noncopyable {
+	class Hardware {
 	public:
+		Hardware(const Hardware&) = delete;
+  		const Hardware& operator=(const Hardware&) = delete;
 		static bool midiEnabled();
 		static void enableKeyboardInstruments(bool state);
+		Hardware() {}
 		virtual ~Hardware() {}
 		/// Get the name of a specific device of this type
 		virtual std::string getName(unsigned) const { return std::string(); }

--- a/game/fbo.hh
+++ b/game/fbo.hh
@@ -1,12 +1,13 @@
 #pragma once
 
-#include <boost/noncopyable.hpp>
 #include "surface.hh"
 #include "video_driver.hh"
 
 /// Frame Buffer Object class
-class FBO: boost::noncopyable {
+class FBO {
   public:
+	FBO(const FBO&) = delete;
+  	const FBO& operator=(const FBO&) = delete;
 	/// Generate the FBO and attach a fresh texture to it
 	FBO(unsigned w, unsigned h) {
 		{

--- a/game/glshader.hh
+++ b/game/glshader.hh
@@ -7,7 +7,6 @@
 #include <map>
 #include <vector>
 #include <epoxy/gl.h>
-#include <boost/noncopyable.hpp>
 
 struct Uniform {
 	GLint id;
@@ -24,7 +23,9 @@ struct Uniform {
 	void setMat4(GLfloat const* m) { glUniformMatrix4fv(id, 1, GL_FALSE, m); }
 };
 
-struct Shader: public boost::noncopyable {
+struct Shader {
+	Shader(const Shader&) = delete;
+  	const Shader& operator=(const Shader&) = delete;
 	/// Print compile errors and such
 	/// @param id of shader or program
 	void dumpInfoLog(GLuint id);

--- a/game/libda/mixer.hpp
+++ b/game/libda/mixer.hpp
@@ -35,8 +35,10 @@ namespace da {
 	}
 
 
-	class chain: boost::noncopyable {
+	class chain {
 	  public:
+	  	chain(const chain&) = delete;
+  		const chain& operator=(const chain&) = delete;
 		typedef std::vector<callback_t> streams_t;
 		void add(callback_t const& cb) { streams.push_back(cb); }
 		void clear() { streams.clear(); }
@@ -61,8 +63,10 @@ namespace da {
 		}
 	}
 
-	class accumulate: boost::noncopyable {
+	class accumulate {
 	  public:
+	  	accumulate(const accumulate&) = delete;
+  		const accumulate& operator=(const accumulate&) = delete;
 		typedef std::vector<callback_t> streams_t;
 		void add(callback_t const& cb) { streams.push_back(cb); }
 		void clear() { streams.clear(); }
@@ -85,8 +89,10 @@ namespace da {
 	  private:
 	};
 
-	class buffer: boost::noncopyable {
+	class buffer {
 	  public:
+	  	buffer(const buffer&) = delete;
+  		const buffer& operator=(const buffer&) = delete;
 		explicit buffer(std::size_t s): m_data(s) {}
 		sample_t* begin() { return &m_data[0]; }
 		sample_t* end() { return begin() + m_data.size(); }
@@ -94,8 +100,10 @@ namespace da {
 		std::vector<sample_t> m_data;
 	};
 
-	class stream: boost::noncopyable {
+	class stream {
 	  public:
+	  	stream(const stream&) = delete;
+  		const stream& operator=(const stream&) = delete;
 		stream(): m_pos() {}
 		bool operator()(pcm_data& data) {
 			sample_t* b = m_buffer->begin();
@@ -112,8 +120,10 @@ namespace da {
 		int64_t m_pos;
 	};
 
-	class fadeinOp: boost::noncopyable {
+	class fadeinOp {
 	  public:
+	  	fadeinOp(const fadeinOp&) = delete;
+  		const fadeinOp& operator=(const fadeinOp&) = delete;
 		fadeinOp(double time = 1.0, int64_t pos = 0): m_pos(pos), m_time(time) {}
 		bool operator()(pcm_data& data) {
 			size_t end = m_time * data.rate;
@@ -131,8 +141,10 @@ namespace da {
 		double m_time;
 	};
 
-	class fadeoutOp: boost::noncopyable {
+	class fadeoutOp {
 	  public:
+	  	fadeoutOp(const fadeoutOp&) = delete;
+  		const fadeoutOp& operator=(const fadeoutOp&) = delete;
 		fadeoutOp(callback_t cb, double time = 1.0, int64_t pos = 0): m_stream(cb), m_pos(pos), m_time(time) {}
 		bool operator()(pcm_data& data) {
 			bool ret = m_stream(data);
@@ -164,8 +176,10 @@ namespace da {
 		sample_t m_level;
 	};
 
-	class mutex_stream: boost::noncopyable {
+	class mutex_stream{
 	  public:
+	  	mutex_stream(const mutex_stream&) = delete;
+  		const mutex_stream& operator=(const mutex_stream&) = delete;
 		mutex_stream(callback_t const& stream): m_stream(stream) {}
 		bool operator()(pcm_data& data) {
 			std::lock_guard<std::recursive_mutex> l(m_mutex);

--- a/game/menu.hh
+++ b/game/menu.hh
@@ -2,7 +2,6 @@
 
 #include "opengl_text.hh"
 #include "configuration.hh"
-#include <boost/noncopyable.hpp>
 #include <functional>
 #include <memory>
 #include <string>

--- a/game/pitch.hh
+++ b/game/pitch.hh
@@ -7,8 +7,6 @@
 #include <algorithm>
 #include <cmath>
 
-#include <boost/noncopyable.hpp>
-
 /// struct to represent tones
 struct Tone {
 	static const std::size_t MAXHARM = 48; ///< The maximum number of harmonics tracked
@@ -72,8 +70,10 @@ private:
 /// analyzer class
  /** class to analyze input audio and transform it into useable data
  */
-class Analyzer: boost::noncopyable {
+class Analyzer {
 public:
+	Analyzer(const Analyzer&) = delete;
+  	const Analyzer& operator=(const Analyzer&) = delete;
 	/// fast fourier transform vector
 	typedef std::vector<std::complex<float> > fft_t;
 	/// list of tones

--- a/game/players.hh
+++ b/game/players.hh
@@ -6,7 +6,6 @@
 #include <string>
 #include <stdexcept>
 
-#include <boost/noncopyable.hpp>
 #include <unicode/tblcoll.h>
 #include <unicode/unistr.h>
 #include <unicode/utypes.h>
@@ -35,7 +34,7 @@ struct PlayersException: public std::runtime_error {
  The filtered list is used to show players in
  the screen_players.
  */
-class Players: boost::noncopyable {
+class Players {
   private:
 	typedef std::set<PlayerItem> players_t;
 	typedef std::vector<PlayerItem> fplayers_t;
@@ -50,6 +49,8 @@ class Players: boost::noncopyable {
 	bool m_dirty;
 
   public:
+	Players(const Players&) = delete;
+  	const Players& operator=(const Players&) = delete;
 	Players();
 	~Players();
 

--- a/game/song.hh
+++ b/game/song.hh
@@ -5,7 +5,6 @@
 #include "notes.hh"
 #include "util.hh"
 
-#include <boost/noncopyable.hpp>
 #include <cpprest/json.h>
 #include <stdexcept>
 #include <string>

--- a/game/songs.hh
+++ b/game/songs.hh
@@ -15,8 +15,10 @@ class Song;
 class Database;
 
 /// songs class for songs screen
-class Songs: boost::noncopyable {
+class Songs {
   public:
+  	Songs(const Songs&) = delete;
+  	const Songs& operator=(const Songs&) = delete;
 	/// constructor
 	Songs(Database& database, std::string const& songlist = std::string());
 	~Songs();

--- a/game/surface.hh
+++ b/game/surface.hh
@@ -4,7 +4,6 @@
 #include "image.hh"
 #include "video_driver.hh"
 
-#include <boost/noncopyable.hpp>
 #include <cairo.h>
 
 #include <algorithm>
@@ -113,9 +112,11 @@ private:
 Shader& getShader(std::string const& name);
 
 /** @short A RAII wrapper for allocating/deallocating OpenGL texture ID **/
-template <GLenum Type> class OpenGLTexture: boost::noncopyable {
+template <GLenum Type> class OpenGLTexture {
   public:
 	/// return Type
+	OpenGLTexture(const OpenGLTexture&) = delete;
+  	const OpenGLTexture& operator=(const OpenGLTexture&) = delete;
 	static GLenum type() { return Type; };
 	static Shader& shader() {
 		switch (Type) {
@@ -137,8 +138,10 @@ template <GLenum Type> class OpenGLTexture: boost::noncopyable {
 };
 
 /** @short A RAII wrapper for binding to a texture (using it, modifying it) **/
-class UseTexture: boost::noncopyable {
+class UseTexture {
   public:
+  	UseTexture(const UseTexture&) = delete;
+  	const UseTexture& operator=(const UseTexture&) = delete;
 	/// constructor
 	template <GLenum Type> UseTexture(OpenGLTexture<Type> const& tex):
 	  m_shader(/* hack of the year */ (glutil::GLErrorChecker("UseTexture"), glActiveTexture(GL_TEXTURE0), glBindTexture(Type, tex.id()), tex.shader())) {}

--- a/game/theme.hh
+++ b/game/theme.hh
@@ -3,12 +3,13 @@
 #include "opengl_text.hh"
 #include "surface.hh"
 #include "cachemap.hh"
-#include <boost/noncopyable.hpp>
 #include <string>
 
 /// abstract theme class
-class Theme: boost::noncopyable {
+class Theme {
 protected:
+	Theme(const Theme&) = delete;
+  	const Theme& operator=(const Theme&) = delete;
 	Theme();
 	Theme(fs::path const& path); ///< creates theme from path
 public:


### PR DESCRIPTION
### What does this PR do?
Removes `boost::noncopyable` from our codebase since it can be replaced by `constructor = delete`

### Closes Issue(s)
N/A

### Motivation
It's good habbit to clean up some old code.