### PR TITLE
Fix deprecated rsvg calls in newer versions of the lib.

### DIFF
--- a/game/svg.cc
+++ b/game/svg.cc
@@ -29,7 +29,7 @@ void loadSVG(Bitmap& bitmap, fs::path const& filename) {
 	}
 #if LIBRSVG_MAJOR_VERSION >= 2 && LIBRSVG_MINOR_VERSION >= 52
 	gdouble svg_width = 0, svg_height = 0;
-	rsvg_handle_get_intrinsic_size_in_pixels(svgHandle.get(),&svg_width, &svg_height);
+	rsvg_handle_get_intrinsic_size_in_pixels(svgHandle.get(), &svg_width, &svg_height);
 	bitmap.resize(static_cast<int>(svg_width * factor + 0.5), static_cast<int>(svg_height * factor + 0.5));
 #else //functions are deprecated since 2.46
 	// Get SVG dimensions

--- a/game/svg.cc
+++ b/game/svg.cc
@@ -30,7 +30,7 @@ void loadSVG(Bitmap& bitmap, fs::path const& filename) {
 #if LIBRSVG_MAJOR_VERSION >= 2 && LIBRSVG_MINOR_VERSION >= 52
 	gdouble svg_width = 0, svg_height = 0;
 	rsvg_handle_get_intrinsic_size_in_pixels(svgHandle.get(),&svg_width, &svg_height);
-	bitmap.resize(static_cast<int>(svg_width*factor + 0.5), static_cast<int>(svg_height *factor + 0.5));
+	bitmap.resize(static_cast<int>(svg_width * factor + 0.5), static_cast<int>(svg_height * factor + 0.5));
 #else //functions are deprecated since 2.46
 	// Get SVG dimensions
 	RsvgDimensionData svgDimension;

--- a/game/svg.cc
+++ b/game/svg.cc
@@ -30,7 +30,7 @@ void loadSVG(Bitmap& bitmap, fs::path const& filename) {
 #if LIBRSVG_MAJOR_VERSION >= 2 && LIBRSVG_MINOR_VERSION >= 52
 	gdouble svg_width = 0, svg_height = 0;
 	rsvg_handle_get_intrinsic_size_in_pixels(svgHandle.get(),&svg_width, &svg_height);
-	bitmap.resize(static_cast<int>(svg_width + 0.5)*factor, static_cast<int>(svg_height + 0.5)*factor);
+	bitmap.resize(static_cast<int>(svg_width*factor + 0.5), static_cast<int>(svg_height *factor + 0.5));
 #else //functions are deprecated since 2.46
 	// Get SVG dimensions
 	RsvgDimensionData svgDimension;

--- a/game/svg.cc
+++ b/game/svg.cc
@@ -47,7 +47,7 @@ void loadSVG(Bitmap& bitmap, fs::path const& filename) {
 	std::shared_ptr<cairo_t> dc(cairo_create(surface.get()), cairo_destroy);
 	cairo_scale(dc.get(), factor, factor);
 #if LIBRSVG_MAJOR_VERSION >= 2 && LIBRSVG_MINOR_VERSION >= 52
-	RsvgRectangle viewport = {0,0, svg_width, svg_height}; //viewport start is defenetely 0,0 but width and height?... from rsvg_handle_get_intrinsic_size_in_pixels I guess...
+	RsvgRectangle viewport = {0,0, svg_width, svg_height}; 
 	rsvg_handle_render_document(svgHandle.get(),dc.get(), &viewport, NULL);
 #else
 	rsvg_handle_render_cairo(svgHandle.get(), dc.get());

--- a/game/svg.cc
+++ b/game/svg.cc
@@ -27,7 +27,7 @@ void loadSVG(Bitmap& bitmap, fs::path const& filename) {
 		g_error_free(pError);
 		throw std::runtime_error("Unable to load " + filename.string());
 	}
-#if LIBRSVG_MAJOR_VERSION >= 2 && LIBRSVG_MINOR_VERSION >= 46
+#if LIBRSVG_MAJOR_VERSION >= 2 && LIBRSVG_MINOR_VERSION >= 52
 	gdouble svg_width = 0, svg_height = 0;
 	rsvg_handle_get_intrinsic_size_in_pixels(svgHandle.get(),&svg_width, &svg_height);
 	bitmap.resize(static_cast<int>(svg_width + 0.5)*factor, static_cast<int>(svg_height + 0.5)*factor);


### PR DESCRIPTION
ubuntu 22.04 comes with rsvg 2.52

in 2.46 rsvg_handle_get_dimensions() was deprecated and superseded by rsvg_handle_get_intrinsic_size_in_pixels

in 2.52 rsvg_handle_render_cairo() has been deprecated and superseded by rsvg_handle_render_document()

here's a quick fix.

### What does this PR do?

check whether a newer version of RSVG is installed and use the new calls instead.

### Closes Issue(s)
no issue yet, since it's a quick fix

### Motivation
keeping performous working on newer rsvg versions which will remove those calls in the future

### Additional Notes
new rsvg_handle_render_document() needs a viewport in which to render. we can all agree this should start at coordinates 0,0 but im not sure about the width/height, I took the ones coming from rsvg_handle_get_intrinsic_size_in_pixels() and apparently I guessed correctly since I don't see any visible glitches, would still be nice if someone can confirm this guess is correct.
