### PR TITLE
Fix libcrypt issue on Arch

### DIFF
--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -57,13 +57,15 @@ AppDir:
       - usr/share/doc/*/changelog.*
       - usr/share/doc/*/NEWS.*
       - usr/share/doc/*/TODO.*
-  after_bundle:
+  after_bundle: |
     ## In Fedora and Gentoo (probably others too), libnsl has been deprecated
     ## from glibc and is available in another package. It still exists as part
     ## of the Debian lineage, and must be copied into the project root so it
     ## can run on Distros where it is not available by default.
     ## Hopefully this can be removed some day.
     cp $TARGET_APPDIR/runtime/compat/lib/x86_64-linux-gnu/libnsl.so.1 $TARGET_APPDIR/
+    ## This needs to be copied to make Arch work
+    cp $TARGET_APPDIR/runtime/compat/lib/x86_64-linux-gnu/libcrypt.so.1 $TARGET_APPDIR/
 AppImage:
   arch: x86_64
   update-information: None


### PR DESCRIPTION
### What does this PR do?

Running the AppImage in Arch produces the following errors:
```sh
/tmp/.mount_perforY45pZh//usr/bin/performous: /usr/lib/libcrypt.so.1: version XCRYPT_2.0' not found (required by /tmp/.mount_perforY45pZh//usr/lib/x86_64-linux-gnu/libkrb5.so.26)
/tmp/.mount_perforY45pZh//usr/bin/performous: /usr/lib/libcrypt.so.1: version XCRYPT_2.0' not found (required by /tmp/.mount_perforY45pZh//usr/lib/x86_64-linux-gnu/libroken.so.18)
```

### Closes Issue(s)

None

### Motivation
Reported by a user in Discord


### More

None

### Additional Notes

A similar fix was needed to make the AppImage run on Fedora and Gentoo
