### PR TITLE
Initialize and destroy Portaudio once

### DIFF
--- a/game/audio.cc
+++ b/game/audio.cc
@@ -440,13 +440,11 @@ int Device::operator()(float const* inbuf, float* outbuf, unsigned long frames) 
 
 struct Audio::Impl {
 	Output output;
-	portaudio::Init init;
 	std::deque<Analyzer> analyzers;
 	std::deque<Device> devices;
 	bool playback = false;
 	std::string selectedBackend = Audio::backendConfig().getValue();
 	Impl() {
-		populateBackends(portaudio::AudioBackends().getBackends());
 		std::clog << portaudio::AudioBackends().dump() << std::flush; // Dump PortAudio backends and devices to log.
 		// Parse audio devices from config
 		ConfigItem::StringList devs = config["audio/devices"].sl();
@@ -546,9 +544,13 @@ struct Audio::Impl {
 	}
 };
 
-Audio::Audio(): self(std::make_unique<Impl>()) {
+portaudio::Init Audio::init;
+
+Audio::Audio() {
 	aubio_tempo_set_silence(Audio::aubioTempo.get(), -50.0);
 	aubio_tempo_set_threshold(Audio::aubioTempo.get(), 0.4);
+        populateBackends(portaudio::AudioBackends().getBackends());
+        self = std::make_unique<Impl>();
 }
 Audio::~Audio() { close(); }
 

--- a/game/audio.hh
+++ b/game/audio.hh
@@ -75,6 +75,8 @@ class ConfigItem;
 /** @short High level audio playback API **/
 class Audio {
 	friend int getBackend();
+        // static because Port audio once for the whole software lifetime
+	static portaudio::Init init;
 	struct Impl;
 	std::unique_ptr<Impl> self;
 	friend class ScreenSongs;


### PR DESCRIPTION
Portaudio requires to call init and shutdown *once* per application,
but we were calling it everythime we were changing the audio subsystem.

This patch fixes that by making sure it is called only once.
