### PR TITLE
Workaround failing regex on FC30

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,11 @@ if(CMAKE_BUILD_TYPE STREQUAL "Release")
 	add_definitions("-DNDEBUG")
 endif()
 
+if (USE_BOOST_REGEX)
+        add_definitions(-DUSE_BOOST_REGEX)
+endif()
+
+
 # Enable C++14 support and other compiler flags...
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 	execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)

--- a/game/backgrounds.cc
+++ b/game/backgrounds.cc
@@ -7,7 +7,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <random>
-#include <regex>
+#include "regex.hh"
 
 void Backgrounds::reload() {
 	if (m_loading) return;
@@ -47,7 +47,7 @@ void Backgrounds::reload_internal(fs::path const& parent) {
 	if (std::distance(parent.begin(), parent.end()) > 20) { std::clog << "backgrounds/info: >>> Not scanning: " << parent.string() << " (maximum depth reached, possibly due to cyclic symlinks)" << std::endl; return; }
 	try {
 		// Find suitable file formats
-		std::regex expression(R"(\.(png|jpeg|jpg|svg)$)", std::regex_constants::icase);
+		regex expression(R"(\.(png|jpeg|jpg|svg)$)", regex_constants::icase);
 		for (fs::directory_iterator dirIt(parent), dirEnd; m_loading && dirIt != dirEnd; ++dirIt) {
 			fs::path p = dirIt->path();
 			if (fs::is_directory(p)) { reload_internal(p); continue; }

--- a/game/controllers-midi.cc
+++ b/game/controllers-midi.cc
@@ -1,9 +1,9 @@
 #ifdef USE_PORTMIDI
 
 #include "controllers.hh"
-#include "portmidi.hh"
 #include "fs.hh"
-#include <regex>
+#include "portmidi.hh"
+#include "regex.hh"
 #include <unordered_map>
 
 namespace input {
@@ -11,7 +11,7 @@ namespace input {
 	class Midi: public Hardware {
 	public:
 		Midi() {
-			std::regex re(config["game/midi_input"].s());
+			regex re(config["game/midi_input"].s());
 			for (int dev = 0; dev < Pm_CountDevices(); ++dev) {
 				try {
 					PmDeviceInfo const* info = Pm_GetDeviceInfo(dev);

--- a/game/controllers.cc
+++ b/game/controllers.cc
@@ -6,8 +6,9 @@
 #include "unicode.hh"
 #include <boost/filesystem.hpp>
 #include <SDL2/SDL_joystick.h>
+#include "regex.hh"
+
 #include <deque>
-#include <regex>
 #include <stdexcept>
 #include <algorithm>
 
@@ -101,7 +102,7 @@ struct ControllerDef {
 	SourceType sourceType;
 	DevType devType;
 	double latency;
-	std::regex deviceRegex;
+	regex deviceRegex;
 	MinMax<unsigned> deviceMinMax;
 	MinMax<unsigned> channelMinMax;
 	ButtonMapping mapping;

--- a/game/libda/portaudio.hpp
+++ b/game/libda/portaudio.hpp
@@ -10,7 +10,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <future>
-#include <regex>
+#include "../regex.hh"
 #include <set>
 #include <stdexcept>
 
@@ -92,7 +92,7 @@ namespace portaudio {
 					{ " \\(.*\\)", "" },  // Remove the parenthesis part entirely
 				};
 				for (auto const& rep: replacements) {
-					std::string flex = std::regex_replace(dev.flex, std::regex(rep[0]), rep[1]);
+					std::string flex = regex_replace(dev.flex, regex(rep[0]), rep[1]);
 					if (flex == dev.flex) continue;  // Nothing changed
 					// Verify that flex doesn't find any wrong devices
 					bool fail = false;

--- a/game/players.cc
+++ b/game/players.cc
@@ -6,7 +6,7 @@
 #include "libxml++-impl.hh"
 
 #include <algorithm>
-#include <regex>
+#include "regex.hh"
 #include <unicode/stsearch.h>
 
 UErrorCode Players::m_icuError = U_ZERO_ERROR;
@@ -131,7 +131,7 @@ void Players::filter_internal() {
 			});
 		}
 // 		for (auto const& p: m_players) {
-// 			if (regex_search(p.name, std::regex(m_filter, std::regex_constants::icase))) filtered.push_back(p);
+// 			if (regex_search(p.name, regex(m_filter, regex_constants::icase))) filtered.push_back(p);
 // 		}
 		m_filtered.swap(filtered);
 	} catch (...) {

--- a/game/regex.hh
+++ b/game/regex.hh
@@ -1,0 +1,16 @@
+
+#pragma once
+
+// Note: One could expect to have boost regex removed, but for some obscure
+// reason, std::regex code crash on Fedora 30 (see bug #476). Thus, until FC is
+// fixed or deprecated, may be eeded to keep this for a little while
+
+#ifdef USE_BOOST_REGEX
+#include <boost/regex.hpp>
+using regex = boost::regex;
+namespace regex_constants = boost::regex_constants;
+#else
+#include <regex>
+using regex = std::regex;
+namespace regex_constants = std::regex_constants;
+#endif

--- a/game/songparser.cc
+++ b/game/songparser.cc
@@ -1,8 +1,8 @@
 #include "songparser.hh"
+#include "regex.hh"
 
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem/fstream.hpp>
-#include <regex>
 
 
 namespace SongParserUtil {
@@ -128,7 +128,7 @@ void SongParser::guessFiles () {
 	std::string logMissing, logFound;
 
 	// Run checks, remove bogus values and construct regexps
-	std::vector<std::regex> regexps;
+	std::vector<regex> regexps;
 	bool missing = false;
 	for (auto const& p : fields) {
 		fs::path& file = *p.first;
@@ -137,7 +137,7 @@ void SongParser::guessFiles () {
 			file.clear();
 		}
 		if (file.empty()) { missing = true; }
-		regexps.emplace_back (p.second, std::regex_constants::icase);
+		regexps.emplace_back (p.second, regex_constants::icase);
 	}
 	
 	if (!missing) {

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -13,7 +13,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <iostream>
-#include <regex>
+#include "regex.hh"
 #include <stdexcept>
 
 #include <boost/filesystem.hpp>
@@ -233,7 +233,7 @@ void Songs::CacheSonglist() { }
 void Songs::reload_internal(fs::path const& parent) {
 	if (std::distance(parent.begin(), parent.end()) > 20) { std::clog << "songs/info: >>> Not scanning: " << parent.string() << " (maximum depth reached, possibly due to cyclic symlinks)\n"; return; }
 	try {
-		std::regex expression(R"((\.txt|^song\.ini|^notes\.xml|\.sm)$)", std::regex_constants::icase);
+		regex expression(R"((\.txt|^song\.ini|^notes\.xml|\.sm)$)", regex_constants::icase);
 		for (fs::directory_iterator dirIt(parent), dirEnd; m_loading && dirIt != dirEnd; ++dirIt) { //loop through files
 			fs::path p = dirIt->path();
 			if (fs::is_directory(p)) { reload_internal(p); continue; } //if the file is a folder redo this function with this folder as path

--- a/game/unicode.cc
+++ b/game/unicode.cc
@@ -1,7 +1,7 @@
 #include "unicode.hh"
 
 #include "configuration.hh"
-#include <regex>
+#include "regex.hh"
 #include <sstream>
 #include <stdexcept>
 #include <unicode/unistr.h>
@@ -102,8 +102,8 @@ void UnicodeUtil::collate (songMetadata& stringmap) {
 				pattern += std::string(")\\s(.+))$");
 			}
 		}
-		std::string collatedString = std::regex_replace(convertToUTF8(kv.second),
-		std::regex(pattern, std::regex_constants::icase), "$3,$2");
+		std::string collatedString = regex_replace(convertToUTF8(kv.second),
+		regex(pattern, regex_constants::icase), "$3,$2");
 		stringmap[kv.first] = collatedString;
 	}
 }


### PR DESCRIPTION
Allows to select c++11 regex or boost on cmake invocation.

to enable at build do:
cmake -DUSE_BOOST_REGEX=true ../performous/dir/

default behaviour (without setting USE_BOOST_REGEX) is to use std::regex

This is mainly a workaround for bug #476

