### PR TITLE
Remove extraneous semicolons

### DIFF
--- a/game/dancegraph.cc
+++ b/game/dancegraph.cc
@@ -31,7 +31,7 @@ namespace {
 	int getNextBigStreak(int prev) { return prev + 10; }
 
 	/// Get an accuracy value [0, 1] for the error offset (in seconds)
-	double accuracy(double error) { return 1.0 - (std::abs(error) / maxTolerance); };
+	double accuracy(double error) { return 1.0 - (std::abs(error) / maxTolerance); }
 
 	/// Gives points based on error from a perfect hit
 	double points(double error) {

--- a/game/ffmpeg.cc
+++ b/game/ffmpeg.cc
@@ -48,7 +48,7 @@ AudioBuffer::uFvec AudioBuffer::makePreviewBuffer() {
 		}
 	}
 	return fvec;
-};
+}
 
 bool AudioBuffer::wantMore() {
 	return m_write_pos < m_read_pos + static_cast<std::int64_t>(m_data.size() / 2);
@@ -221,7 +221,7 @@ static void printFFmpegInfo() {
 #if (LIBAVFORMAT_VERSION_INT) < (AV_VERSION_INT(58,0,0))
 	av_register_all();
 #endif
-};
+}
 
 class FFmpeg::Error: public std::runtime_error {
   public:


### PR DESCRIPTION
Remove extraneous semicolons.

Note: This PR addresses all pedantic warnings left over with the compilation option specific in the experimental meson build.

Outstanding warnings from GCC after this is applied:

```
[16/71] Compiling C++ object performous.p/game_glshader.cc.o
../game/glshader.cc: In member function ‘void Shader::dumpInfoLog(GLuint)’:
../game/glshader.cc:34:7: warning: ISO C++ forbids variable length array ‘infoLog’ [-Wvla]
   34 |  char infoLog[maxLength];
      |       ^~~~~~~
[23/71] Compiling C++ object performous.p/game_controllers.cc.o
../game/controllers.cc: In constructor ‘ButtonMap::ButtonMap()’:
../game/controllers.cc:92:50: warning: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct ButtonMap’; use assignment or value-initialization instead [-Wclass-memaccess]
   92 |  ButtonMap() { std::memset(this, 0, sizeof(*this)); }
      |                                                  ^
../game/controllers.cc:88:8: note: ‘struct ButtonMap’ declared here
   88 | struct ButtonMap {
