### PR TITLE
Fix a breaking change in ubuntu 1804 docker image

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -131,6 +131,10 @@ jobs:
             # Ubuntu 18.04 has system Aubio 0.4.5, this is not enough
             # because performous requires a minimum version of 0.4.9.
             EXTRA_CMAKE_ARGS="${EXTRA_CMAKE_ARGS} -DSELF_BUILT_AUBIO=ALWAYS"
+            if ([ "${ID}" = "ubuntu" ]); then
+              export CC=gcc-8
+              export CXX=g++-8
+            fi
           fi
 
           ## Figure out what type of packages we need to generate
@@ -140,7 +144,7 @@ jobs:
             'ubuntu')
           PACKAGE_TYPE='DEB';;
             *)
-          PACKAGE_TYPE='TAR';;
+          PACKAGE_TYPE='TGZ';;
           esac
 
           PACKAGE_VERSION=${{ needs.determine_version.outputs.complete_version }}


### PR DESCRIPTION
### What does this PR do?

Fixes the Ubuntu1804 build since we made a breaking change in https://github.com/performous/performous-docker/pull/14
We need to add `CC` and `CXX` variables and set them correctly for ubuntu1804 since ubuntu1804 ships with GCC 7, while we need 8 for `std::filesystem`

### Closes Issue(s)

None
