### PR TITLE
Fixes - default songfolders

### DIFF
--- a/data/config/schema.xml
+++ b/data/config/schema.xml
@@ -349,21 +349,29 @@ to save the current settings to XML.
 	</entry>
 
 	<!-- Paths -->
-	<entry name="paths/songs" type="string_list">
+	<entry name="paths/songs" type="string_list" hidden="false">
+		<short>Song folders</short>
+		<long>Where to recursively look for songs. DATADIR at the beginning means all Performous data folders.</long>
+	</entry>
+	<entry name="paths/showhiddenfolders" type="bool" value="false">
+		<short>Show hidden folders</short>
+		<long>When true the screen_paths will also show hidden folders</long>
+	</entry>
+	<entry name="paths/system" type="string_list">
 		<stringvalue>DATADIR/songs/</stringvalue>
 		<stringvalue>/usr/local/share/games/ultrastar/songs/</stringvalue>
 		<stringvalue>/usr/local/share/games/fretsonfire/data/songs/</stringvalue>
 		<stringvalue>/usr/share/games/ultrastar/songs/</stringvalue>
 		<stringvalue>/usr/share/games/fretsonfire/data/songs/</stringvalue>
 		<stringvalue>~/.ultrastar/songs/</stringvalue>
-		<short>Song folders</short>
-		<long>Where to recursively look for songs. DATADIR at the beginning means all Performous data folders.</long>
-	</entry>
-	<entry name="paths/showhiddenfolders" type="bool" value = "false">
-		<short>Show hidden folders</short>
-		<long>When true the screen_paths will also show hidden folders</long>
-	</entry>
-	<entry name="paths/system" type="string_list">
+		<stringvalue>/usr/local/share/performous/songs</stringvalue>
+		<stringvalue>/usr/share/performous/songs</stringvalue>
+		<stringvalue>~/.local/share/games/performous</stringvalue>
+		<stringvalue>~/.local/share/performous</stringvalue>
+		<stringvalue>%USERPROFILE%\AppData\Roaming\performous</stringvalue>
+		<stringvalue>~\AppData\Roaming\performous</stringvalue>
+		<stringvalue>%HOMEDRIVE%%HOMEPATH%\Application Data\performous</stringvalue>
+		<stringvalue>~\Application Data\performous</stringvalue>
 		<short>Base folders for data</short>
 		<long>System defaults are included automatically. Additional paths can be added here.</long>
 	</entry>

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -96,17 +96,18 @@ void Songs::LoadCache() {
     	return;
     }
 
-    auto stringList = config["paths/songs"].sl();
-
+	auto systemSongs = config["paths/system"].sl();
+    auto userSongs = config["paths/songs"].sl();
+	userSongs.insert(userSongs.begin(), systemSongs.begin(), systemSongs.end());
     for(auto const& song : jsonRoot.as_array()) {
     	struct stat buffer;
     	auto songPath = song.at("TxtFile").as_string();
     	auto isSongPathInConfiguredPaths = std::find_if(
-                                                        stringList.begin(), 
-                                                        stringList.end(), 
-														[songPath](const std::string& stringListItem) { 
-															return songPath.find(stringListItem) != std::string::npos;
-														 }) != stringList.end();
+                                                        userSongs.begin(), 
+                                                        userSongs.end(), 
+														[songPath](const std::string& userSongItem) { 
+															return songPath.find(userSongItem) != std::string::npos;
+														 }) != userSongs.end();
     	if(_STAT(songPath.c_str(), &buffer) == 0 && isSongPathInConfiguredPaths) {
     		std::shared_ptr<Song> realSong(new Song(song));
     		m_songs.push_back(realSong);


### PR DESCRIPTION
### What does this PR do?
Moved system song paths to the correct section in config: `paths/system`
Concats both user and system songs into one vector
Uses the concatted vector to check the song cache.

### Closes Issue(s)
* Closes #433 

### Motivation
Default folders should always be included.