### PR TITLE
consolidate submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ced"]
 	path = 3rdparty/ced
-	url = ./compact_enc_det
+	url = ../compact_enc_det
 [submodule "3rdparty/aubio"]
 	path = 3rdparty/aubio
-	url = ./aubio
+	url = ../aubio

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ced"]
-	path = ced
-	url = https://github.com/performous/compact_enc_det
+	path = 3rdparty/ced
+	url = ./compact_enc_det
 [submodule "3rdparty/aubio"]
 	path = 3rdparty/aubio
-	url = git@github.com:performous/aubio.git
+	url = ./aubio

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ else()
 	message(STATUS "Localization disabled: Gettext tools (msgfmt) missing")
 endif()
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/ced)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/ced)
 
 if (APPLE)
 	set_property(GLOBAL PROPERTY BLA_VENDOR APPLE)
@@ -114,7 +114,7 @@ ExternalProject_Get_Property(aubio INSTALL_DIR)
 set (AUBIO_INSTALL_DIR ${INSTALL_DIR})
 
 add_subdirectory(game)
-add_subdirectory(ced)
+add_subdirectory(3rdparty/ced)
 add_subdirectory(docs)
 
 if(WIN32)


### PR DESCRIPTION
# What does this PR do?

Makes the submodules be listed the same and moved to the 3rdparty folder.
Submodules are now pulled/updated the way you cloned the repo.
So if you cloned the repo with SSH the submodules will also be pulled by SSH
and if you cloned the repo with https the submodules will also be pulled by https

### Closes Issue(s)

Closes #461 
### Motivation

The lack of structure was bothering me.