### PR TITLE
Fixes the maximize / fullscreen bug

### DIFF
--- a/game/video_driver.cc
+++ b/game/video_driver.cc
@@ -96,7 +96,6 @@ Window::Window() {
 	createShaders();
 	resize();
 	SDL_ShowWindow(screen);
-	m_fullscreen = config["graphic/fullscreen"].b();
 }
 
 void Window::createShaders() {
@@ -339,14 +338,22 @@ void Window::swap() {
 void Window::event(Uint8 const& eventID) {
 	switch (eventID) {
 		case SDL_WINDOWEVENT_MAXIMIZED:
-			[[fallthrough]];
+			if (Platform::currentOS() == Platform::macos) {
+				config["graphic/fullscreen"].b() = true;
+				}
+			else { m_needResize = true; }
+			break;	
 		case SDL_WINDOWEVENT_RESTORED:
-			[[fallthrough]];
-		case SDL_WINDOWEVENT_RESIZED:
-			[[fallthrough]];
+			if (Platform::currentOS() == Platform::macos) {
+				config["graphic/fullscreen"].b() = false;
+				}
+			else { m_needResize = true; }
+			break;	
 		case SDL_WINDOWEVENT_SHOWN:
 			[[fallthrough]];
 		case SDL_WINDOWEVENT_SIZE_CHANGED:
+			[[fallthrough]];
+		case SDL_WINDOWEVENT_RESIZED:
 			m_needResize = true;
 			break;
 		default: break;

--- a/game/video_driver.cc
+++ b/game/video_driver.cc
@@ -96,7 +96,7 @@ Window::Window() {
 	createShaders();
 	resize();
 	SDL_ShowWindow(screen);
-	m_fullscreen = !config["graphic/fullscreen"].b();
+	m_fullscreen = config["graphic/fullscreen"].b();
 }
 
 void Window::createShaders() {
@@ -339,11 +339,9 @@ void Window::swap() {
 void Window::event(Uint8 const& eventID) {
 	switch (eventID) {
 		case SDL_WINDOWEVENT_MAXIMIZED:
-			config["graphic/fullscreen"].b() = true;
-			break;	
+			[[fallthrough]];
 		case SDL_WINDOWEVENT_RESTORED:
-			config["graphic/fullscreen"].b() = false;
-			break;	
+			[[fallthrough]];
 		case SDL_WINDOWEVENT_RESIZED:
 			[[fallthrough]];
 		case SDL_WINDOWEVENT_SHOWN:


### PR DESCRIPTION
### What does this PR do?
It restores the way maximize window was intended: to maximize a screen.

### Closes Issue(s)
* Closes #420 
* Fixes the issue with minimizing performous when another program is used on another screen

### Motivation
At the last few events i always had to go back to a previous commit to restore the feature that i can use performous on another screen and use a browser on my main laptop. Since performous otherwise would just minimize the application.