### PR TITLE
Always run the commenter

### DIFF
--- a/.github/workflows/comment_on_pr.yml
+++ b/.github/workflows/comment_on_pr.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   pr_comment:
     name: Add packages to PRs
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'completed'
+    if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Get the PR number


### PR DESCRIPTION
### What does this PR do?

Enables the commenter to run on workflows even if they aren't completely successful.

### Closes Issue(s)

None

### Motivation

Sometimes failed runs will still produce artifacts that can be valuable when uploaded to a PR, even if one of the builds failed. Currently, even if only something like the Windows build or the Mac build failed, it would block the rest of the artifacts from all of the other builds from being posted, even if they are successful.


### More

None

### Additional Notes

Initially I had taken this code from another repo that was only using a single build as the canary, so if that was going to fail then it wouldn't make any sense to run it because no artifacts would have been produced. In our case, there is the potential that artifacts can be produced, so it should be run on every workflow. If there are indeed no artifacts produced for a workflow, then the commenter will bail anyway with an error and will not post a comment to the PR.