### PR TITLE
Instantly translate menus as lang changes

### DIFF
--- a/game/configuration.cc
+++ b/game/configuration.cc
@@ -135,7 +135,7 @@ std::string const ConfigItem::getValue() const {
 	if (this->getName() == "game/language") {
 		int autoLanguageType = 1337;
 		int val = LanguageToLanguageId(this->getEnumName()); // In the case of the language, val is the real value while m_value is the enum case for its cosmetic name.
-		std::string languageName = (val != autoLanguageType) ? this->getEnumName() : _("Auto");
+		std::string languageName = (val != autoLanguageType) ? this->getEnumName() : "Auto";
 		return languageName;
 	}
 	if (m_type == "int") {
@@ -331,7 +331,7 @@ void writeConfig(bool system) {
 			auto newLanguagestr = item.getEnumName();
 			auto currentLanguageId = LanguageToLanguageId(currentLanguageStr);
 			auto newLanguageId = LanguageToLanguageId(newLanguagestr);
-			if ((newLanguagestr == _("Auto") || currentLanguageId != newLanguageId) && !config["game/language"].getOldValue().empty()) {
+			if ((newLanguagestr == "Auto" || currentLanguageId != newLanguageId) && !config["game/language"].getOldValue().empty()) {
 				std::cout << "Wanting to change something, old value: '" << currentLanguageStr << "' new value: '" << newLanguagestr << "'" << std::endl;
 				entryNode->set_attribute("value", std::to_string(newLanguageId));
 				config["game/language"].selectEnum(newLanguagestr);
@@ -451,23 +451,23 @@ int PaHostApiNameToHostApiTypeId (const std::string& name) {
 }
 
 unsigned int LanguageToLanguageId(const std::string& name) {
-	if (name == _("Asturian")) return 1;
-	if (name == _("Danish")) return 2;
-	if (name == _("German")) return 3;
-	if (name == _("English")) return 4;
-	if (name == _("Spanish")) return 5;
-	if (name == _("Persian")) return 6;
-	if (name == _("Finnish")) return 7;
-	if (name == _("French")) return 8;
-	if (name == _("Hungarian")) return 9;
-	if (name == _("Italian")) return 10;
-	if (name == _("Japanese")) return 11;
-	if (name == _("Dutch")) return 12;
-	if (name == _("Polish")) return 13;
-	if (name == _("Portuguese")) return 14;
-	if (name == _("Slovak")) return 15;
-	if (name == _("Swedish")) return 16;
-	if (name == _("Chinese")) return 17;
+	if (name == "Asturian") return 1;
+	if (name == "Danish") return 2;
+	if (name == "German") return 3;
+	if (name == "English") return 4;
+	if (name == "Spanish") return 5;
+	if (name == "Persian") return 6;
+	if (name == "Finnish") return 7;
+	if (name == "French") return 8;
+	if (name == "Hungarian") return 9;
+	if (name == "Italian") return 10;
+	if (name == "Japanese") return 11;
+	if (name == "Dutch") return 12;
+	if (name == "Polish") return 13;
+	if (name == "Portuguese") return 14;
+	if (name == "Slovak") return 15;
+	if (name == "Swedish") return 16;
+	if (name == "Chinese") return 17;
 
 	return 1337; // if no name matched return "Auto" which translates to computer language OR English.
 }

--- a/game/configuration.cc
+++ b/game/configuration.cc
@@ -185,14 +185,6 @@ void ConfigItem::addEnum(std::string name) {
 	m_step = 1;
 }
 
-void ConfigItem::removeAllEnums() {
-	verifyType("int");
-	m_enums.clear();
-	m_min = 0;
-	m_max = int(m_enums.size() - 1);
-	m_step = 1;
-}
-
 void ConfigItem::selectEnum(std::string const& name) {
 	auto it = std::find(m_enums.begin(), m_enums.end(), name);
 	if (it == m_enums.end()) throw std::runtime_error("Enum value " + name + " not found in " + m_shortDesc);
@@ -497,11 +489,8 @@ void populateBackends (const std::list<std::string>& backendList) {
 	backendConfig.setOldValue(backendConfig.getEnumName());
 }
 
-void populateLanguages(const std::map<std::string, std::string>& languages, bool refreshOutDated) {
+void populateLanguages(const std::map<std::string, std::string>& languages) {
 	ConfigItem& languageConfig = config["game/language"];
-	if (refreshOutDated) {
-		languageConfig.removeAllEnums();
-	}
 	for (auto const& language : languages) {
 		languageConfig.addEnum(language.second);
 	}

--- a/game/configuration.hh
+++ b/game/configuration.hh
@@ -43,7 +43,6 @@ class ConfigItem {
 	std::string const& getShortDesc() const { return m_shortDesc; } ///< get the short description for this ConfigItem
 	std::string const& getLongDesc() const { return m_longDesc; } ///< get the long description for this ConfigItem
 	void addEnum(std::string name); ///< Dynamically adds an enum to all values
-	void removeAllEnums(); /// Removes all the enum values from this entry.
 	void selectEnum(std::string const& name); ///< Set integer value by enum name
 	std::string const getEnumName() const; ///< Returns the selected enum option's text
 
@@ -75,7 +74,7 @@ extern Config config; ///< A global variable that contains all config items
 /** Read config schema and configuration from XML files **/
 void readConfig();
 void populateBackends(const std::list<std::string>& backendList);
-void populateLanguages(const std::map<std::string, std::string>& languages, bool refreshOutDated = false);
+void populateLanguages(const std::map<std::string, std::string>& languages);
 
 /** Write modified config options to user's or system-wide config XML **/
 void writeConfig(bool system = false);

--- a/game/i18n.cc
+++ b/game/i18n.cc
@@ -5,6 +5,10 @@
 
 TranslationEngine::TranslationEngine(const char *package) : m_package(package) {
 	initializeAllLanguages();
+	/* set all languages in configuration.
+	 * They are kept untranslated internally which prevents having issues
+	 * when changing languages (and need to update internal stuff with
+	 * translations) */
 	populateLanguages(GetAllLanguages());
 
 	std::clog << "locale/debug: Checking if language is set in config." << std::endl;
@@ -43,7 +47,6 @@ void TranslationEngine::setLanguage(const std::string& language, bool fromSettin
 	try {
 		std::locale::global(m_gen(m_currentLanguage.first));
 		std::cout << "locale/notice: Current language is: '" << m_currentLanguage.second << "'" << std::endl;
-		populateLanguages(GetAllLanguages(true), true);
 	}
 	catch (std::runtime_error& e) {
 		std::clog << "locale/warning: Unable to detect locale, will try to fallback to en_US.UTF-8. Exception: " << e.what() << std::endl;
@@ -52,7 +55,7 @@ void TranslationEngine::setLanguage(const std::string& language, bool fromSettin
 }
 
 std::string TranslationEngine::getLanguageByHumanReadableName(const std::string& language) {
-	if (language == _("Auto")) {
+	if (language == "Auto") {
 		return boost::locale::util::get_system_locale(true);
 	}
 
@@ -89,25 +92,27 @@ std::map<std::string, std::string> TranslationEngine::GetAllLanguages(bool refre
 	}
 	if (m_languages.size() != 0) return m_languages;
 
+	// Internally, all strings are kept in English, but they are eventually
+	// displayed as menu entries thus they need translation
 	m_languages = {
-		{ "None", _("Auto") },
-		{ "ast_ES.UTF-8", _("Asturian") },
-		{ "da_DK.UTF-8", _("Danish") },
-		{ "de_DE.UTF-8", _("German") },
-		{ "en_US.UTF-8", _("English") },
-		{ "es_ES.UTF-8", _("Spanish") },
-		{ "fa_IR.UTF-8", _("Persian") },
-		{ "fi_FI.UTF-8", _("Finnish") },
-		{ "fr_FR.UTF-8", _("French") },
-		{ "hu_HU.UTF-8", _("Hungarian") },
-		{ "it_IT.UTF-8", _("Italian") },
-		{ "ja_JP.UTF-8", _("Japanese") },
-		{ "nl_NL.UTF-8", _("Dutch") },
-		{ "pl_PL.UTF-8", _("Polish") },
-		{ "pt_PT.UTF-8", _("Portuguese") },
-		{ "sk_SK.UTF-8", _("Slovak") },
-		{ "sv_SE.UTF-8", _("Swedish") },
-		{ "zh_CN.UTF-8", _("Chinese") }
+		{ "None", translate_noop("Auto") },
+		{ "ast_ES.UTF-8", translate_noop("Asturian") },
+		{ "da_DK.UTF-8", translate_noop("Danish") },
+		{ "de_DE.UTF-8", translate_noop("German") },
+		{ "en_US.UTF-8", translate_noop("English") },
+		{ "es_ES.UTF-8", translate_noop("Spanish") },
+		{ "fa_IR.UTF-8", translate_noop("Persian") },
+		{ "fi_FI.UTF-8", translate_noop("Finnish") },
+		{ "fr_FR.UTF-8", translate_noop("French") },
+		{ "hu_HU.UTF-8", translate_noop("Hungarian") },
+		{ "it_IT.UTF-8", translate_noop("Italian") },
+		{ "ja_JP.UTF-8", translate_noop("Japanese") },
+		{ "nl_NL.UTF-8", translate_noop("Dutch") },
+		{ "pl_PL.UTF-8", translate_noop("Polish") },
+		{ "pt_PT.UTF-8", translate_noop("Portuguese") },
+		{ "sk_SK.UTF-8", translate_noop("Slovak") },
+		{ "sv_SE.UTF-8", translate_noop("Swedish") },
+		{ "zh_CN.UTF-8", translate_noop("Chinese") }
 	};
 
 	return m_languages;

--- a/game/menu.cc
+++ b/game/menu.cc
@@ -66,6 +66,11 @@ void Menu::action(int dir) {
 				}
 				if (dir > 0) ++(*(current().value));
 				else if (dir < 0) --(*(current().value));
+
+				if (current().value->getName() == "game/language") {
+					auto &value = config["game/language"];
+					Game::getSingletonPtr()->setLanguage(value.getValue());
+				}
 			}
 			break;
 		}

--- a/game/screen_intro.cc
+++ b/game/screen_intro.cc
@@ -109,7 +109,7 @@ void ScreenIntro::draw_menu_options() {
 			{
 				ColorTrans c(Color::alpha(opt.isActive() ? 1.0 : 0.5));
 				theme->option_selected.dimensions.left(x).center(start_y + ii*0.065);
-				theme->option_selected.draw(opt.getName());
+				theme->option_selected.draw(_(opt.getName()));
 			}
 			wcounter = std::max(wcounter, theme->option_selected.w() + 2 * sel_margin); // Calculate the widest entry
 			// If this is a config item, show the value below
@@ -121,7 +121,7 @@ void ScreenIntro::draw_menu_options() {
 
 		// Regular option (not selected)
 		} else {
-			std::string title = opt.getName();
+			std::string title = _(opt.getName());
 			SvgTxtTheme& txt = getTextObject(title);
 			ColorTrans c(Color::alpha(opt.isActive() ? 1.0 : 0.5));
 			txt.dimensions.left(x).center(start_y + ii*0.065);
@@ -144,7 +144,7 @@ void ScreenIntro::draw() {
 	theme->comment_bg.dimensions.center().screenBottom(-0.01);
 	theme->comment_bg.draw();
 	theme->comment.dimensions.left(-0.48).screenBottom(-0.028);
-	theme->comment.draw(m_menu.current().getComment());
+	theme->comment.draw(_(m_menu.current().getComment()));
 	// Key help for config
 	if (m_menu.getSubmenuLevel() > 0) {
 		theme->short_comment_bg.dimensions.stretch(theme->short_comment.w() + 0.065, 0.025);
@@ -171,8 +171,8 @@ void ScreenIntro::populateMenu() {
 	MenuImage imgConfig(new Texture(findFile("intro_configure.svg")));
 	MenuImage imgQuit(new Texture(findFile("intro_quit.svg")));
 	m_menu.clear();
-	m_menu.add(MenuOption(_("Perform"), _("Start performing!"), imgSing).screen("Songs"));
-	m_menu.add(MenuOption(_("Practice"), _("Check your skills or test the microphones."), imgPractice).screen("Practice"));
+	m_menu.add(MenuOption(translate_noop("Perform"), translate_noop("Start performing!"), imgSing).screen("Songs"));
+	m_menu.add(MenuOption(translate_noop("Practice"), translate_noop("Check your skills or test the microphones."), imgPractice).screen("Practice"));
 	// Configure menu + submenu options
 	MenuOptions configmain;
 	for (auto const& submenu: configMenu) {
@@ -181,15 +181,15 @@ void ScreenIntro::populateMenu() {
 			// Process items that belong to that submenu
 			for (auto const& item: submenu.items) {
 				ConfigItem& c = config[item];
-				opts.push_back(MenuOption(_(c.getShortDesc()), _(c.getLongDesc())).changer(c));
+				opts.push_back(MenuOption(c.getShortDesc(), c.getLongDesc()).changer(c));
 			}
-			configmain.push_back(MenuOption(_(submenu.shortDesc), _(submenu.longDesc), imgConfig).submenu(opts));
+			configmain.push_back(MenuOption(submenu.shortDesc, submenu.longDesc, imgConfig).submenu(opts));
 		} else {
-			configmain.push_back(MenuOption(_(submenu.shortDesc), _(submenu.longDesc), imgConfig).screen(submenu.name));
+			configmain.push_back(MenuOption(submenu.shortDesc, submenu.longDesc, imgConfig).screen(submenu.name));
 		}
 	}
-	m_menu.add(MenuOption(_("Configure"), _("Configure audio and game options."), imgConfig).submenu(configmain));
-	m_menu.add(MenuOption(_("Quit"), _("Leave the game."), imgQuit).screen(""));
+	m_menu.add(MenuOption(translate_noop("Configure"), translate_noop("Configure audio and game options."), imgConfig).submenu(configmain));
+	m_menu.add(MenuOption(translate_noop("Quit"), translate_noop("Leave the game."), imgQuit).screen(""));
 }
 
 #ifdef USE_WEBSERVER


### PR DESCRIPTION
This pr makes it possible to change the translation of the menu
dynamicaly when changing the current language. This prevents the need to
restart or save the config.

https://user-images.githubusercontent.com/820313/166120410-3ec5750b-8b01-4f67-ad95-fd459671b03c.mp4


