### PR TITLE
add note type 'R' (rap) and 'G' (golden?)

### DIFF
--- a/game/notegraph.cc
+++ b/game/notegraph.cc
@@ -1,4 +1,4 @@
-#include "notegraph.hh"
+﻿#include "notegraph.hh"
 
 #include "configuration.hh"
 #include "database.hh"
@@ -158,9 +158,13 @@ void NoteGraph::drawNotes() {
 		Texture* t1;
 		Texture* t2;
 		switch (it->type) {
-		  case Note::NORMAL: case Note::SLIDE: t1 = &m_notebar; t2 = &m_notebar_hl; break;
-		  case Note::GOLDEN: t1 = &m_notebargold; t2 = &m_notebargold_hl; break;
-		  case Note::FREESTYLE:  // Freestyle notes use custom handling
+			case Note::NORMAL: case Note::SLIDE: t1 = &m_notebar; t2 = &m_notebar_hl; break;
+			case Note::GOLDEN:
+			case Note::GOLDEN2: //fallthrough
+				t1 = &m_notebargold; t2 = &m_notebargold_hl;
+			break;
+			case Note::FREESTYLE:  // Freestyle notes use custom handling
+			case Note::RAP: //handle RAP notes like freestyle for now
 			{
 				Dimensions dim;
 				dim.middle(m_baseX + 0.5 * (it->begin + it->end) * pixUnit).center(m_baseY + it->note * m_noteUnit).stretch((it->end - it->begin) * pixUnit, -m_noteUnit * 12.0);

--- a/game/notes.cc
+++ b/game/notes.cc
@@ -1,4 +1,4 @@
-#include "notes.hh"
+﻿#include "notes.hh"
 
 #include "util.hh"
 #include <cmath>
@@ -22,10 +22,12 @@ double Note::score(double n, double b, double e) const {
 double Note::scoreMultiplier() const {
 	switch(type) {
 		case GOLDEN:
+		case GOLDEN2:
 			return 2.0;
 		case SLEEP:
 			return 0.0;
 		case FREESTYLE:
+		case RAP:
 		case NORMAL:
 		case SLIDE:
 		case TAP:

--- a/game/notes.hh
+++ b/game/notes.hh
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <map>
 #include <string>
@@ -60,7 +60,7 @@ struct Note {
 	/// which players sung well
 	mutable std::vector<Color> stars;
 	/// note type
-	enum Type { FREESTYLE = 'F', NORMAL = ':', GOLDEN = '*', SLIDE = '+', SLEEP = '-',
+	enum Type { FREESTYLE = 'F', NORMAL = ':', GOLDEN = '*', GOLDEN2 = 'G', SLIDE = '+', SLEEP = '-', RAP = 'R',
 	  TAP = '1', HOLDBEGIN = '2', HOLDEND = '3', ROLL = '4', MINE = 'M', LIFT = 'L'} type;
 	int note; ///< MIDI pitch of the note (at the end for slide notes)
 	int notePrev; ///< MIDI pitch of the previous note (should be same as note for everything but SLIDE)

--- a/game/player.cc
+++ b/game/player.cc
@@ -1,4 +1,4 @@
-#include "player.hh"
+﻿#include "player.hh"
 #include "song.hh"
 #include "engine.hh" // just for Engine::TIMESTEP
 
@@ -51,7 +51,7 @@ void Player::update() {
 		}
 		if (endTime < m_scoreIt->end) break;  // The note continues past this timestep
 		// Check if we got a star
-		if ((m_scoreIt->type == Note::NORMAL || m_scoreIt->type == Note::SLIDE || m_scoreIt->type == Note::GOLDEN)
+		if ((m_scoreIt->type == Note::NORMAL || m_scoreIt->type == Note::SLIDE || m_scoreIt->type == Note::GOLDEN || m_scoreIt->type == Note::GOLDEN2)
 		  && (m_noteScore / m_vocal.m_scoreFactor / m_scoreIt->maxScore() > 0.8)) {
 			m_scoreIt->stars.push_back(m_color);
 		}

--- a/game/screen_intro.cc
+++ b/game/screen_intro.cc
@@ -1,4 +1,4 @@
-#include "screen_intro.hh"
+﻿#include "screen_intro.hh"
 
 #include "fs.hh"
 #include "glmath.hh"
@@ -9,7 +9,7 @@
 #include "theme.hh"
 #include "menu.hh"
 
-#include <SDL_timer.h>
+#include <SDL2/SDL_timer.h>
 
 ScreenIntro::ScreenIntro(std::string const& name, Audio& audio): Screen(name), m_audio(audio), m_first(true) {
 }

--- a/game/songparser-txt.cc
+++ b/game/songparser-txt.cc
@@ -1,4 +1,4 @@
-#include "songparser.hh"
+﻿#include "songparser.hh"
 #include "unicode.hh"
 
 #include <boost/algorithm/string.hpp>
@@ -165,8 +165,10 @@ bool SongParser::txtParseNote(std::string line) {
 	unsigned int ts = m_txt.prevts;
 	switch (n.type) {
 		case Note::NORMAL:
+		case Note::RAP:
 		case Note::FREESTYLE:
 		case Note::GOLDEN:
+		case Note::GOLDEN2:
 		{
 			unsigned int length = 0;
 			if (!(iss >> ts >> length >> n.note)) throw std::runtime_error("Invalid note line format");


### PR DESCRIPTION
So I was adding some more songs today and I got a file for this new BTS song (dynamite - see attachment) 
[BTS - Dynamite.txt](https://github.com/performous/performous/files/5212988/BTS.-.Dynamite.txt)

and it contained 2 new types of notes: 'R' (RAP) and 'G' (probably Golden).
for now I made R the same as freestyle since older songs used to do this, meaning that it does count score (1x), however in guitar hero "rap" notes dont count against your score. 
I can change that, but that means it needs a new graphic.

I made 'G' notes behave the same as '*' (golden) notes for now, don't know why they were introduced.
Anyhow, here's a hotfix so the song loads correctly without an "unknown note type" error.