### PR TITLE
Pitchwave order

### DIFF
--- a/game/notegraph.cc
+++ b/game/notegraph.cc
@@ -203,9 +203,9 @@ namespace {
 void NoteGraph::drawWaves(Database const& database) {
 	if (m_vocal.notes.empty()) return; // Cannot draw without notes
 	UseTexture tblock(m_wave);
-	std::list<Player> players = database.cur;
-	players.sort([](const Player& f, const Player& s) {return f.m_score < s.m_score; });
-	for (auto const& player: players) {
+	auto sortedPlayers = std::list<std::reference_wrapper<const Player>>(database.cur.begin(), database.cur.end());
+	sortedPlayers.sort([](const Player& playerOne, const Player& playerTwo) {return playerOne.m_score < playerTwo.m_score; });
+	for (const Player& player: sortedPlayers) {
 		if (player.m_vocal.name != m_vocal.name)
 			continue;
 		float const texOffset = 2.0 * m_time; // Offset for animating the wave texture

--- a/game/notegraph.cc
+++ b/game/notegraph.cc
@@ -203,7 +203,9 @@ namespace {
 void NoteGraph::drawWaves(Database const& database) {
 	if (m_vocal.notes.empty()) return; // Cannot draw without notes
 	UseTexture tblock(m_wave);
-	for (auto const& player: database.cur) {
+	std::list<Player> players = database.cur;
+	players.sort([](const Player& f, const Player& s) {return f.m_score < s.m_score; });
+	for (auto const& player: players) {
 		if (player.m_vocal.name != m_vocal.name)
 			continue;
 		float const texOffset = 2.0 * m_time; // Offset for animating the wave texture


### PR DESCRIPTION
### What does this PR do?

Fixes the pitchwave order. The highest score gets on top.
We used to just iterate over the players and draw them one after another.

### Closes Issue(s)

Closes #199

### Motivation

The best will be king of the hill no more no less.

### Additional Notes

I'm not so sure about the copying the `database.cur` to a `std::list<Player>` but i couldn't get sort to work on `database.cur` ...
