### PR TITLE
Fixes a problem where localization wasn't functioning without make install

### DIFF
--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -9,7 +9,13 @@ file(GLOB _languages *.po)
 set(_mofiles)
 foreach(_pofile ${_languages})
 	get_filename_component(_language ${_pofile} NAME_WE)
-	set(_mofile ${CMAKE_CURRENT_BINARY_DIR}/${_language}.mo)
+	if(WIN32)
+		# For some reason we need this structure on Windows to make localization work for a local build folder without install.
+		set(_mofile ${CMAKE_CURRENT_BINARY_DIR}/${_language}/LC_MESSAGES/${CMAKE_PROJECT_NAME}.mo)
+	else()
+		set(_mofile ${CMAKE_CURRENT_BINARY_DIR}/${_language}.mo)
+	endif()
+
 	add_custom_command(
 		OUTPUT ${_mofile}
 		COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} -v ${_pofile} -o ${_mofile}


### PR DESCRIPTION
### What does this PR do?

In current master when running performous from the build folder without running `make install` localization isn't working _on windows._
This is due to the fact that the localization has to be a specific format for `gettext` to understand namely:
```
.root-locale-dir
|----> en
|---------> LC_MESSAGES
|----------------> Performous.mo
|----> de
|---------> LC_MESSAGES
|----------------> Performous.mo
```

This PR fixes that issue.

### Closes Issue(s)

None

### Motivation

Wanted to try out #747 but ran into this issue.