### PR TITLE
Basic meson support

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -35,7 +35,7 @@ blocks:
           commands:
             - mkdir build.clang && cd build.clang && cmake -DENABLE_WEBSERVER=ON -DCMAKE_VERBOSE_MAKEFILE=1 -DENABLE_WEBCAM=ON ..
             - make VERBOSE=1
-  - name: MacOS 10.14.6 Build    
+  - name: MacOS 10.14.6 Build
     dependencies: []
     task:
       agent:
@@ -58,7 +58,7 @@ blocks:
           - mkdir -p /Users/semaphore/Applications
           - sudo ln -sf /Users/semaphore/local/Applications /Users/semaphore/Applications/MacPorts
           - sudo ln -sf /Users/semaphore/local/ /opt/local
-          - test -e /Users/semaphore/local/bin/port || ( curl -LJ https://www.dropbox.com/s/4c5oav6za5l4gvv/macports-10_15-install.tar.gz?dl=1 | tar x ) 
+          - test -e /Users/semaphore/local/bin/port || ( curl -LJ https://www.dropbox.com/s/4c5oav6za5l4gvv/macports-10_15-install.tar.gz?dl=1 | tar x )
       jobs:
         - name: Generate app bundle
           commands:
@@ -70,3 +70,41 @@ blocks:
             - ./performous-app-build.sh -D
             - cd /Users/semaphore
             - cache store macports-10_15 ./local
+  - name: Ubuntu 18.04 Build (Meson)
+    task:
+      prologue:
+        commands:
+          - echo "Installing Performous dependencies..."
+          - sudo apt-get update -y
+          - sudo apt-get install -y gettext clang-9 gcc-8 g++-8
+          - sudo apt-get install -y python3-dev python3-pip
+          - sem-version python 3.8
+          - sudo pip3 install meson
+          - sudo apt-get install -y ninja-build
+          - sudo apt-get install -y libepoxy-dev libsdl2-dev libcairo2-dev libpango1.0-dev librsvg2-dev libboost-all-dev libavcodec-dev libavformat-dev libswscale-dev libswresample-dev libpng-dev libjpeg-dev libxml++2.6-dev portaudio19-dev libicu-dev libopencv-dev libportmidi-dev libglm-dev libaubio-dev libcpprest-dev
+          - echo "Checking out..."
+          - checkout
+          - git submodule update --init --recursive
+      jobs:
+        - name: GCC-8.4.0 Build
+          env_vars:
+            - name: CC
+              value: gcc-8
+            - name: CXX
+              value: g++-8
+          commands:
+            - echo "Setting up build..."
+            - meson setup build.gcc -Dusewebcam=true -Dusemididrum=true -Dusewebserver=true
+            - echo "Building..."
+            - meson compile -C build.gcc
+        - name: Clang-9 Build
+          env_vars:
+            - name: CC
+              value: clang-9
+            - name: CXX
+              value: clang++-9
+          commands:
+            - echo "Setting up build..."
+            - meson setup build.clang -Dusewebcam=true -Dusemididrum=true -Dusewebserver=true
+            - echo "Building..."
+            - meson compile -C build.clang

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -77,12 +77,10 @@ blocks:
         commands:
           - echo "Installing Performous dependencies..."
           - sudo apt-get update -y
-          - sudo apt-get install -y gettext clang-9 gcc-8 g++-8
-          - sudo apt-get install -y python3-dev python3-pip
+          - sudo apt-get install -y ninja-build
+          - sudo apt-get install -y gettext clang-9 gcc-8 g++-8 python3-dev python3-pip libepoxy-dev libsdl2-dev libcairo2-dev libpango1.0-dev librsvg2-dev libboost-all-dev libavcodec-dev libavformat-dev libswscale-dev libswresample-dev libpng-dev libjpeg-dev libxml++2.6-dev portaudio19-dev libicu-dev libopencv-dev libportmidi-dev libglm-dev libaubio-dev libcpprest-dev
           - sem-version python 3.8
           - sudo pip3 install meson
-          - sudo apt-get install -y ninja-build
-          - sudo apt-get install -y libepoxy-dev libsdl2-dev libcairo2-dev libpango1.0-dev librsvg2-dev libboost-all-dev libavcodec-dev libavformat-dev libswscale-dev libswresample-dev libpng-dev libjpeg-dev libxml++2.6-dev portaudio19-dev libicu-dev libopencv-dev libportmidi-dev libglm-dev libaubio-dev libcpprest-dev
           - echo "Checking out..."
           - checkout
           - git submodule update --init --recursive

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -71,6 +71,7 @@ blocks:
             - cd /Users/semaphore
             - cache store macports-10_15 ./local
   - name: Ubuntu 18.04 Build (Meson)
+    dependencies: []
     task:
       prologue:
         commands:

--- a/game/config.hh.in
+++ b/game/config.hh.in
@@ -1,6 +1,6 @@
 #pragma once
 
-// The build system uses this file to generate config.hh within the build folder.
+// The build system uses this file to generate the config.hh header file within the build folder.
 
 #define PACKAGE "@CMAKE_PROJECT_NAME@"
 #define VERSION "@PROJECT_VERSION@"

--- a/game/config.hh.in
+++ b/game/config.hh.in
@@ -1,0 +1,10 @@
+#pragma once
+
+// The build system uses this file to generate config.hh within the build folder.
+
+#define PACKAGE "@CMAKE_PROJECT_NAME@"
+#define VERSION "@PROJECT_VERSION@"
+#define LOCALEDIR "@LOCALE_DIR@"
+#define SHARED_DATA_DIR "@SHARE_INSTALL@"
+#define LIBXMLPP_VERSION_2_6 @LIBXMLPP_VERSION_2_6@
+#define LIBXMLPP_VERSION_3_0 @LIBXMLPP_VERSION_3_0@

--- a/game/ffmpeg.cc
+++ b/game/ffmpeg.cc
@@ -14,14 +14,14 @@
 #include <thread>
 
 extern "C" {
-#include AVCODEC_INCLUDE
-#include AVFORMAT_INCLUDE
-#include SWSCALE_INCLUDE
-#include SWRESAMPLE_INCLUDE
-#include AVUTIL_INCLUDE
-#include AVUTIL_OPT_INCLUDE
-#include AVUTIL_MATH_INCLUDE
-#include AVUTIL_ERROR_INCLUDE
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libswscale/swscale.h>
+#include <libswresample/swresample.h>
+#include <libavutil/avutil.h>
+#include <libavutil/opt.h>
+#include <libavutil/mathematics.h>
+#include <libavutil/error.h>
 }
 
 #define AUDIO_CHANNELS 2

--- a/game/song.cc
+++ b/game/song.cc
@@ -9,8 +9,8 @@
 #include <limits>
 
 extern "C" {
-#include AVFORMAT_INCLUDE
-#include AVCODEC_INCLUDE
+#include <libavformat/avformat.h>
+#include <libavcodec/avcodec.h>
 }
 #ifdef USE_WEBSERVER
 Song::Song(web::json::value const& song): dummyVocal(TrackName::LEAD_VOCAL), randomIdx(rand()) {

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,188 @@
+project('performous', 
+        'cpp',
+        default_options : ['cpp_std=c++17'])
+
+conf = configuration_data()
+conf.set('CMAKE_PROJECT_NAME', 'Performous')
+conf.set('PROJECT_VERSION', 'git-meson')
+conf.set('LOCALE_DIR', 'share/locale')
+conf.set('SHARE_INSTALL', 'share/games/performous')
+
+libxmlpp = dependency('libxml++-3.0', required : false)
+if libxmlpp.found()
+  conf.set('LIBXMLPP_VERSION_3_0', 1)
+  conf.set('LIBXMLPP_VERSION_2_6', 0)
+else
+  libxmlpp = dependency('libxml++-2.6')
+  conf.set('LIBXMLPP_VERSION_2_6', 1)
+  conf.set('LIBXMLPP_VERSION_3_0', 0)
+endif
+
+opencv = dependency('opencv4', required : false)
+if opencv.found()
+  add_project_arguments('-DUSE_OPENCV', language : 'cpp')
+else
+  warning('OpenCV not found:    Webcam support DISABLED')
+endif
+
+portmidi = dependency('PortMidi', required : false, cmake_module_path : 'cmake/Modules/')
+if portmidi.found()
+  add_project_arguments('-DUSE_PORTMIDI', language: 'cpp')
+else
+  warning('PORTMIDI not found:  MIDI drum support DISABLED')
+endif
+
+# This could in principle work, but doesn't in practice, at least not on my system
+# - cpprestsdk doesn't support pkg-config
+# - FindCppRest.cmake shipped with Performous doesn't find it for some reason
+# - The library's installed cpprestsdk-config.cmake is not in path
+# - This build script doesn't add the required extra Boost components to build
+cpprest = dependency('CppRest', required : false, cmake_module_path : 'cmake/Modules/')
+if cpprest.found()
+  add_project_arguments('-DUSE_WEBSERVER', language: 'cpp')
+else
+  warning('CppRestSdk not found:  WEBSERVER support DISABLED')
+endif
+
+configure_file(input : 'game/config.hh.in', output : 'config.hh', configuration : conf)
+
+dependencies = [
+  dependency('pangocairo'),
+  dependency('sdl2'),
+  dependency('aubio'),
+  dependency('boost', modules : [
+    'filesystem',
+    'iostreams',
+    'locale',
+    'program_options',
+    'system'
+  ]),
+  dependency('epoxy'),
+  dependency('icu-uc'),
+  dependency('icu-i18n'),
+  dependency('icu-io'),
+  dependency('libpng'),
+  dependency('libjpeg'),
+  dependency('librsvg-2.0'),
+  dependency('libavcodec'),
+  dependency('libavformat'),
+  dependency('libavutil'),
+  dependency('libswscale'),
+  dependency('libswresample'),
+  dependency('portaudio-2.0'),
+  dependency('fontconfig'),
+  libxmlpp,
+  opencv,
+  portmidi,
+  cpprest
+]
+
+compiler=meson.get_compiler('cpp')
+if compiler.get_id() == 'gcc'
+  compiler_args=compiler.get_supported_arguments(
+    ['-Wall','-Wextra','-pedantic','-Wc++20-compat',
+    '-Wno-deprecated-declarations',
+    '-Wno-mismatched-tags',
+    '-Wno-narrowing',
+    '-Wno-overflow'])
+else
+  compiler_args=compiler.get_supported_arguments(
+    ['-Wall','-Wextra','-pedantic','-Wc++20-compat',
+    '-Wno-c++11-narrowing',
+    '-Wno-implicit-int-float-conversion',
+    '-Wno-inconsistent-missing-override',
+    '-Wno-deprecated-declarations',
+    '-Wno-mismatched-tags'])
+endif
+
+executable('performous', [
+  '3rdparty/ced/compact_enc_det/compact_enc_det.cc',
+  '3rdparty/ced/compact_enc_det/compact_enc_det_hint_code.cc',
+  '3rdparty/ced/util/encodings/encodings.cc',
+  '3rdparty/ced/util/languages/languages.cc',
+  'game/3dobject.cc',
+  'game/audio.cc',
+  'game/backgrounds.cc',
+  'game/cache.cc',
+  'game/color.cc',
+  'game/configuration.cc',
+  'game/controllers-joystick.cc',
+  'game/controllers-keyboard.cc',
+  'game/controllers-midi.cc',
+  'game/controllers.cc',
+  'game/dancegraph.cc',
+  'game/database.cc',
+  'game/dialog.cc',
+  'game/engine.cc',
+  'game/execname.cc',
+  'game/ffmpeg.cc',
+  'game/fs.cc',
+  'game/game.cc',
+  'game/glshader.cc',
+  'game/glutil.cc',
+  'game/guitargraph.cc',
+  'game/hiscore.cc',
+  'game/image.cc',
+  'game/instrumentgraph.cc',
+  'game/layout_singer.cc',
+  'game/log.cc',
+  'game/main.cc',
+  'game/menu.cc',
+  'game/midifile.cc',
+  'game/musicalscale.cc',
+  'game/notegraph.cc',
+  'game/notes.cc',
+  'game/opengl_text.cc',
+  'game/pitch.cc',
+  'game/platform.cc',
+  'game/player.cc',
+  'game/players.cc',
+  'game/playlist.cc',
+  'game/progressbar.cc',
+  'game/requesthandler.cc',
+  'game/screen_audiodevices.cc',
+  'game/screen_intro.cc',
+  'game/screen_paths.cc',
+  'game/screen_players.cc',
+  'game/screen_playlist.cc',
+  'game/screen_practice.cc',
+  'game/screen_sing.cc',
+  'game/screen_songs.cc',
+  'game/song.cc',
+  'game/songitems.cc',
+  'game/songparser-ini.cc',
+  'game/songparser-mid.cc',
+  'game/songparser-sm.cc',
+  'game/songparser-txt.cc',
+  'game/songparser-xml.cc',
+  'game/songparser.cc',
+  'game/songs.cc',
+  'game/svg.cc',
+  'game/texture.cc',
+  'game/theme.cc',
+  'game/unicode.cc',
+  'game/util.cc',
+  'game/video.cc',
+  'game/video_driver.cc',
+  'game/webcam.cc',
+  'game/webserver.cc'
+],
+  dependencies : dependencies,
+  include_directories : include_directories('3rdparty/ced'),
+  cpp_args : compiler_args,
+  install: true
+)
+
+datapaths = [
+  'data/backgrounds',
+  'data/config',
+  'data/fonts',
+  'data/shaders',
+  'data/sounds',
+  'data/themes',
+  'data/xsl'
+]
+
+foreach dp: datapaths
+  install_subdir(dp, install_dir: 'share/games/performous')
+endforeach

--- a/meson.build
+++ b/meson.build
@@ -244,10 +244,10 @@ foreach dp: datapaths
   install_subdir(dp, install_dir: 'share/games/performous')
 endforeach
 
-#TBD: desktop file, pixmap files, man etc. see cmake of data and docs dir
+# TBD: desktop file, pixmap files, man etc. see cmake of data and docs dir
 # help2man = find_program('help2man', required: false)
 # if help2man.found()
 #   help2man_opts = [
 #     '--no-info',
 #     '--section=1',
-#...
+# Maybe also add a target to build a debian pkg ...

--- a/meson.build
+++ b/meson.build
@@ -1,13 +1,54 @@
-project('performous', 
+#Project definition
+project('performous',
         'cpp',
-        default_options : ['cpp_std=c++17'])
+        version: '1.x',
+        default_options : ['cpp_std=c++17','buildtype=debugoptimized'],
+        meson_version: '>=0.53.0',
+        license : 'GPL-2.0-or-later')
 
+#Print project summary.  Limited to strict minimum for now
+summary({'Use Open CV': get_option('usewebcam'),
+         'Use Port Midi': get_option('usemididrum'),
+         'Use Web Server': get_option('usewebserver')
+        }, section: 'Build Options')
+
+#Configuration
 conf = configuration_data()
 conf.set('CMAKE_PROJECT_NAME', 'Performous')
-conf.set('PROJECT_VERSION', 'git-meson')
+conf.set('PROJECT_VERSION', meson.project_version())
 conf.set('LOCALE_DIR', 'share/locale')
 conf.set('SHARE_INSTALL', 'share/games/performous')
 
+#Compilers flags.  Some warnings really should be enabled (eg narrowing, overflow etc) but some legacy code
+#has too many of those for the output to be useful.
+#LTO is used if it is available on GCC (10+), but not on clang as it does not seem to be linking fine
+compiler=meson.get_compiler('cpp')
+if compiler.get_id() == 'gcc'
+  compiler_args=compiler.get_supported_arguments(
+    ['-Wall','-Wextra','-pedantic','-Wc++20-compat',
+    '-Wno-deprecated-declarations',
+    '-Wno-mismatched-tags',
+    '-Wno-narrowing',
+    '-Wno-overflow',
+    '-flto'])
+else
+  compiler_args=compiler.get_supported_arguments(
+    ['-Wall','-Wextra','-pedantic','-Wc++20-compat',
+    '-Wno-c++11-narrowing',
+    '-Wno-implicit-int-float-conversion',
+    '-Wno-inconsistent-missing-override',
+    '-Wno-deprecated-declarations',
+    '-Wno-mismatched-tags'])
+endif
+
+#Link with stdc++fs if it is supplied by the compiler (gcc v8 or older, clang v10 or older)
+#This is currently necessary on semaphore CI, which is running gcc8 max.
+#Has_Link_Argument is only supported in meson 0.46+
+if compiler.has_link_argument('-lstdc++fs')
+  add_project_link_arguments(['-lstdc++fs'], language: 'cpp')
+endif
+
+#Dependencies
 libxmlpp = dependency('libxml++-3.0', required : false)
 if libxmlpp.found()
   conf.set('LIBXMLPP_VERSION_3_0', 1)
@@ -18,39 +59,69 @@ else
   conf.set('LIBXMLPP_VERSION_3_0', 0)
 endif
 
-opencv = dependency('opencv4', required : false)
-if opencv.found()
-  add_project_arguments('-DUSE_OPENCV', language : 'cpp')
+#OpenCV may be referred to as opencv or opencv4
+if get_option('usewebcam')
+  message('OpenCV build requested')
+  opencv = dependency('opencv', required: false)
+  if opencv.found()
+      add_project_arguments('-DUSE_OPENCV', language : 'cpp')
+  else
+    opencv = dependency('opencv4', method : 'pkg-config', required: false)
+    if opencv.found()
+      add_project_arguments('-DUSE_OPENCV', language : 'cpp')
+    else
+      error('OpenCV not found but webcam build requested')
+    endif
+  endif
 else
-  warning('OpenCV not found:    Webcam support DISABLED')
+  opencv=dependency('',required: false)
 endif
 
-portmidi = dependency('PortMidi', required : false, cmake_module_path : 'cmake/Modules/')
-if portmidi.found()
-  add_project_arguments('-DUSE_PORTMIDI', language: 'cpp')
+#Portmidi is maybe not found in pkg-config, use find library as an alternative
+if get_option('usemididrum')
+  message('Portmidi build requested')
+  portmidi = dependency('portmidi', required: false)
+  if portmidi.found()
+    add_project_arguments('-DUSE_PORTMIDI', language: 'cpp')
+  else
+    portmidi = compiler.find_library('libportmidi', required: false)
+    if portmidi.found()
+      add_project_arguments('-DUSE_PORTMIDI', language: 'cpp')
+    else
+      error('PORTMIDI not found but MIDI drum support build requested')
+    endif
+  endif
 else
-  warning('PORTMIDI not found:  MIDI drum support DISABLED')
+  portmidi=dependency('',required: false)
 endif
 
-# This could in principle work, but doesn't in practice, at least not on my system
-# - cpprestsdk doesn't support pkg-config
-# - FindCppRest.cmake shipped with Performous doesn't find it for some reason
-# - The library's installed cpprestsdk-config.cmake is not in path
-# - This build script doesn't add the required extra Boost components to build
-cpprest = dependency('CppRest', required : false, cmake_module_path : 'cmake/Modules/')
-if cpprest.found()
-  add_project_arguments('-DUSE_WEBSERVER', language: 'cpp')
+#Cpprest may not be in pkg-config
+#Also, libssl and libcrypto are only needed when webserver support is requested
+if get_option('usewebserver')
+  message('Webserver build requested')
+  cpprest=dependency('cpprest', required : false)
+  if cpprest.found()
+    add_project_arguments('-DUSE_WEBSERVER', language: 'cpp')
+  else
+    cpprest=compiler.find_library('libcpprest', required:false)
+    if cpprest.found()
+      add_project_arguments('-DUSE_WEBSERVER', language: 'cpp')
+    else
+      error('CppRestSdk not found but webserver build requested')
+    endif
+  endif
 else
-  warning('CppRestSdk not found:  WEBSERVER support DISABLED')
+  cpprest=dependency('',required: false)
 endif
 
+#Write configuration file
 configure_file(input : 'game/config.hh.in', output : 'config.hh', configuration : conf)
 
 dependencies = [
   dependency('pangocairo'),
   dependency('sdl2'),
   dependency('aubio'),
-  dependency('boost', modules : [
+  dependency('boost', modules : [ # Meson treats boost specially: no pkg-config supported
     'filesystem',
     'iostreams',
     'locale',
@@ -71,29 +142,14 @@ dependencies = [
   dependency('libswresample'),
   dependency('portaudio-2.0'),
   dependency('fontconfig'),
+  dependency('glm'),
+  dependency('libssl', required:get_option('usewebserver')), #Only needed with webserver
+  dependency('libcrypto', required:get_option('usewebserver')), #Idem
   libxmlpp,
   opencv,
   portmidi,
   cpprest
 ]
-
-compiler=meson.get_compiler('cpp')
-if compiler.get_id() == 'gcc'
-  compiler_args=compiler.get_supported_arguments(
-    ['-Wall','-Wextra','-pedantic','-Wc++20-compat',
-    '-Wno-deprecated-declarations',
-    '-Wno-mismatched-tags',
-    '-Wno-narrowing',
-    '-Wno-overflow'])
-else
-  compiler_args=compiler.get_supported_arguments(
-    ['-Wall','-Wextra','-pedantic','-Wc++20-compat',
-    '-Wno-c++11-narrowing',
-    '-Wno-implicit-int-float-conversion',
-    '-Wno-inconsistent-missing-override',
-    '-Wno-deprecated-declarations',
-    '-Wno-mismatched-tags'])
-endif
 
 executable('performous', [
   '3rdparty/ced/compact_enc_det/compact_enc_det.cc',
@@ -173,6 +229,7 @@ executable('performous', [
   install: true
 )
 
+#Installation of data files
 datapaths = [
   'data/backgrounds',
   'data/config',
@@ -186,3 +243,11 @@ datapaths = [
 foreach dp: datapaths
   install_subdir(dp, install_dir: 'share/games/performous')
 endforeach
+
+#TBD: desktop file, pixmap files, man etc. see cmake of data and docs dir
+# help2man = find_program('help2man', required: false)
+# if help2man.found()
+#   help2man_opts = [
+#     '--no-info',
+#     '--section=1',
+#...

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,3 @@
-option('usewebcam', type: 'boolean', value: false, description: 'Build with webcam support')
-option('usemididrum', type: 'boolean', value: false, description: 'Build with midi drum support')
-option('usewebserver', type: 'boolean', value: false, description: 'Build with web server support')
+option('usewebcam', type: 'boolean', value: false, description: 'Build with webcam support (opencv)')
+option('usemididrum', type: 'boolean', value: false, description: 'Build with midi drum support (portmidi)')
+option('usewebserver', type: 'boolean', value: false, description: 'Build with web server support (cpprest)')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,3 @@
+option('usewebcam', type: 'boolean', value: false, description: 'Build with webcam support')
+option('usemididrum', type: 'boolean', value: false, description: 'Build with midi drum support')
+option('usewebserver', type: 'boolean', value: false, description: 'Build with web server support')


### PR DESCRIPTION
Updated experimental Meson support, based on the previous PR by @Tronic. 
I simplified @Tronic PR to the extent possible.
It should apply cleanly to current master/head.
Compiles with gcc and clang under ubuntu.
Warnings have been set to return a reasonable set, which can be tackled in subsequent PRs.
Uses system aubio.
Builds ced in the binary. 