### PR TITLE
Fix crash on shader error destroy

### DIFF
--- a/data/shaders/dancenote.vert
+++ b/data/shaders/dancenote.vert
@@ -18,7 +18,7 @@ layout (std140) uniform danceNote {
 	float clock;
 	float scale;
 	vec2 position;
-	float padding[2];
+	float dnPadding[2];
 };
 
 out vData {

--- a/data/shaders/stereo3d.geom
+++ b/data/shaders/stereo3d.geom
@@ -4,7 +4,7 @@
 layout (std140) uniform stereoParams {
 	float sepFactor;
 	float z0;
-	float padding[2];
+	float s3dPadding[2];
 };
 
 layout(triangles) in;

--- a/game/configuration.cc
+++ b/game/configuration.cc
@@ -299,13 +299,6 @@ void writeConfig(bool system) {
 		entryNode->set_attribute("name", name);
 		std::string type = item.get_type();
 		entryNode->set_attribute("type", type);
-		if (name == "graphic/stereo3d") {
-			std::string prev3DState = item.getOldValue();
-			if (prev3DState != std::to_string(item.b()) && !prev3DState.empty()) {
-				std::clog << "video/info: Stereo 3D configuration changed, will reset shaders." << std::endl;
-				Game::getSingletonPtr()->window().resetShaders();
-			}
-		}
 		if (name == "audio/backend") {
 			std::string currentBackEnd = Audio::backendConfig().getOldValue();
 			int oldValue = PaHostApiNameToHostApiTypeId(currentBackEnd);

--- a/game/fbo.hh
+++ b/game/fbo.hh
@@ -16,7 +16,8 @@ class FBO {
 	}
 	/// Handle clean-up
 	~FBO() {
-		if (m_fbo) glDeleteFramebuffers(1, &m_fbo);
+		if (glIsFramebuffer(m_fbo))
+			glDeleteFramebuffers(1, &m_fbo);
 	}
 	/// Returns a reference to the attached texture
 	OpenGLTexture<GL_TEXTURE_2D>& getTexture() {

--- a/game/glutil.hh
+++ b/game/glutil.hh
@@ -37,7 +37,7 @@ namespace glutil {
 	struct stereo3dParams {
 		float sepFactor; // 256
 		float z0; // 260
-		float padding[2] = {7.0, 13.0}; // 264
+		float s3dPadding[2] = {7.0, 13.0}; // 264
 		
 		static GLsizeiptr size() { return sizeof(stereo3dParams); };
 		static GLintptr offset() { return alignOffset(shaderMatrices::size()); };
@@ -65,7 +65,7 @@ namespace glutil {
 		float clock; // 344
 		float scale; // 348
 		glmath::vec2 position; // 352
-		float padding[2] = {7.0, 13.0};
+		float dnPadding[2] = {7.0, 13.0};
 
 		static GLsizeiptr size() { return sizeof(danceNoteUniforms); };
 		static GLintptr offset() { return alignOffset(lyricColorUniforms::offset() + lyricColorUniforms::size()); };

--- a/game/menu.cc
+++ b/game/menu.cc
@@ -70,9 +70,15 @@ void Menu::action(int dir) {
 					auto &value = config["game/language"];
 					Game::getSingletonPtr()->setLanguage(value.getValue());
 				} else if (current().value->getName() == "graphic/stereo3d") {
-					std::clog << "video/info: Stereo 3D configuration changed, will reset shaders." << std::endl;
-					Game::getSingletonPtr()->window().resetShaders();
-				}
+					try {
+						std::clog << "video/info: Stereo 3D configuration changed, will reset shaders.\n";
+						Game::getSingletonPtr()->window().resetShaders();
+					} catch (const std::exception &) {
+						std::cerr << "video/info: Disable Stereo 3D because shader creation failed.\n";
+						current().value->b() = false; // Disable 3D if shader fails
+						throw;
+					}
+                                }
 			}
 			break;
 		}

--- a/game/menu.cc
+++ b/game/menu.cc
@@ -61,8 +61,7 @@ void Menu::action(int dir) {
 					current().value->setOldValue(current().value->getValue());
 				}
 				else if (current().value->getName() == "graphic/stereo3d") {
-					std::string oldValue((current().value->getValue() == _("Disabled")) ? "0" : "1");
-					current().value->setOldValue(oldValue);
+					current().value->setOldValue(current().value->getValue());
 				}
 				if (dir > 0) ++(*(current().value));
 				else if (dir < 0) --(*(current().value));
@@ -70,6 +69,9 @@ void Menu::action(int dir) {
 				if (current().value->getName() == "game/language") {
 					auto &value = config["game/language"];
 					Game::getSingletonPtr()->setLanguage(value.getValue());
+				} else if (current().value->getName() == "graphic/stereo3d") {
+					std::clog << "video/info: Stereo 3D configuration changed, will reset shaders." << std::endl;
+					Game::getSingletonPtr()->window().resetShaders();
 				}
 			}
 			break;


### PR DESCRIPTION
Fixes #750 

Prevent trying to delete a FBO that was invalidated and report the shader error early when creation fails.