### PR TITLE
Add git describe to version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 #Project definition
 project('performous',
         'cpp',
-        version: '2.x',
+        version: '1.x',
         default_options : ['cpp_std=c++17','buildtype=debugoptimized'],
         meson_version: '>=0.53.0',
         license : 'GPL-2.0-or-later')

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 #Project definition
 project('performous',
         'cpp',
-        version: '1.x',
+        version: '2.x',
         default_options : ['cpp_std=c++17','buildtype=debugoptimized'],
         meson_version: '>=0.53.0',
         license : 'GPL-2.0-or-later')
@@ -12,10 +12,22 @@ summary({'Use Open CV': get_option('usewebcam'),
          'Use Web Server': get_option('usewebserver')
         }, section: 'Build Options')
 
+#Add git describe output to version number.
+#This does not appear work on semaphore, maybe because of stdout.
+#If it fails, falls back to the project version defined above, without git reference.
+version = meson.project_version()
+git = find_program('git', required: true)
+if git.found()
+  gitcmd = run_command(git, 'describe')
+  if gitcmd.returncode() == 0
+    version = meson.project_version()+' (git: '+gitcmd.stdout().strip() +')'
+  endif
+endif
+
 #Configuration
 conf = configuration_data()
 conf.set('CMAKE_PROJECT_NAME', 'Performous')
-conf.set('PROJECT_VERSION', meson.project_version())
+conf.set('PROJECT_VERSION', version)
 conf.set('LOCALE_DIR', 'share/locale')
 conf.set('SHARE_INSTALL', 'share/games/performous')
 


### PR DESCRIPTION
Adds the git describe output, containing the git commit id etc. to the project version.
When started, the app then logs the git reference:

```
...
core/notice: Performous 2.x (git: 1.0-1128-gcfb61b90) starting...
  Internationalization: Enabled
  MIDI Hardware I/O:    Enabled
... 
```

This works when building locally, but on semaphore there appears to be an issue with reading from stdout (maybe).  
In this case, the git describe output is ignored (ie only Performous 2.x is displayed).