### PR TITLE
Retire Fedora 33, add Fedora 36

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -105,9 +105,9 @@ jobs:
           - ubuntu18.04
           - ubuntu20.04
           - ubuntu22.04
-          - fedora33
           - fedora34
           - fedora35
+          - fedora36
     steps:
       - name: Checkout Git
         id: checkout_git

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Latest builds
 - [Linux - Ubuntu 18.04](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-ubuntu_18.04.deb.zip)
 - [Linux - Ubuntu 20.04](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-ubuntu_20.04.deb.zip)
 - [Linux - Ubuntu 22.04](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-ubuntu_22.04.deb.zip)
-- [Linux - Fedora 33](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-fedora_33.rpm.zip)
 - [Linux - Fedora 34](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-fedora_34.rpm.zip)
 - [Linux - Fedora 35](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-fedora_35.rpm.zip)
+- [Linux - Fedora 36](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-fedora_36.rpm.zip)
 - [Linux - AppImage](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest.AppImage.zip)


### PR DESCRIPTION
### What does this PR do?

Fedora 36 will debut in a few weeks, so enabling the build for it during beta like we did for Ubuntu 22.04

Fedora 33 has been end-of-life'd for almost a year now, so removing it from our builds.

### Closes Issue(s)

None

### Motivation

[Mentioning of debut of Fedora 36 in this issue](https://github.com/performous/performous/pull/727)


### More

None

### Additional Notes

After this is merged, https://github.com/performous/performous-docker/pull/19 will also need to be merged.

`Fedora 33` will need to be removed as a required check, and `Fedora 36` will need to be added as a required check in this repo.