### PR TITLE
Migrates boost-format to fmt

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,8 +21,7 @@ sudo apt-get install git-core cmake build-essential gettext help2man \
    libepoxy-dev libsdl2-dev libcairo2-dev libpango1.0-dev librsvg2-dev \
    libboost-all-dev libavcodec-dev libavformat-dev libswscale-dev libswresample-dev \
    libpng-dev libjpeg-dev libxml++2.6-dev portaudio19-dev \
-   libopencv-dev libportmidi-dev libcppnetlib-dev libjsoncpp-dev
-   nlohmann-json3-dev
+   libopencv-dev libportmidi-dev libcpprest-dev nlohmann-json3-dev libfmt-dev
 ```
 
 Notice: Dependency problems may prevent installation of portaudio19-dev. At least with Ubuntu 13.04 this can be solved by first installing libjack-jackd2-dev, even though that package is not actually needed for Performous.

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -227,7 +227,7 @@ jobs:
           chmod +x appimage-builder-x86_64.AppImage
           sudo mv appimage-builder-x86_64.AppImage /usr/local/bin/appimage-builder
           sudo apt update
-          sudo apt-get install -y --no-install-recommends git cmake build-essential gettext help2man libopenblas-dev libfftw3-dev libicu-dev libepoxy-dev libsdl2-dev libfreetype6-dev libpango1.0-dev librsvg2-dev libxml++2.6-dev libavcodec-dev libavformat-dev libswscale-dev libjpeg-dev portaudio19-dev libglm-dev libboost-filesystem-dev libboost-iostreams-dev libboost-locale-dev libboost-system-dev libboost-program-options-dev libssl-dev libcpprest-dev libportmidi-dev libopencv-dev libaubio-dev nlohmann-json3-dev
+          sudo apt-get install -y --no-install-recommends git cmake build-essential gettext help2man libopenblas-dev libfftw3-dev libicu-dev libepoxy-dev libsdl2-dev libfreetype6-dev libpango1.0-dev librsvg2-dev libxml++2.6-dev libavcodec-dev libavformat-dev libswscale-dev libjpeg-dev portaudio19-dev libglm-dev libboost-filesystem-dev libboost-iostreams-dev libboost-locale-dev libboost-system-dev libboost-program-options-dev libssl-dev libcpprest-dev libportmidi-dev libopencv-dev libaubio-dev nlohmann-json3-dev libfmt-dev
 
       - name: Checkout Git
         id: checkout_git
@@ -315,14 +315,14 @@ jobs:
         run: |
           brew fetch --deps boost cmake ffmpeg@4 help2man icu4c portaudio\
             portmidi opencv libepoxy librsvg libxml++3 sdl2 dylibbundler\
-            aubio fftw glm nlohmann-json
+            aubio fftw glm nlohmann-json fmt
 
       - name: Install Dependencies
         id: install_deps
         run: |
            brew install boost cmake ffmpeg@4 help2man icu4c portaudio\
             portmidi opencv libepoxy librsvg libxml++3 sdl2 dylibbundler\
-            aubio fftw glm nlohmann-json
+            aubio fftw glm nlohmann-json fmt
            brew link ffmpeg@4
 
       - name: Build package

--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -114,6 +114,9 @@ foreach(lib ${OUR_LIBS} SDL2 PangoCairo LibRSVG LibXML++ AVFormat SWResample SWS
 	add_definitions(${${lib}_DEFINITIONS})
 endforeach(lib)
 
+find_package(fmt REQUIRED)
+target_link_libraries(performous PRIVATE fmt::fmt)
+
 target_include_directories(fs PRIVATE ${SDL2_INCLUDE_DIRS})
 target_link_libraries(fs PRIVATE ${SDL2_LIBRARIES})
 

--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -114,7 +114,7 @@ foreach(lib ${OUR_LIBS} SDL2 PangoCairo LibRSVG LibXML++ AVFormat SWResample SWS
 	add_definitions(${${lib}_DEFINITIONS})
 endforeach(lib)
 
-find_package(fmt REQUIRED)
+find_package(fmt REQUIRED CONFIG)
 target_link_libraries(performous PRIVATE fmt::fmt)
 
 target_include_directories(fs PRIVATE ${SDL2_INCLUDE_DIRS})

--- a/game/cache.cc
+++ b/game/cache.cc
@@ -1,13 +1,13 @@
 #include "cache.hh"
 #include "fs.hh"
 
-#include <boost/format.hpp>
+#include <fmt/core.h>
 #include <algorithm>
 #include <boost/algorithm/string/classification.hpp>
 
 namespace cache {
 	fs::path constructSVGCacheFileName(fs::path const& svgfilename, double factor){
-		std::string const lod = (boost::format("%.2f") % factor).str();
+		std::string const lod = fmt::format("{:.2f}", factor);
 		std::string const cache_basename = svgfilename.filename().string() + ".cache_" + lod + ".premul.png";
 		std::string fullpath = svgfilename.parent_path().string();
 		// Windows drive name handling

--- a/game/cache.cc
+++ b/game/cache.cc
@@ -1,7 +1,7 @@
 #include "cache.hh"
 #include "fs.hh"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <algorithm>
 #include <boost/algorithm/string/classification.hpp>
 

--- a/game/configuration.cc
+++ b/game/configuration.cc
@@ -8,7 +8,7 @@
 #include "screen_intro.hh"
 #include "util.hh"
 #include "game.hh"
-#include <boost/format.hpp>
+#include <fmt/core.h>
 
 #include <algorithm>
 #include <future>
@@ -90,10 +90,8 @@ namespace {
 		T s = std::abs(m * std::get<T>(step));
 		unsigned precision = 0;
 		while (s > 0.0 && (s *= 10) < 10) ++precision;
-		// Format the output
-		boost::format fmter("%f");
-		fmter % boost::io::group(std::setprecision(precision), double(m) * std::get<T>(value));
-		return fmter.str();
+		// Not quite sure how to format this with FMT
+		return fmt::format("{:d}", std::get<T>(value));
 	}
 
 	std::string getText(xmlpp::Element const& elem) {
@@ -148,7 +146,7 @@ std::string const ConfigItem::getValue() const {
 	if (m_type == "string") return std::get<std::string>(m_value);
 	if (m_type == "string_list") {
 		StringList const& sl = std::get<StringList>(m_value);
-		return sl.size() == 1 ? "{" + sl[0] + "}" : (boost::format(_("%d items")) % sl.size()).str();
+		return sl.size() == 1 ? "{" + sl[0] + "}" : fmt::format(_("{:d} items"), sl.size());
 	}
 	if (m_type == "option_list") return std::get<OptionList>(m_value).at(m_sel);
 	throw std::logic_error("ConfigItem::getValue doesn't know type '" + m_type + "'");

--- a/game/configuration.cc
+++ b/game/configuration.cc
@@ -8,7 +8,7 @@
 #include "screen_intro.hh"
 #include "util.hh"
 #include "game.hh"
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <algorithm>
 #include <future>

--- a/game/guitargraph.cc
+++ b/game/guitargraph.cc
@@ -6,7 +6,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <stdexcept>
-#include <boost/format.hpp>
+#include <fmt/core.h>
 
 namespace {
 	#if 0 // Here is some dummy gettext calls to populate the dictionary
@@ -1098,7 +1098,7 @@ void GuitarGraph::drawInfo(double time) {
 		// Draw scores
 		{
 			ColorTrans c(Color(0.1, 0.3, 1.0, 0.9));
-			m_scoreText->render((boost::format("%04d") % getScore()).str());
+			m_scoreText->render(fmt::format("{:04d}", getScore()));
 			m_scoreText->dimensions().middle(-xcor).fixedHeight(h).screenBottom(-0.22);
 			m_scoreText->draw();
 		}

--- a/game/guitargraph.cc
+++ b/game/guitargraph.cc
@@ -6,7 +6,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <stdexcept>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace {
 	#if 0 // Here is some dummy gettext calls to populate the dictionary

--- a/game/layout_singer.cc
+++ b/game/layout_singer.cc
@@ -6,7 +6,7 @@
 #include "database.hh"
 
 #include <list>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 LayoutSinger::LayoutSinger(VocalTrack& vocal, Database& database, NoteGraphScalerPtr const& scaler, std::shared_ptr<ThemeSing> theme):
   m_vocal(vocal), m_noteGraph(vocal, scaler), m_lyricit(vocal.notes.begin()), m_lyrics(), m_database(database), m_theme(theme), m_hideLyrics() {

--- a/game/layout_singer.cc
+++ b/game/layout_singer.cc
@@ -6,7 +6,7 @@
 #include "database.hh"
 
 #include <list>
-#include <boost/format.hpp>
+#include <fmt/core.h>
 
 LayoutSinger::LayoutSinger(VocalTrack& vocal, Database& database, NoteGraphScalerPtr const& scaler, std::shared_ptr<ThemeSing> theme):
   m_vocal(vocal), m_noteGraph(vocal, scaler), m_lyricit(vocal.notes.begin()), m_lyrics(), m_database(database), m_theme(theme), m_hideLyrics() {
@@ -34,7 +34,7 @@ void LayoutSinger::drawScore(PositionMode position) {
 		if (p->m_vocal.name != m_vocal.name) continue;
 		Color color(p->m_color.r, p->m_color.g, p->m_color.b, p->activity());
 		if (color.a == 0.0) continue;
-		m_score_text[i%4]->render((boost::format("%04d") % p->getScore()).str());
+		m_score_text[i % 4]->render(fmt::format("{:04d}", p->getScore()));
 		switch(position) {
 			case LayoutSinger::PositionMode::FULL:
 				m_player_icon->dimensions.left(-0.5 + 0.01 + 0.125 * j).fixedWidth(0.035).screenTop(0.055);

--- a/game/main.cc
+++ b/game/main.cc
@@ -26,7 +26,7 @@
 #include "screen_players.hh"
 #include "screen_playlist.hh"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <boost/program_options.hpp>
 #include <cstdlib>
 #include <csignal>

--- a/game/main.cc
+++ b/game/main.cc
@@ -26,7 +26,7 @@
 #include "screen_players.hh"
 #include "screen_playlist.hh"
 
-#include <boost/format.hpp>
+#include <fmt/core.h>
 #include <boost/program_options.hpp>
 #include <cstdlib>
 #include <csignal>
@@ -148,7 +148,7 @@ void mainLoop(std::string const& songlist) {
 		Profiler prof("mainloop");
 		bool benchmarking = config["graphic/fps"].b();
 		if (songs.doneLoading == true && songs.displayedAlert == false) {
-			gm.dialog((boost::format(_("Done Loading!\n Loaded %d songs.")) % songs.loadedSongs()).str());
+			gm.dialog(fmt::format(_("Done Loading!\n Loaded {0} songs."), songs.loadedSongs()));
 			songs.displayedAlert = true;
 		}
 		if (g_take_screenshot) {

--- a/game/screen_players.cc
+++ b/game/screen_players.cc
@@ -16,7 +16,7 @@
 
 #include <iostream>
 #include <sstream>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 ScreenPlayers::ScreenPlayers(std::string const& name, Audio& audio, Database& database):
   Screen(name), m_audio(audio), m_database(database), m_players(database.m_players)

--- a/game/screen_players.cc
+++ b/game/screen_players.cc
@@ -16,7 +16,7 @@
 
 #include <iostream>
 #include <sstream>
-#include <boost/format.hpp>
+#include <fmt/core.h>
 
 ScreenPlayers::ScreenPlayers(std::string const& name, Audio& audio, Database& database):
   Screen(name), m_audio(audio), m_database(database), m_players(database.m_players)
@@ -141,8 +141,7 @@ void ScreenPlayers::draw() {
 	} else {
 		// Format the player information text
 		oss_song << m_database.scores.front().track << '\n';
-		// TODO: use boost::format
-		oss_song << boost::format(_("You reached %1% points!")) % m_database.scores.front().score;
+		oss_song << fmt::format(_("You reached {0} points!"), m_database.scores.front().score);
 		oss_order << _("Change player with arrow keys.") << '\n'
 			<< _("Name:") << ' ' << m_players.current().name << '\n';
 		//m_database.queryPerPlayerHiscore(oss_order);

--- a/game/screen_sing.cc
+++ b/game/screen_sing.cc
@@ -19,7 +19,7 @@
 #include "screen_songs.hh"
 #include "notegraphscalerfactory.hh"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <iostream>
 #include <stdexcept>
 #include <cmath>

--- a/game/screen_sing.cc
+++ b/game/screen_sing.cc
@@ -19,7 +19,7 @@
 #include "screen_songs.hh"
 #include "notegraphscalerfactory.hh"
 
-#include <boost/format.hpp>
+#include <fmt/core.h>
 #include <iostream>
 #include <stdexcept>
 #include <cmath>
@@ -547,9 +547,9 @@ void ScreenSing::draw() {
 		Song::SongSection section("error", 0);
 		std::string statustxt;
 		if (m_song->getPrevSection(t - 1.0, section)) {
-			statustxt = (boost::format("%02u:%02u - %s") % (t / 60) % (t % 60) % section.name).str();
+			statustxt = fmt::format("{:02d}:{:02d} - {}", (t / 60), (t % 60), (section.name));
 		} else {
-			statustxt = (boost::format("%02u:%02u") % (t / 60) % (t % 60)).str();
+			statustxt = fmt::format("{:02d}:{:02d}", (t / 60), (t % 60));
 		}
 
 		if (!m_score_window.get() && m_instruments.empty() && !m_layout_singer.empty()) {

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -17,7 +17,7 @@
 #include <stdexcept>
 
 #include "fs.hh"
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <unicode/stsearch.h>
 
 #include <fstream>

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -17,7 +17,7 @@
 #include <stdexcept>
 
 #include "fs.hh"
-#include <boost/format.hpp>
+#include <fmt/core.h>
 #include <unicode/stsearch.h>
 
 #include <fstream>
@@ -541,7 +541,7 @@ namespace {
 		try {
 			std::string ext = s.cover.extension().string();
 			if (exists(s.cover)) {
-				std::string coverlink = "covers/" + (boost::format("%|04|") % num).str() + ext;
+				std::string coverlink = fmt::format("covers/{:04d}{:1}", num, ".jpg");
 				if (fs::is_symlink(coverlink)) fs::remove(coverlink);
 				create_symlink(s.cover, coverlink);
 				xmlpp::set_first_child_text(xmlpp::add_child_element(song, "cover"), coverlink);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,7 +7,6 @@
     "boost-program-options",
     "boost-iostreams",
     "boost-system",
-    "boost-format",
     "boost-locale",
     {
       "name": "boost-locale",
@@ -41,7 +40,8 @@
       ]
     },
     "nlohmann-json",
-    "aubio"
+    "aubio",
+    "fmt"
   ],
   "builtin-baseline": "14e7bb4ae24616ec54ff6b2f6ef4e8659434ea44"
 }


### PR DESCRIPTION
### What does this PR do?
Removed boost-format added fmt.
Updated the various places to use fmt
Updated CI to use `libfmt-dev`

### Closes Issue(s)

Closes partly #39 

~~Depends on https://github.com/performous/performous-docker/pull/20~~ Has been merged :)

### Motivation

libfmt is way faster than boost is and the syntax is quite a bit nicer.
Also removing boost completely has been on our roadmap, since it's a very big dependency.

### Additional Notes

Do take a special look to the `configuration.cc` -> `numericFormat` template method. I'm not quite sure if i did the right conversion. During runtime i didn't see any problems.
