### PR TITLE
Fix vsredist libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,10 @@ if(NOT APPLE)
   endif()
 endif()
 
+if(WIN32)
+	set(CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION ".")
+endif()
+
 #CPACK variables
 include(InstallRequiredSystemLibraries)
 


### PR DESCRIPTION
### What does this PR do?

Fix vsredist libraries to live alongside performous.exe on windows rather than in bin folder. As windows is too stupid to check for that folder.

### Closes Issue(s)

Some reported issues regarding the installer on Discord.

### Motivation

Installer didnt work for non-developers.