### PR TITLE
Fix build and harfbuzz detection with newer pango > 1.44.7

### DIFF
--- a/cmake/Modules/FindHarfbuzz.cmake
+++ b/cmake/Modules/FindHarfbuzz.cmake
@@ -1,0 +1,27 @@
+# - Try to find Harfbuzz
+# Once done, this will define
+#
+#  Harfbuzz_FOUND - system has Harfbuzz
+#  Harfbuzz_INCLUDE_DIRS - the Harfbuzz include directories
+#  Harfbuzz_LIBRARIES - link these to use Harfbuzz
+
+include(LibFindMacros)
+
+# Use pkg-config to get hints about paths
+libfind_pkg_check_modules(Harfbuzz_PKGCONF harfbuzz)
+
+# Include dir
+find_path(Harfbuzz_INCLUDE_DIR
+  NAMES harfbuzz/hb.h
+  HINTS ${Harfbuzz_PKGCONF_INCLUDE_DIRS}
+  PATH_SUFFIXES harfbuzz
+)
+
+# Finally the library itself
+find_library(Harfbuzz_LIBRARY
+  NAMES harfbuzz
+  HINTS ${Harfbuzz_PKGCONF_LIBRARY_DIRS}
+)
+
+libfind_process(Harfbuzz)
+

--- a/cmake/Modules/FindPango.cmake
+++ b/cmake/Modules/FindPango.cmake
@@ -8,6 +8,7 @@
 include(LibFindMacros)
 
 # Dependencies
+libfind_package(Pango Harfbuzz)
 libfind_package(Pango Freetype)
 libfind_package(Pango Glib)
 libfind_package(Pango GObject)

--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -86,6 +86,7 @@ foreach(lib ${OUR_LIBS} SDL2 PangoCairo LibRSVG LibXML++ AVFormat SWResample SWS
 	find_package(${lib} REQUIRED)
 	message(STATUS "${lib} includes: ${${lib}_INCLUDE_DIRS}")
 	include_directories(${${lib}_INCLUDE_DIRS})
+	include_directories(${${lib}_PKGCONF_INCLUDE_DIRS})
 	list(APPEND LIBS ${${lib}_LIBRARIES})
 	add_definitions(${${lib}_DEFINITIONS})
 endforeach(lib)


### PR DESCRIPTION
Example error log in Ubuntu:
cd /build/performous-1.1+git20181118/obj-x86_64-linux-gnu/game && /usr/bin/c++  -DBOOST_ALL_NO_LIB -DBOOST_ATOMIC_DYN_LINK -DBOOST_CHRONO_DYN_LINK -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_IOSTREAMS_DYN_LINK -DBOOST_LOCALE_DYN_LINK -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_SYSTEM_DYN_LINK -DBOOST_THREAD_DYN_LINK -DUSE_PORTMIDI -DUSE_WEBSERVER -I/build/performous-1.1+git20181118/ced -I/usr/include/x86_64-linux-gnu/SDL2 -I/usr/include/pango-1.0 -I/usr/include/cairo -I/usr/include/freetype2 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/librsvg-2.0 -I/usr/include/gdk-pixbuf-2.0 -I/usr/lib/x86_64-linux-gnu/libxml++-2.6/include -I/usr/include/libxml++-2.6 -I/usr/include/libxml2 -I/usr/lib/x86_64-linux-gnu/glibmm-2.4/include -I/usr/include/glibmm-2.4 -I/usr/include/sigc++-2.0 -I/usr/lib/x86_64-linux-gnu/sigc++-2.0/include -I/usr/include/cpprest -I/build/performous-1.1+git20181118/obj-x86_64-linux-gnu/game  -DBOOST_NO_CXX11_SCOPED_ENUMS -std=c++14 -Wall -Wextra -fcx-limited-range -g -O2 -fdebug-prefix-map=/build/performous-1.1+git20181118=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -pthread   -o CMakeFiles/performous.dir/configuration.cc.o -c /build/performous-1.1+git20181118/game/configuration.cc
In file included from /usr/include/pango-1.0/pango/pango-font.h:25,
                 from /usr/include/pango-1.0/pango/pango-attributes.h:25,
                 from /usr/include/pango-1.0/pango/pango.h:25,
                 from /usr/include/pango-1.0/pango/pangocairo.h:25,
                 from /build/performous-1.1+git20181118/game/opengl_text.hh:6,
                 from /build/performous-1.1+git20181118/game/menu.hh:3,
                 from /build/performous-1.1+git20181118/game/screen_intro.hh:4,
                 from /build/performous-1.1+git20181118/game/configuration.cc:8:
/usr/include/pango-1.0/pango/pango-coverage.h:28:10: fatal error: hb.h: No such file or directory
   28 | #include <hb.h>
      |          ^~~~~~
compilation terminated.
make[3]: *** [game/CMakeFiles/performous.dir/build.make:131: game/CMakeFiles/performous.dir/configuration.cc.o] Error 1
make[3]: *** Waiting for unfinished jobs....
[ 52%] Linking CXX executable ss_extract

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/performous/performous/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

<!-- List here all the issues closed by this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
