### PR TITLE
Fix build failure on other systems due to execname not being defined

### DIFF
--- a/game/execname.cc
+++ b/game/execname.cc
@@ -14,5 +14,6 @@
 #elif (BOOST_OS_LINUX)
 #include "platform/execname.unix.inc"
 #else
-	return fs::path();
+	#error execname function undefined on your OS, please port it
+//	return fs::path();
 #endif // BOOST_OS_WINDOWS


### PR DESCRIPTION
/<<BUILDDIR>>/performous-1.1+git20181118/game/execname.cc:17:2: error: expected unqualified-id before ‘return’
  return fs::path();
  ^~~~~~
