### PR TITLE
Singing: Fix long lyric phrases going off-screen.

### DIFF
--- a/game/opengl_text.cc
+++ b/game/opengl_text.cc
@@ -261,14 +261,14 @@ void SvgTxtTheme::draw(std::vector<TZoomText>& _text, bool lyrics) {
 	}
 
 	double texture_ar = text_x / text_y;
-	m_texture_width = std::min(0.96, text_x / targetWidth); // targetWidth is defined in video_driver.cc, it's the base rendering width, used to project the svg onto a gltexture. currently we're targeting 1366x768 as base resolution.
+	m_texture_width = std::min(lyrics ? 0.864 : 0.96, text_x / targetWidth); // targetWidth is defined in video_driver.cc, it's the base rendering width, used to project the svg onto a gltexture. currently we're targeting 1366x768 as base resolution.
 	
 	double position_x = dimensions.x1();
-	if (m_align == CENTER) position_x -= 0.5 * m_texture_width;
+	if (m_align == CENTER) position_x -= 0.5 * (m_texture_width * (lyrics ? 1.1 : 1.0));
 	if (m_align == RIGHT) position_x -= m_texture_width;
 
-	if ((position_x + m_texture_width) > 0.48) { 
-		m_texture_width = (0.48 - position_x);
+	if ((position_x + m_texture_width * (lyrics ? 1.1 : 1.0)) > (lyrics ? 0.432 : 0.48)) { 
+		m_texture_width = ((lyrics ? 0.432 : 0.48) - position_x / (lyrics ? 1.1 : 1.0)) ;
 	}
 	m_texture_height = m_texture_width / texture_ar; // Keep aspect ratio.
 	for (size_t i = 0; i < _text.size(); i++) {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/performous/performous/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

Fix a bug in my calculations that resulted in long lyrical phrases going off the screen. Now I'm accounting for their expected enlargement when being sung.

<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

<!-- List here all the issues closed by this pull request. -->

### Motivation

Been meaning to fix this for a while but had forgotten.

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated documentation

### Additional Notes

Related to #411; still might be worth checking in the spacing that was bothering @Tronic. To be clear, I don't really intend to change it at least for asian mode, but I haven't really tried the other mode in ages so I'm open to being convinced. 

<!-- Anything else we should know when reviewing? -->
