### PR TITLE
Fixed latest build links to be a direct download

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 Performous
 ==========
 
-Build status
-[![Build Status](https://performous.semaphoreci.com/badges/performous.svg)](https://performous.semaphoreci.com/projects/performous)
+[![Build Status](https://github.com/performous/performous/actions/workflows/build_and_release.yml/badge.svg?branch=master)](https://github.com/performous/performous/actions?query=branch%3Amaster+workflow%3A%22Build+and+Release+Performous%22+is%3Asuccess)
 
 An open-source karaoke, band and dancing game where one or more players perform a song and the game scores their performances. Supports songs in UltraStar, Frets on Fire and StepMania formats. Microphones and instruments from SingStar, Guitar Hero and Rock Band as well as some dance pads are autodetected.
 
@@ -16,11 +15,11 @@ For compiling instructions, see docs/Compiling.txt or visit the wiki page: https
 
 Latest builds
 ==========
-- [Windows](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest.exe)
-- [Mac OS X](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest.dmg)
-- [Linux - Ubuntu 18.04](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-ubuntu_18.04.deb)
-- [Linux - Ubuntu 20.04](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-ubuntu_20.04.deb)
-- [Linux - Ubuntu 22.04](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-ubuntu_22.04.deb)
-- [Linux - Fedora 33](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-fedora_33.rpm)
-- [Linux - Fedora 34](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-fedora_34.rpm)
-- [Linux - Fedora 35](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-fedora_35.rpm)
+- [Windows](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest.exe.zip)
+- [Mac OS X](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest.dmg.zip)
+- [Linux - Ubuntu 18.04](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-ubuntu_18.04.deb.zip)
+- [Linux - Ubuntu 20.04](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-ubuntu_20.04.deb.zip)
+- [Linux - Ubuntu 22.04](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-ubuntu_22.04.deb.zip)
+- [Linux - Fedora 33](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-fedora_33.rpm.zip)
+- [Linux - Fedora 34](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-fedora_34.rpm.zip)
+- [Linux - Fedora 35](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-fedora_35.rpm.zip)


### PR DESCRIPTION
### What does this PR do?

Changed the links to be direct download links.
Updated the badge to reflect the GH-Actions statusses

### Closes Issue(s)

None

### Notes

Nightly.Link / GH-Actions doesn't let us download the file directly without authentication. Therefore it's wrapped within a zip file which can be downloaded without authentication.