### PR TITLE
Fixed duplicate songs on windows 

### DIFF
--- a/data/config/schema.xml
+++ b/data/config/schema.xml
@@ -413,7 +413,6 @@ to save the current settings to XML.
 		<stringvalue>%USERPROFILE%\AppData\Roaming\performous</stringvalue>
 		<stringvalue>~\AppData\Roaming\performous</stringvalue>
 		<stringvalue>%HOMEDRIVE%%HOMEPATH%\Application Data\performous</stringvalue>
-		<stringvalue>~\Application Data\performous</stringvalue>
 		<short>Default Song folders</short>
 		<long>Where to recursively look for songs. DATADIR at the beginning means all Performous data folders.</long>
 	</entry>


### PR DESCRIPTION
### What does this PR do?

Fixes duplicate songs issue on Windows.
'Application Data' folder on windows is a symlink to an already mentioned folder: `<USERHOME>\AppData\Roaming\performous`

This then loads the song twice which isn't handy.

### Closes Issue(s)

None

### Motivation

Duplicate songs aren't nice.