### PR TITLE
Feature - Open on last window position

### DIFF
--- a/data/config/schema.xml
+++ b/data/config/schema.xml
@@ -217,6 +217,18 @@ to save the current settings to XML.
 		<short>Windowed height</short>
 		<long>The height of the window.</long>
 	</entry>
+	<entry name="graphic/window_pos_x" type="int" value="0" hidden="true">
+		<ui unit=" pixels" />
+		<limits min="0" max="65000" step="256" />
+		<short>X-Position of the window</short>
+		<long>The X-Position of the window.</long>
+	</entry>
+	<entry name="graphic/window_pos_y" type="int" value="0" hidden="true">
+		<ui unit=" pixels" />
+		<limits min="0" max="65000" step="256" />
+		<short>Y-Position of the window</short>
+		<long>The Y-Position of the window.</long>
+	</entry>
 	<entry name="graphic/highdpi" type="bool" value="true">
 		<short>High DPI Graphics</short>
 		<long>Enable High-DPI (Retina) graphics when supported; requires restart.</long>

--- a/game/main.cc
+++ b/game/main.cc
@@ -77,7 +77,7 @@ static void checkEvents(Game& gm, Time eventTime) {
 		// Let the navigation system grab any and all SDL events
 		gm.controllers.pushEvent(event, eventTime);
 		auto type = event.type;
-		if (type == SDL_WINDOWEVENT) window.event(event.window.event);
+		if (type == SDL_WINDOWEVENT) window.event(event.window.event, event.window.data1, event.window.data2);
 		if (type == SDL_QUIT) gm.finished();
 		if (type == SDL_KEYDOWN) {
 			auto key  = event.key.keysym.scancode;

--- a/game/video_driver.cc
+++ b/game/video_driver.cc
@@ -75,8 +75,10 @@ Window::Window() {
 		else { SDL_SetHintWithPriority("SDL_HINT_VIDEO_HIGHDPI_DISABLED", "1", SDL_HINT_OVERRIDE); }
 		int width = config["graphic/window_width"].i();
 		int height = config["graphic/window_height"].i();
-		std::clog << "video/info: Create window " << width << "x" << height << std::endl;
-		screen = SDL_CreateWindow(PACKAGE " " VERSION, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, flags);
+		int windowPosX = config["graphic/window_pos_x"].i();
+		int windowPosY = config["graphic/window_pos_y"].i();
+		std::clog << "video/info: Create window dimensions: " << width << "x" << height << " on screen position: " << windowPosX << "x" << windowPosY << std::endl;
+		screen = SDL_CreateWindow(PACKAGE " " VERSION, windowPosX, windowPosY, width, height, flags);
 		if (!screen) throw std::runtime_error(std::string("SDL_SetVideoMode failed: ") + SDL_GetError());
 		SDL_GL_CreateContext(screen);
 		glutil::GLErrorChecker error("Initializing buffers");
@@ -335,8 +337,11 @@ void Window::swap() {
 	SDL_GL_SwapWindow(screen);
 }
 
-void Window::event(Uint8 const& eventID) {
+void Window::event(Uint8 const& eventID, Sint32 const& data1, Sint32 const& data2) {
 	switch (eventID) {
+		case SDL_WINDOWEVENT_MOVED:
+			setWindowPosition(data1, data2);
+			break;
 		case SDL_WINDOWEVENT_MAXIMIZED:
 			if (Platform::currentOS() == Platform::macos) {
 				config["graphic/fullscreen"].b() = true;
@@ -357,7 +362,13 @@ void Window::event(Uint8 const& eventID) {
 			m_needResize = true;
 			break;
 		default: break;
-	}	
+	}
+}
+
+void Window::setWindowPosition(const Sint32& x, const Sint32& y)
+{
+	config["graphic/window_pos_x"].i() = x;
+	config["graphic/window_pos_y"].i() = y;
 }
 
 FBO& Window::getFBO() {

--- a/game/video_driver.hh
+++ b/game/video_driver.hh
@@ -67,7 +67,7 @@ public:
 	/// swaps buffers
 	void swap();
 	/// Handle window events
-	void event(Uint8 const& eventID);
+	void event(Uint8 const& eventID, Sint32 const& data1, Sint32 const& data2);
 	/// Resize window (contents) / toggle full screen according to config. Returns true if resized.
 	void resize();
 	/// take a screenshot
@@ -101,6 +101,7 @@ private:
 	const GLuint vertTexCoord = 1;
 	const GLuint vertNormal = 2;
 	const GLuint vertColor = 3;
+	void setWindowPosition(const Sint32& x, const Sint32& y);
 	void setFullscreen();
 	/// Setup everything for drawing a view.
 	/// @param num 0 = no stereo, 1 = left eye, 2 = right eye


### PR DESCRIPTION
### What does this PR do?
This makes performous open at one specific coordinate.
It can be configured through the `config.xml` and the value will auto-update when the window of performous is moved. This especially is neat when having 2 or more screens.
Once the coordinate is bigger upon loading performous than the screen it'll default back to the screen which is attached.

### Motivation
To see a program open up on a place you exited is so much more userfriendly.
