### PR TITLE
Fix some leaks

### DIFF
--- a/game/glshader.cc
+++ b/game/glshader.cc
@@ -162,6 +162,11 @@ Shader& Shader::link() {
 
 	// Link and check status
 	glLinkProgram(program);
+
+	// always detach shaders, linked or not, they need to be detached
+	for (auto id : shader_ids)
+		glDetachShader(program, id);
+
 	glGetProgramiv(program, GL_LINK_STATUS, &gl_response);
 	dumpInfoLog(program);
 	if (gl_response != GL_TRUE) {

--- a/game/glshader.cc
+++ b/game/glshader.cc
@@ -156,16 +156,14 @@ Shader& Shader::link() {
 		throw std::runtime_error("Couldn't create shader program.");
 	}
 	// Attach all compiled shaders to it
-	for (ShaderObjects::const_iterator it = shader_ids.begin(); it != shader_ids.end(); ++it)
-		glAttachShader(program, *it);
+	for (auto id : shader_ids) glAttachShader(program, id);
 	ec.check("glAttachShader");
 
 	// Link and check status
 	glLinkProgram(program);
 
 	// always detach shaders, linked or not, they need to be detached
-	for (auto id : shader_ids)
-		glDetachShader(program, id);
+	for (auto id : shader_ids) glDetachShader(program, id);
 
 	glGetProgramiv(program, GL_LINK_STATUS, &gl_response);
 	dumpInfoLog(program);

--- a/game/glutil.cc
+++ b/game/glutil.cc
@@ -13,19 +13,8 @@ namespace glutil {
 		return result;
 	}
 		
-	VertexArray::VertexArray() {
-		glGenVertexArrays(1, &m_vao);
-		glGenBuffers(1, &m_vbo);
-	}
-
-	VertexArray::~VertexArray() {
-		clear();
-	}
-
 	void VertexArray::clear() {
 		m_vertices.clear();
-		glDeleteVertexArrays(1, &m_vao);
-		glDeleteBuffers(1, &m_vbo);
 	}
 
 	void VertexArray::draw(GLint mode) {

--- a/game/glutil.cc
+++ b/game/glutil.cc
@@ -24,6 +24,8 @@ namespace glutil {
 
 	void VertexArray::clear() {
 		m_vertices.clear();
+		glDeleteVertexArrays(1, &m_vao);
+		glDeleteBuffers(1, &m_vbo);
 	}
 
 	void VertexArray::draw(GLint mode) {

--- a/game/glutil.hh
+++ b/game/glutil.hh
@@ -80,11 +80,7 @@ namespace glutil {
 	private:
 		std::vector<VertexInfo> m_vertices;
 		VertexInfo m_vert;
-		GLuint m_vbo = 0, m_vao = 0;
 	public:
-		VertexArray();
-		~VertexArray();
-
 		VertexArray& vertex(float x, float y, float z = 0.0f) {
 			return vertex(glmath::vec3(x, y, z));
 		}

--- a/game/video_driver.hh
+++ b/game/video_driver.hh
@@ -118,9 +118,12 @@ private:
 	std::unique_ptr<FBO> m_fbo;
 	int m_windowX = 0;
 	int m_windowY = 0;
+	std::unique_ptr<SDL_Window, void (*)(SDL_Window*)> screen;
+	std::unique_ptr<std::remove_pointer_t<SDL_GLContext> /* SDL_GLContext is a void* */, void (*)(SDL_GLContext)> glContext;
 	using ShaderMap = std::map<std::string, std::unique_ptr<Shader>>;
+	// Careful, Shaders depends on SDL_Window, thus m_shaders need to be
+	// destroyed before screen (and thus be creater after)
 	ShaderMap m_shaders; ///< Shader programs by name
-	SDL_Window* screen = nullptr;
 	public:
 	FBO& getFBO();
 };


### PR DESCRIPTION
Too many leaks make performous quite unusable after 30minutes...

for instance, just starting a song and exiting the software reports:
before patches:
SUMMARY: AddressSanitizer: 717529669 byte(s) leaked in 333158 allocation(s).
after:
now SUMMARY: AddressSanitizer: 143451 byte(s) leaked in 4998 allocation(s).

So there are actually remaining leaks, mainly reported in libfontconfig, but I cannot figure out how to fix them (documentation is poor, and lib seems to leak anyway...)