### PR TITLE
Bugfix: Clamping score to 10k points

### DIFF
--- a/game/instrumentgraph.hh
+++ b/game/instrumentgraph.hh
@@ -13,6 +13,7 @@
 #include "menu.hh"
 #include "screen.hh"
 #include "fs.hh"
+#include "util.hh"
 
 /// Represents popup messages
 class Popup {
@@ -95,7 +96,7 @@ public:
 	void position(double cx, double width) { m_cx.setTarget(cx); m_width.setTarget(width); }
 	unsigned stream() const { return m_stream; }
 	double correctness() const { return m_correctness.get(); }
-	int getScore() const { return (m_score > 0 ? m_score : 0) * m_scoreFactor; }
+	int getScore() const { return clamp((m_score > 0 ? m_score : 0) * m_scoreFactor, 0.0, 10000.0); }
 	input::DevType getGraphType() const { return m_dev->type; }
 	virtual double getWhammy() const { return 0; }
 	bool isKeyboard() const { return m_dev->source.isKeyboard(); }


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where the score could reach more than 10k points. This caused the game to crash with a runtime exception: "Invalid score value" when the highscore is reached.
Initially we thought the bug appeared while singing. But later we found out it's during guitars.

### Closes Issue(s)

Closes #577 

### Motivation

Fixes a bug

### More

- [ ] Added/updated documentation

### Additional Notes

I've only added a clamp around the `getscore()` method. I'm not sure if this is visually enough. We don't want the game to show more than 10k points at any given time: playing time, highscore time
