### PR TITLE
Move video FFMPEG init back to thread

### DIFF
--- a/game/video.cc
+++ b/game/video.cc
@@ -37,7 +37,7 @@ void Video::push(Bitmap&& f) {
 	m_queue.emplace_back(std::move(f));
 }
 
-Video::~Video() { 
+Video::~Video() {
 	{
 		std::lock_guard<std::mutex> l(m_mutex);
 		m_quit = true;
@@ -47,40 +47,46 @@ Video::~Video() {
 }
 
 Video::Video(fs::path const& _videoFile, double videoGap): m_videoGap(videoGap), m_textureTime(), m_alpha(-0.5, 1.5) {
-	// make ffmpeg here to get any exception in the current thread
-	auto ffmpeg = std::make_unique<VideoFFmpeg>(_videoFile, [this] (auto f) { this->push(std::move(f)); });
-	m_grabber = std::async(std::launch::async, [this, file = _videoFile, ffmpeg = std::move(ffmpeg)] {
-		int errors = 0;
-		std::unique_lock<std::mutex> l(m_mutex);
-		while (!m_quit) {
-			if (m_seek_asked) {
-				m_seek_asked = false;
+	m_grabber = std::async(std::launch::async, [this, file = _videoFile] {
+		try {
+			auto ffmpeg = std::make_unique<VideoFFmpeg>(file, [this](auto f) { this->push(std::move(f)); });
+			int errors = 0;
+			std::unique_lock<std::mutex> l(m_mutex);
+			while (!m_quit) {
+				if (m_seek_asked) {
+					m_seek_asked = false;
 
-				auto seek_pos = m_readPosition;
-				// discard all outdated frame. To avoid races between clean and push, clean and push are done in this thread.
-				m_queue.clear();
+					auto seek_pos = m_readPosition;
+					// discard all outdated frame. To avoid races between clean and push, clean and push are done in this thread.
+					m_queue.clear();
 
-				UnlockGuard<decltype(l)> unlocked(l); // release lock during seek
-				ffmpeg->seek(seek_pos);
-				continue;
-			}
-
-			try {
-				UnlockGuard<decltype(l)> unlocked(l); // release lock during possibly blocking ffmpeg stuff
-				ffmpeg->handleOneFrame();
-				errors = 0;
-			} catch (FFmpeg::Eof&) {
-				{
-					UnlockGuard<decltype(l)> unlocked(l); // release lock for possibly blocking calls
-					push(Bitmap()); // EOF marker
-					std::clog << "ffmpeg/debug: done loading " << file << std::endl;
+					UnlockGuard<decltype(l)> unlocked(l);  // release lock during seek
+					ffmpeg->seek(seek_pos);
+					continue;
 				}
-				m_cond.wait(l, [this]{ return m_quit || m_seek_asked; });
-			} catch (std::exception& e) {
-				UnlockGuard<decltype(l)> unlocked(l); // release lock for possibly blocking calls
-				std::clog << "ffmpeg/error: " << file << ": " << e.what() << std::endl;
-				if (++errors > 2) { std::clog << "ffmpeg/error: FFMPEG terminating due to multiple errors" << std::endl; break; }
+
+				try {
+					UnlockGuard<decltype(l)> unlocked(l);  // release lock during possibly blocking ffmpeg stuff
+					ffmpeg->handleOneFrame();
+					errors = 0;
+				} catch (FFmpeg::Eof&) {
+					{
+						UnlockGuard<decltype(l)> unlocked(l);  // release lock for possibly blocking calls
+						push(Bitmap());						   // EOF marker
+						std::clog << "ffmpeg/debug: done loading " << file << std::endl;
+					}
+					m_cond.wait(l, [this] { return m_quit || m_seek_asked; });
+				} catch (std::exception& e) {
+					UnlockGuard<decltype(l)> unlocked(l);  // release lock for possibly blocking calls
+					std::clog << "ffmpeg/error: " << file << ": " << e.what() << std::endl;
+					if (++errors > 2) {
+						std::clog << "ffmpeg/error: FFMPEG terminating due to multiple errors" << std::endl;
+						break;
+					}
+				}
 			}
+		} catch (std::exception& e) {
+			std::clog << "ffmpeg/error: " << file << ": " << e.what() << std::endl;
 		}
 	});
 }
@@ -107,4 +113,3 @@ void Video::render(double time) {
 	ColorTrans c(Color::alpha(alpha));
 	m_texture.draw();
 }
-


### PR DESCRIPTION
- Reverting part of 977fb50d7e529730b100519ac1692a0c5ed02d09
- Catch errors to avoid crash

No I/O should be done in main thread because it may block, so the initialisation needs to be done in a separate thread, keeping main thread always running smoothly. The current master was also not catching any loading errors, and thus would crash the game whenever a video failed to load.

Probably a similar fix needs to be done to audio ffmpeg, but I cannot look into that right now.
