### PR TITLE
Adds a skip option while iterating through directories

### DIFF
--- a/game/screen_paths.cc
+++ b/game/screen_paths.cc
@@ -98,7 +98,7 @@ void ScreenPaths::generateMenuFromPath(fs::path path) {
 	
 	// Extract list of all directories
 	std::list<fs::path> directories;
-	for (const auto &di : fs::directory_iterator(path)) {
+	for (const auto &di : fs::directory_iterator(path, fs::directory_options::skip_permission_denied)) {
 		auto &p = di.path();
 		if (fs::is_directory(p) && (showHiddenfolders || p.filename().c_str()[0] != '.')) {
 			directories.emplace_back(p);


### PR DESCRIPTION
### What does this PR do?

Uses the [Directory Options](https://en.cppreference.com/w/cpp/filesystem/directory_options) to skip directories we don't have permission for without throwing an exception.

**This doesn't remove the entry from the directory list though.**

### Closes Issue(s)

Partly Closes #700 
