### PR TITLE
Fix build with GCC 12

### DIFF
--- a/game/libda/sample.hpp
+++ b/game/libda/sample.hpp
@@ -62,10 +62,12 @@ namespace da {
 	static inline int conv_to_s24_fast(sample_t s) { return static_cast<int>(s * max_s24); }
 	static inline int conv_to_s32_fast(sample_t s) { return static_cast<int>(s * max_s32); }
 
-	template <typename ValueType> class step_iterator: public std::iterator<std::random_access_iterator_tag, ValueType> {
+	template <typename ValueType> class step_iterator {
 		ValueType* m_pos;
 		std::ptrdiff_t m_step;
 	  public:
+        using iterator_category = std::random_access_iterator_tag;
+        using value_type = ValueType;
 		step_iterator(ValueType* pos, std::ptrdiff_t step): m_pos(pos), m_step(step) {}
 		ValueType& operator*() { return *m_pos; }
 		step_iterator operator+(std::ptrdiff_t rhs) { return step_iterator(m_pos + m_step * rhs, m_step); }


### PR DESCRIPTION

### Motivation

allow to build with gcc 12 and in Fedora 36

https://gcc.gnu.org/gcc-12/porting_to.html
 The following headers are used less widely in libstdc++ and may need to be included explicitly when compiled with GCC 12: 

please test and confirm this fix is good .

Thank you 
