### PR TITLE
Run an apt update on the appimage builder

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -226,6 +226,7 @@ jobs:
           wget -O appimage-builder-x86_64.AppImage https://github.com/AppImageCrafters/appimage-builder/releases/download/v1.0.0-beta.1/appimage-builder-1.0.0-677acbd-x86_64.AppImage
           chmod +x appimage-builder-x86_64.AppImage
           sudo mv appimage-builder-x86_64.AppImage /usr/local/bin/appimage-builder
+          sudo apt update
           sudo apt-get install -y --no-install-recommends git cmake build-essential gettext help2man libopenblas-dev libfftw3-dev libicu-dev libepoxy-dev libsdl2-dev libfreetype6-dev libpango1.0-dev librsvg2-dev libxml++2.6-dev libavcodec-dev libavformat-dev libswscale-dev libjpeg-dev portaudio19-dev libglm-dev libboost-filesystem-dev libboost-iostreams-dev libboost-locale-dev libboost-system-dev libboost-program-options-dev libssl-dev libcpprest-dev libportmidi-dev libopencv-dev libaubio-dev nlohmann-json3-dev
 
       - name: Checkout Git


### PR DESCRIPTION
### What does this PR do?

Runs `sudo apt update` before trying the install on the AppImage builder to make double sure we have a valid archive. This should have been done anyway.

### Closes Issue(s)

None

### Motivation

Failed Appimage builds


### More

Tried it on a whim and it cleared the issue.

### Additional Notes

None
