### PR TITLE
Fixed checking if song exist in songlist paths

### DIFF
--- a/game/platform.hh
+++ b/game/platform.hh
@@ -15,6 +15,15 @@
 #include <boost/filesystem.hpp>
 #include <SDL2/SDL_events.h>
 
+#if (BOOST_OS_WINDOWS) 
+#include <sys/types.h>
+#include <sys/stat.h>
+#define _STAT(x, y) _stat(x, y)
+#else
+#include <sys/stat.h>
+#define _STAT(x, y) stat(x, y)
+#endif
+
 struct Platform {
 enum platforms { windows, linux, macos, bsd, solaris, unix };
 Platform();


### PR DESCRIPTION
### What does this PR do?
Fixes a problem with caching as described in #386 
It is fixed by checking if the path of the song's txt file starts with either one of the configured directories.
> @Lord-Kamina did you mean by 'removed' songs changing the song directory (within your config.xml) or by adding it as a parameter? While the other folder is still available on that hard drive? Because in my opinion it's not a deleted song as it's still available from a source.
>
>I think the desired behavior would be to check if the txt file exists (like it happens now) AND to check if that file is in one of the configured song directories.
<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

Closes #386 

### Motivation
It's nice to see the cache update to check upon the current used paths. This way the cache can't be outdated.

## PERFORMANCE NOTES
I have no clue how this will impact larger libraries. It should be slower (but hopefully not too slow) since it does check every cached path if it's still valid...