### PR TITLE
let game to memorize player's names selection

### DIFF
--- a/game/database.cc
+++ b/game/database.cc
@@ -57,18 +57,21 @@ void Database::addSong(std::shared_ptr<Song> s) {
 
 void Database::addHiscore(std::shared_ptr<Song> s) {
 	int playerid = m_players.lookup(m_players.current().name);
-	int score = scores.front().score;
-	std::string track = scores.front().track;
-	int songid = m_songs.lookup(s);
+	int songid = m_songs.lookup(*s);
+	
+	ScoreItem const& hiscore = scores.front();
+	
+	//just remember, who was selected this playerid
+	playersByDevices[hiscore.player_id] = playerid;
 
-	m_hiscores.addHiscore(score, playerid, songid, track);
-	std::clog << "database/info: Added new hiscore " << score << " points on track " << track << " of songid " << songid << std::endl;
+	m_hiscores.addHiscore(hiscore.score, playerid, songid, hiscore.track);
+	std::clog << "database/info: Added new hiscore " << hiscore.score << " points on track " << hiscore.track << " of songid " << songid << std::endl;
 }
 
 bool Database::reachedHiscore(std::shared_ptr<Song> s) const {
 	int score = scores.front().score;
 	std::string track = scores.front().track;
-	int songid = m_songs.lookup(s);
+	int songid = m_songs.lookup(*s);
 
 	return m_hiscores.reachedHiscore(score, songid, track);
 }
@@ -85,7 +88,7 @@ void Database::queryOverallHiscore(std::ostream & os, std::string const& track) 
 }
 
 void Database::queryPerSongHiscore(std::ostream & os, std::shared_ptr<Song> s, std::string const& track) const {
-	int songid = m_songs.lookup(s);
+	int songid = m_songs.lookup(*s);
 	if (songid == -1) return;  // Song not included in database (yet)
 	// Reorder hiscores by track / score
 	std::map<std::string, std::multiset<HiscoreItem>> scoresByTrack;

--- a/game/database.hh
+++ b/game/database.hh
@@ -14,6 +14,7 @@ struct ScoreItem {
 	input::DevType type;
 	std::string track;  ///< includes difficulty
 	std::string track_simple; ///< no difficulty
+	std::string player_id; ///< some string to identify player's source device (microphone name or something like it)
 	Color color;
 	bool operator<(ScoreItem const& other) const { return score < other.score; }
 };
@@ -68,11 +69,12 @@ public:
 private: // will be bypassed by above friend declaration
 	typedef std::list<Player> cur_players_t;
 	typedef std::list<ScoreItem> cur_scores_t;
+	typedef std::map <std::string, int> players_devices_t;
 
 	//This fields are misused as additional parameters
 	cur_players_t cur;
 	cur_scores_t scores;
-
+	players_devices_t playersByDevices;
 public: // methods for database management
 
 	/**A facade for Players::addPlayer.*/
@@ -96,7 +98,6 @@ public: // methods for database queries
 	void queryPerPlayerHiscore(std::ostream & os, std::string const& track = std::string()) const;
 
 	bool hasHiscore(Song& s) const;
-	bool noPlayers() const;
 
 private:
 	fs::path m_filename;

--- a/game/player.hh
+++ b/game/player.hh
@@ -9,9 +9,11 @@
 #include <vector>
 #include <utility>
 
+#include <boost/optional.hpp>
+
 class Song;
 
-/// player class
+/// TODO: rename to Vocalist or something like that
 struct Player {
 	/// currently played vocal track
 	VocalTrack& m_vocal;
@@ -43,6 +45,9 @@ struct Player {
 	Notes::const_iterator m_scoreIt;
 	/// constructor
 	Player(VocalTrack& vocal, Analyzer& analyzer, size_t frames);
+
+	std::string const& getId() const { return m_analyzer.getId(); }
+
 	/// prepares analyzer
 	void prepare() { m_analyzer.process(); }
 	/// updates player stats

--- a/game/players.hh
+++ b/game/players.hh
@@ -82,11 +82,21 @@ class Players {
 	/// advances to next player
 	void advance(int diff) {
 		int size = m_filtered.size();
-		if (size == 0) return;  // Do nothing if no songs are available
+		if (size == 0) return;  // Do nothing if no players are available
 		int _current = size ? (int(math_cover.getTarget()) + diff) % size : 0;
 		if (_current < 0) _current += m_filtered.size();
 		math_cover.setTarget(_current,this->size());
 	}
+	/// Advances to player with known ID. Do nothing, if playerId is not present in filtered list.
+	void advanceToId(int playerId) {
+		for (int i = 0; i < m_filtered.size(); ++i) {
+			if (m_filtered[i].id == playerId) {
+				math_cover.setTarget(i, this->size());
+				return;
+			}
+		}
+	}
+
 	/// get current id
 	int currentId() const { return math_cover.getTarget(); }
 	/// gets current position

--- a/game/screen_players.hh
+++ b/game/screen_players.hh
@@ -36,6 +36,8 @@ class ScreenPlayers : public Screen {
 
   private:
 	Texture* loadTextureFromMap(fs::path path);
+	void checkoutNewScore();
+
   	Audio& m_audio;
 	Database& m_database;
 	Players& m_players;

--- a/game/screen_sing.cc
+++ b/game/screen_sing.cc
@@ -685,6 +685,7 @@ ScoreWindow::ScoreWindow(Instruments& instruments, Database& database):
 		item.track = "Vocals"; // For database
 		item.track_simple = "vocals"; // For ScoreWindow
 		item.color = Color(p->m_color.r, p->m_color.g, p->m_color.b);
+		item.player_id = p->getId();
 
 		m_database.scores.push_back(item);
 		++p;
@@ -701,6 +702,7 @@ ScoreWindow::ScoreWindow(Instruments& instruments, Database& database):
 		if (item.track_simple == TrackName::DRUMS) item.color = Color(0.1, 0.1, 0.1);
 		else if (item.track_simple == TrackName::BASS) item.color = Color(0.5, 0.3, 0.1);
 		else item.color = Color(1.0, 0.0, 0.0);
+		item.player_id = item.track_simple; //probably not totally unique, but at least lets to discern some players with their favorite instrument
 
 		m_database.scores.push_back(item);
 		++it;

--- a/game/songitems.cc
+++ b/game/songitems.cc
@@ -50,7 +50,7 @@ int SongItems::addSongItem(std::string const& artist, std::string const& title, 
 }
 
 void SongItems::addSong(std::shared_ptr<Song> song) {
-	int id = lookup(song);
+	int id = lookup(*song);
 	if (id == -1)
 	{
 		id = addSongItem(song->artist, song->title);
@@ -71,14 +71,7 @@ void SongItems::addSong(std::shared_ptr<Song> song) {
 	m_songs.insert(si);
 }
 
-int SongItems::lookup(std::shared_ptr<Song> song) const {
-	for (auto const& s: m_songs) {
-		if (song->collateByArtistOnly == s.artist && song->collateByTitleOnly == s.title) return s.id;
-	}
-	return -1;
-}
-
-int SongItems::lookup(Song& song) const {
+int SongItems::lookup(const Song& song) const {
 	for (auto const& s: m_songs) {
 		if (song.collateByArtistOnly == s.artist && song.collateByTitleOnly == s.title) return s.id;
 	}

--- a/game/songitems.hh
+++ b/game/songitems.hh
@@ -80,8 +80,7 @@ public:
 
 	/**Lookup a songid for a specific song.
 	  @return -1 if no song found.*/
-	int lookup(std::shared_ptr<Song> song) const;
-	int lookup(Song& song) const;
+	int lookup(Song const& song) const;
 
 	/**Lookup the artist + title for a specific song.
 	  @return "Unknown Song" if nothing is found.


### PR DESCRIPTION

### What does this PR do?
matches player controller's name with player name at high scores screen

### Closes Issue(s)
#61 

### Motivation
To save players from routine searching his/her name at names list
Two or more players usually uses their favorite controllers so that game should remember player's name selection for that controller.


### More

- [ ] small refactoring: SongItems::lookup(std::shared_ptr<Song> song) removed because it responsibilities could be taken by SongItems::lookup(Song& song) 

### Additional Notes

<!-- Anything else we should know when reviewing? -->
one of my experimental crafts, not sure is it good way to do so but will be glad to discuss :)
