### PR TITLE
Updated vcpkg baseline, so we have build support with VS2022

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -41,5 +41,5 @@
       ]
     }
   ],
-  "builtin-baseline": "8c092e5cb6c275906758f0b5b54dde4ce6afaaa0"
+  "builtin-baseline": "af2287382b1991dbdcb7e5112d236f3323b9dd7a"
 }


### PR DESCRIPTION
### What does this PR do?

Updates the baseline within vcpkg.json to match the latest release: https://github.com/microsoft/vcpkg/releases/tag/2022.03.10

This adds support for Visual Studio 2022 and fixes an issue where we couldn't create a NSIS installer with VS2022

### Closes Issue(s)

Closes #698 

### Motivation

Using the latest IDE is nice since it comes with many new features.

### More

- Will update the documentation once this is merged.
