### PR TITLE
Remove uneeded constructor

### DIFF
--- a/game/controllers.cc
+++ b/game/controllers.cc
@@ -89,7 +89,6 @@ struct ButtonMap {
 	Button map;  // Generic action
 	Button negative, positive;  // Half-axis movement
 	Button up, down, left, right;  // Hat direction
-	ButtonMap() { std::memset(this, 0, sizeof(*this)); }
 };
 
 typedef std::map<HWButton, ButtonMap> ButtonMapping;


### PR DESCRIPTION
Remove uneeded constructor in controllers.cc, which also suppresses a warning.
The default implicit constructor should work well enough.
Tested on Ubuntu.