### PR TITLE
Address warning "ISO C++ forbids variable length array infoLog"

### DIFF
--- a/game/glshader.cc
+++ b/game/glshader.cc
@@ -141,7 +141,7 @@ Shader& Shader::compileCode(std::string const& srccode, GLenum type) {
 	if (gl_response != GL_TRUE) {
 		throw std::runtime_error("Shader compile error.");
 	}
-	
+
 	shader_ids.push_back(new_shader);
 	return *this;
 }

--- a/game/glshader.cc
+++ b/game/glshader.cc
@@ -26,7 +26,7 @@ namespace {
 
 /// Dumps Shader/Program InfoLog
 void Shader::dumpInfoLog(GLuint id) {
-	GLint maxLength=0;
+	GLint maxLength = 0;
 
 	if (glIsShader(id)) glGetShaderiv(id, GL_INFO_LOG_LENGTH, &maxLength);
 	else glGetProgramiv(id, GL_INFO_LOG_LENGTH, &maxLength);

--- a/game/glshader.cc
+++ b/game/glshader.cc
@@ -25,26 +25,25 @@ namespace {
 }
 
 /// Dumps Shader/Program InfoLog
-void Shader::dumpInfoLog(GLuint id) {
-	int maxLength;
+void Shader::dumpInfoLog(GLuint id) { 
+	GLint maxLength=0;
 
 	if (glIsShader(id)) glGetShaderiv(id, GL_INFO_LOG_LENGTH, &maxLength);
 	else glGetProgramiv(id, GL_INFO_LOG_LENGTH, &maxLength);
 
-	char infoLog[maxLength];
+	std::vector<GLchar> infoLog(maxLength);
 	int infoLogLength = 0;
 
-	if (glIsShader(id)) glGetShaderInfoLog(id, maxLength, &infoLogLength, infoLog);
-	else glGetProgramInfoLog(id, maxLength, &infoLogLength, infoLog);
+	if (glIsShader(id)) glGetShaderInfoLog(id, maxLength, &infoLogLength, infoLog.data());
+	else glGetProgramInfoLog(id, maxLength, &infoLogLength, infoLog.data());
 
+	if (maxLength == 0) return;	
 	// Ignore success messages that the Radeon driver always seems to give
-	if (std::equal(infoLog, infoLog + infoLogLength, "Vertex shader(s) linked, fragment shader(s) linked, geometry shader(s) linked.")) return;
-
-	if (maxLength == 0) return;
+	if (std::equal(infoLog.data(), infoLog.data() + infoLogLength, "Vertex shader(s) linked, fragment shader(s) linked, geometry shader(s) linked.")) return;
 	// Format a (possibly multi-line) log message
-	std::string prefix = "opengl/error: Shader " + name + ": ";
+	std::string prefix = "opengl/error: Shader [" + name + "]: ";
 	std::string logmsg = prefix;
-	for (char ch: std::string(infoLog)) {
+	for (char ch: std::string(infoLog.data())) {
 		if (logmsg.back() == '\n') logmsg += prefix;
 		logmsg += ch;
 	}
@@ -94,6 +93,7 @@ Shader::~Shader() {
 }
 
 Shader& Shader::compileFile(fs::path const& filename) {
+	std::clog << "opengl/info: Compiling " << filename.string() << std::endl;
 	fs::path ext = filename.extension();
 	GLenum type;
 	if (ext == ".vert") type = GL_VERTEX_SHADER;
@@ -141,7 +141,7 @@ Shader& Shader::compileCode(std::string const& srccode, GLenum type) {
 	if (gl_response != GL_TRUE) {
 		throw std::runtime_error("Shader compile error.");
 	}
-
+	
 	shader_ids.push_back(new_shader);
 	return *this;
 }

--- a/game/glshader.cc
+++ b/game/glshader.cc
@@ -25,7 +25,7 @@ namespace {
 }
 
 /// Dumps Shader/Program InfoLog
-void Shader::dumpInfoLog(GLuint id) { 
+void Shader::dumpInfoLog(GLuint id) {
 	GLint maxLength=0;
 
 	if (glIsShader(id)) glGetShaderiv(id, GL_INFO_LOG_LENGTH, &maxLength);
@@ -37,7 +37,7 @@ void Shader::dumpInfoLog(GLuint id) {
 	if (glIsShader(id)) glGetShaderInfoLog(id, maxLength, &infoLogLength, infoLog.data());
 	else glGetProgramInfoLog(id, maxLength, &infoLogLength, infoLog.data());
 
-	if (maxLength == 0) return;	
+	if (maxLength == 0) return;
 	// Ignore success messages that the Radeon driver always seems to give
 	if (std::equal(infoLog.data(), infoLog.data() + infoLogLength, "Vertex shader(s) linked, fragment shader(s) linked, geometry shader(s) linked.")) return;
 	// Format a (possibly multi-line) log message


### PR DESCRIPTION
Address the infolog warning, using a vector this time to avoid new/delete.
Reordered a few things, and added a log of the shader being compiled.