### PR TITLE
Added the ease of a uninstall target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,15 +128,17 @@ if(WIN32)
 	install(FILES win32/ConfigureSongDirectory.bat DESTINATION .)
 endif()
 
-# uninstall target
-if(NOT TARGET uninstall)
-  configure_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/uninstall.cmake.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/cmake/uninstall.cmake"
-    IMMEDIATE @ONLY)
+if(NOT APPLE)
+  # uninstall target
+  if(NOT TARGET uninstall)
+    configure_file(
+      "${CMAKE_CURRENT_SOURCE_DIR}/cmake/uninstall.cmake.in"
+      "${CMAKE_CURRENT_BINARY_DIR}/cmake/uninstall.cmake"
+      IMMEDIATE @ONLY)
 
-  add_custom_target(uninstall
-    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake/uninstall.cmake)
+    add_custom_target(uninstall
+      COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake/uninstall.cmake)
+  endif()
 endif()
 
 #CPACK variables

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,17 @@ if(WIN32)
 	install(FILES win32/ConfigureSongDirectory.bat DESTINATION .)
 endif()
 
+# uninstall target
+if(NOT TARGET uninstall)
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/uninstall.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/uninstall.cmake"
+    IMMEDIATE @ONLY)
+
+  add_custom_target(uninstall
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake/uninstall.cmake)
+endif()
+
 #CPACK variables
 include(CPack)
 SET(CPACK_DEBIAN_PACKAGE_MAINTAINER "Niek Nooijens")

--- a/cmake/uninstall.cmake.in
+++ b/cmake/uninstall.cmake.in
@@ -1,0 +1,33 @@
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif()
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif()
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif()
+endforeach()
+
+if(IS_SYMLINK "@CMAKE_INSTALL_PREFIX@/@SHARE_INSTALL@" OR EXISTS "@CMAKE_INSTALL_PREFIX@/@SHARE_INSTALL@")
+  message(STATUS "Uninstalling directory and all empty folders: @CMAKE_INSTALL_PREFIX@/@SHARE_INSTALL@")
+  exec_program(
+    "@CMAKE_COMMAND@" ARGS "-E remove_directory \"@CMAKE_INSTALL_PREFIX@/@SHARE_INSTALL@\""
+    OUTPUT_VARIABLE rm_out
+    RETURN_VALUE rm_retval
+    )
+  if(NOT "${rm_retval}" STREQUAL 0)
+    message(FATAL_ERROR "Problem when removing @CMAKE_INSTALL_PREFIX@/@SHARE_INSTALL@")
+  endif()
+endif()


### PR DESCRIPTION
### What does this PR do?

Added a cmake uninstall target.
Aside from deleting all files, it also remove the directory and all empty directories within
```
$CMAKE_INSTALL_PREFIX/$SHARE_INSTALL
```
This folder should be the location where performous keeps all his data. On unix systems it's:
`/usr/local/share/games/performous/*`

### Closes Issue(s)

None

### Motivation

I always look for how to remove an opensource project completely from my pc. Sadly many projects which i install with cmake don't have a specific target for uninstalling. That's why i'd love performous to have one; For the ease of uninstalling.

Yes i'm aware you can also just remove all the files listed in `install_manifest.txt` using 
```
cat install_manifest.txt | sudo xargs rm
```
But still having a target makes it just plain simple to execute.
Also does the `cat` command **not** clean up the left over directories, **which this target does.**

### Notes

Followed this tutorial: https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#can-i-do-make-uninstall-with-cmake