### PR TITLE
Added conversion compile option for gcc and clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ if (APPLE)
 	endif()
 endif()
 
-add_compile_options(-Wall $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wextra> $<$<CXX_COMPILER_ID:gcc>:-fcx-limited-range>)
+add_compile_options(-Wall $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wextra> $<$<CXX_COMPILER_ID:gcc>:-fcx-limited-range> $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wconversion>)
 
 if(WIN32)
 	set(CMAKE_CXX_FLAGS "-DWIN32_LEAN_AND_MEAN ${CMAKE_CXX_FLAGS}")


### PR DESCRIPTION
### What does this PR do?

This enables warnings about conversion. Within our codebase we do a lot of possible faulty conversions from double to float and other types.

### Closes Issue(s)

None

### Motivation

- Warnings are there for mostly a good reason. In our case for conversions, we have many methods using double, while we give in floats or the other way around. 
- Wanting to go warning free so we can enable treat warnings as errors.
- Windows currently complains about a lot of warnings which of many are these conversion warnings.
