### PR TITLE
Include specific header for opencv

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -17,7 +17,7 @@ blocks:
           - echo "Installing Performous dependencies..."
           - sudo apt -y update
           - sudo add-apt-repository -y ppa:litenstein/performous-bionic
-          - sudo apt -y install cmake gettext help2man clang-9 gcc-8 g++-8 libepoxy-dev libsdl2-dev libcairo2-dev libpango1.0-dev librsvg2-dev libboost-all-dev libavcodec-dev libavformat-dev libswscale-dev libswresample-dev libpng-dev libjpeg-dev libxml++3.0-dev portaudio19-dev libopencv-dev libportmidi-dev libqrencode-dev libicu-dev libglm-dev libopenblas-dev libfftw3-dev
+          - sudo apt -y install cmake gettext help2man clang-9 gcc-8 g++-8 libepoxy-dev libsdl2-dev libcairo2-dev libpango1.0-dev librsvg2-dev libboost-all-dev libavcodec-dev libavformat-dev libswscale-dev libswresample-dev libpng-dev libjpeg-dev libxml++3.0-dev portaudio19-dev libopencv-videoio-dev libportmidi-dev libqrencode-dev libicu-dev libglm-dev libopenblas-dev libfftw3-dev
           - checkout
           - git submodule update --init --recursive
       jobs:
@@ -88,7 +88,7 @@ blocks:
           - echo "Installing Performous dependencies..."
           - sudo apt-get update -y
           - sudo apt-get install -y ninja-build
-          - sudo apt-get install -y gettext clang-9 gcc-8 g++-8 python3-dev python3-pip libepoxy-dev libsdl2-dev libcairo2-dev libpango1.0-dev librsvg2-dev libboost-all-dev libavcodec-dev libavformat-dev libswscale-dev libswresample-dev libpng-dev libjpeg-dev libxml++2.6-dev portaudio19-dev libicu-dev libopencv-dev libportmidi-dev libglm-dev libaubio-dev libcpprest-dev
+          - sudo apt-get install -y gettext clang-9 gcc-8 g++-8 python3-dev python3-pip libepoxy-dev libsdl2-dev libcairo2-dev libpango1.0-dev librsvg2-dev libboost-all-dev libavcodec-dev libavformat-dev libswscale-dev libswresample-dev libpng-dev libjpeg-dev libxml++2.6-dev portaudio19-dev libicu-dev libopencv-videoio-dev libportmidi-dev libglm-dev libaubio-dev libcpprest-dev
           - sem-version python 3.8
           - sudo pip3 install meson
           - echo "Checking out..."

--- a/game/webcam.cc
+++ b/game/webcam.cc
@@ -8,7 +8,7 @@
 #include <thread>
 
 #ifdef USE_OPENCV
-#include <opencv2/opencv.hpp>
+#include <opencv2/videoio.hpp>
 
 #else
 // Dummy classes


### PR DESCRIPTION
For webcam support, include the specific header required (ie <opencv2/videoio.hpp>
) rather than the generic one (ie #include <opencv2/opencv.hpp>)

This results in faster parse time.

When installing dependencies, we can probably only install opencv-videoio, which has a smaller footprint than the generic opencv and depends on opencv-core which is also required.

Tested on Ubuntu 21.04. 
 