### PR TITLE
Ignore all build folders in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
-build
-build32
-build64
+build*
 CMakeLists.txt.user*
 *~
 *.mo

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-build*
+/[bB]uild*/
 CMakeLists.txt.user*
 *~
 *.mo


### PR DESCRIPTION
I suppose we don't want any build* folder ending up in git, so ignore any folder starting with build instead of only build32 and build64.  This is consistent with semaphore which uses build.gcc and build.clang for example.