### PR TITLE
Don't include libasound2 in appimage

### DIFF
--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -49,7 +49,8 @@ AppDir:
       - libswresample3
       - libswscale5
       - libxml++2.6-2v5
-    exclude: []
+    exclude:
+      - libasound2
   files:
     exclude:
       - usr/share/man


### PR DESCRIPTION
### What does this PR do?

This PR exludes libasound2 from the appimage, which result in the host system's libasound2 being used.
This should fix a bunch of problems with audio not working on (for example) archlinux

### Motivation

I was trying to run the appimage on archlinux, while pure ALSA works (directly to the hardware) pulseaudio support was not working, this was caused by libasound2 not being able to load the alsa-pulse plugin:
```
ALSA lib dlmisc.c:283:(snd_dlobj_cache_get0) Cannot open shared library /usr/lib/x86_64-linux-gnu/alsa-lib/libasound_module_pcm_pulse.so ((null): /usr/lib/x86_64-linux-gnu/alsa-lib/libasound_module_pcm_pulse.so: cannot open shared object file: No such file or directory)
ALSA lib dlmisc.c:283:(snd_dlobj_cache_get0) Cannot open shared library /usr/lib/x86_64-linux-gnu/alsa-lib/libasound_module_pcm_pulse.so ((null): /usr/lib/x86_64-linux-gnu/alsa-lib/libasound_module_pcm_pulse.so: cannot open shared object file: No such file or directory)
````

### Additional Notes

libasound2 does dynamic plugin loading, but the paths to those plugins differ between distros, even when including all the plugins in the appimage, it still fails to load them.
Given that libasound2 should be present on any modern~ish system with a working audio setup, loading it from the host should not be an issue.
