### PR TITLE
Added skipping meson build

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -82,6 +82,8 @@ blocks:
     execution_time_limit:
       minutes: 10
     dependencies: []
+    skip:
+      when: "branch != 'meson'"
     task:
       prologue:
         commands:


### PR DESCRIPTION
### What does this PR do?

Skips the meson build when the current branch isn't `meson` as suggested by [semaphore](https://github.com/semaphoreci/semaphore/issues/68)

### Closes Issue(s)

* None

### Motivation

Meson is still experimental phase and our main building system is cmake. For the time being this will continue being our main building system. We'll have a separate branch called `meson` which we'll update every now and then to the latest master. This way we still support and know our meson build is successful. And can it not stop our PR's from getting merged.