### PR TITLE
Fix type filter, short song previews and idiotic NaN comparison.

### DIFF
--- a/game/song.cc
+++ b/game/song.cc
@@ -32,6 +32,28 @@ Song::Song(web::json::value const& song): dummyVocal(TrackName::LEAD_VOCAL), ran
 	music["background"] = song.has_field("SongFile") ? fs::path(song.at("SongFile").as_string()) : "";
 	music["vocals"] = song.has_field("Vocals") ? fs::path(song.at("Vocals").as_string()) : "";
 	loadStatus = Song::LoadStatus::HEADER;
+	
+	if (song.has_field("VocalTracks")) {
+		for (unsigned i = 0; i < song.at("VocalTracks").as_number().to_uint32(); i++) {
+			std::string track = "DummyTrack" + std::to_string(i);
+			insertVocalTrack(track, VocalTrack(track));
+		}
+	}
+	
+	if (song.has_field("KeyboardTracks")) {
+			instrumentTracks.insert(make_pair(TrackName::KEYBOARD, InstrumentTrack(TrackName::KEYBOARD)));
+	}
+	
+	if (song.has_field("DrumTracks")) {
+			instrumentTracks.insert(make_pair(TrackName::DRUMS, InstrumentTrack(TrackName::DRUMS)));
+	}		
+	if (song.has_field("DanceTracks")) {
+		DanceDifficultyMap danceDifficultyMap;
+			danceTracks.insert(std::make_pair("dance-single", danceDifficultyMap));
+	}		
+	if (song.has_field("GuitarTracks")) {
+			instrumentTracks.insert(std::make_pair(TrackName::GUITAR, InstrumentTrack(TrackName::GUITAR)));
+	}		
 	collateUpdate();
 }
 

--- a/game/songparser-ini.cc
+++ b/game/songparser-ini.cc
@@ -19,6 +19,8 @@ bool SongParser::iniCheck(std::string const& data) const {
 /// Parse header data for Songs screen
 void SongParser::iniParseHeader() {
 	Song& s = m_song;
+	if (!m_song.vocalTracks.empty()) { m_song.vocalTracks.clear(); }
+	if (!m_song.instrumentTracks.empty()) { m_song.instrumentTracks.clear(); }
 	std::string line;
 	while (getline(line)) {
 		if (line.empty()) continue;

--- a/game/songparser-mid.cc
+++ b/game/songparser-mid.cc
@@ -55,6 +55,8 @@ namespace {
 
 void SongParser::midParseHeader() {
 	Song& s = m_song;
+	if (!m_song.vocalTracks.empty()) { m_song.vocalTracks.clear(); }
+	if (!m_song.instrumentTracks.empty()) { m_song.instrumentTracks.clear(); }
 	// Parse tracks from midi
 	MidiFileParser midi(s.midifilename);
 	for (MidiFileParser::Tracks::const_iterator it = midi.tracks.begin(); it != midi.tracks.end(); ++it) {

--- a/game/songparser-sm.cc
+++ b/game/songparser-sm.cc
@@ -35,6 +35,7 @@ reaches value #NOTES.
 void SongParser::smParseHeader() {
 	Song& s = m_song;
 	std::string line;
+	if (!m_song.danceTracks.empty()) { m_song.danceTracks.clear(); }
 	// Parse the the entire file
 	while (getline(line) && smParseField(line)) {}
 	if (m_song.danceTracks.empty() ) throw std::runtime_error("No note data in the file");

--- a/game/songparser-txt.cc
+++ b/game/songparser-txt.cc
@@ -28,6 +28,7 @@ void SongParser::txtParseHeader() {
 void SongParser::txtParse() {
 	std::string line;
 	m_curSinger = CurrentSinger::P1;
+	if (!m_song.vocalTracks.empty()) { m_song.vocalTracks.clear(); }
 	m_song.insertVocalTrack(TrackName::LEAD_VOCAL, VocalTrack(TrackName::LEAD_VOCAL));
 	m_song.insertVocalTrack(DUET_P2, VocalTrack(DUET_P2));
 	while (getline(line) && txtParseField(line)) {} // Parse the header again

--- a/game/songparser-xml.cc
+++ b/game/songparser-xml.cc
@@ -89,6 +89,7 @@ void SongParser::xmlParseHeader() {
 	std::string singers;  // Only used for "Together" track
 	xmlpp::const_NodeSet tracks;
 	dom.find("/ss:MELODY/ss:TRACK", tracks);
+	if (!m_song.vocalTracks.empty()) { m_song.vocalTracks.clear(); }
 	for (auto const& elem: tracks) {
 		auto const& trackNode = dynamic_cast<xmlpp::Element const&>(*elem);
 		std::string name = trackNode.get_attribute("Name")->get_value();  // "Player1" or "Player2"

--- a/game/songparser.cc
+++ b/game/songparser.cc
@@ -87,8 +87,8 @@ SongParser::SongParser(Song& s): m_song(s) {
 		}
 
 		// Default for preview position if none was specified in header
-		if (s.preview_start != s.preview_start) {
-			s.preview_start = (type == INI ? 5.0 : 30.0);  // 5 s for band mode, 30 s for others
+		if (std::isnan(s.preview_start)) {
+			s.preview_start = ((type == INI || s.getDurationSeconds() < 50.0) ? 5.0 : 30.0);  // 5 s for band mode, 30 s for others
 		}
 		guessFiles();
 		if (!m_song.midifilename.empty()) {midParseHeader(); }

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -172,6 +172,26 @@ void Songs::CacheSonglist() {
     	if(!std::isnan(duration)) {
 	    	songObject["Duration"] = web::json::value(duration);
 	    }
+
+		// Cache songtype also.
+		if(song->hasVocals()) {
+			uint32_t vocals = song->vocalTracks.size();
+        	songObject["VocalTracks"] = web::json::value::number(vocals);
+    	}
+		if(song->hasKeyboard()) {
+        	songObject["KeyboardTracks"] = web::json::value::number(1);
+    	}
+		if(song->hasDrums()) {
+        	songObject["DrumTracks"] = web::json::value::number(1);
+    	}
+		if(song->hasDance()) {
+			uint32_t dance = song->danceTracks.size();
+        	songObject["DanceTracks"] = web::json::value::number(dance);
+    	}
+		if(song->hasGuitars()) {
+			uint32_t guitars = song->instrumentTracks.size() - song->hasDrums() - song->hasKeyboard();
+        	songObject["GuitarTracks"] = web::json::value::number(guitars);
+    	}
 	    if(songObject != web::json::value::object()) {
         	jsonRoot[i] = songObject;
         	i++;

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -293,14 +293,16 @@ void Songs::filter_internal() {
 			icu::UnicodeString filter = ((charset == "UTF-8") ? icu::UnicodeString::fromUTF8(m_filter) : icu::UnicodeString(m_filter.c_str(), charset.c_str()));
 			UErrorCode icuError = U_ZERO_ERROR;
 			std::copy_if (m_songs.begin(), m_songs.end(), std::back_inserter(filtered), [&](std::shared_ptr<Song> it){
-			icu::StringSearch search = icu::StringSearch(filter, icu::UnicodeString::fromUTF8((*it).strFull()), &UnicodeUtil::m_dummyCollator, nullptr, icuError);
 				if (m_type == 1 && !(*it).hasDance()) return false;
 				if (m_type == 2 && !(*it).hasVocals()) return false;
 				if (m_type == 3 && !(*it).hasDuet()) return false;
 				if (m_type == 4 && !(*it).hasGuitars()) return false;
 				if (m_type == 5 && !(*it).hasDrums() && !(*it).hasKeyboard()) return false;
 				if (m_type == 6 && (!(*it).hasVocals() || !(*it).hasGuitars() || (!(*it).hasDrums() && !(*it).hasKeyboard()))) return false;
-				return (search.first(icuError) != USEARCH_DONE);
+				if (!m_filter.empty()) {
+					icu::StringSearch search = icu::StringSearch(filter, icu::UnicodeString::fromUTF8((*it).strFull()), &UnicodeUtil::m_dummyCollator, nullptr, icuError);
+					return (search.first(icuError) != USEARCH_DONE);
+					}
 			});
 		}
 		m_filtered.swap(filtered);


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/performous/performous/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

- Adds some extra commenting to the filter code, makes sure the search is only even attempted if the search term is not empty and fixes the type filter issue #432 by providing an extra return and storing some extra info on the song cache.
- Also, fixes previews on short songs by previewing at 5 seconds if the song is shorter than 50 seconds in total.
- In a related matter, changes that harebrained NaN comparison to something better. Incidentally, what we were doing is not incorrect (in fact it's mentioned on cppreference as a possible implementation for `is_nan()`. Still, it was pretty hard to read.

<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

#432 
#439 

<!-- List here all the issues closed by this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
