### PR TITLE
Speed up the sorting of songs by score

### DIFF
--- a/game/database.cc
+++ b/game/database.cc
@@ -80,7 +80,7 @@ bool Database::reachedHiscore(std::shared_ptr<Song> s) const {
 	unsigned score = scores.front().score;
 	const auto track = scores.front().track;
 	const auto songid = m_songs.lookup(s);
-	if (!songid) { 
+	if (!songid) {
 		std::clog << "database/error: Invalid song ID for song: " + s->artist + " - " + s->title << std::endl;
 		return false;
 	}
@@ -102,7 +102,7 @@ void Database::queryOverallHiscore(std::ostream & os, std::string const& track) 
 void Database::queryPerSongHiscore(std::ostream & os, std::shared_ptr<Song> s, std::string const& track) const {
 	const auto maybe_songid = m_songs.lookup(s);
 	if (!maybe_songid) return; // song not yet in database.
-        const auto songid = maybe_songid.value();
+		const auto songid = maybe_songid.value();
 	// Reorder hiscores by track / score
 	std::map<std::string, std::multiset<HiscoreItem>> scoresByTrack;
 	for (HiscoreItem const& hi: m_hiscores.queryHiscore(std::nullopt, songid, track, std::nullopt)) scoresByTrack[hi.track].insert(hi);
@@ -127,17 +127,28 @@ void Database::queryPerPlayerHiscore(std::ostream & os, std::string const& track
 	}
 }
 
-bool Database::hasHiscore(Song const& s) const 
+bool Database::hasHiscore(Song const& s) const
 try {
 	return m_hiscores.hasHiscore(m_songs.lookup(s).value());
 } catch (const std::exception&) {
 	return false;
 }
 
-unsigned Database::getHiscore(const Song& s) const try {
+unsigned Database::getHiscore(Song const& s) const try {
 	const auto songid = m_songs.lookup(s);
 	return m_hiscores.getHiscore(songid.value());
 } catch (const std::exception&) {
 	return 0;
+}
+
+unsigned Database::getHiscore(SongPtr const& s) const {
+	try {
+		auto const songid = m_songs.getSongId(s);
+
+		return m_hiscores.getHiscore(songid);
+	} catch (const std::exception& e) {
+		std::clog << "database/error: Invalid song ID for song: " + s->artist + " - " + s->title << std::endl;
+		return 0;
+	}
 }
 

--- a/game/database.cc
+++ b/game/database.cc
@@ -149,7 +149,7 @@ unsigned Database::getHiscore(SongPtr const& s) const {
 	} catch (const std::exception& e) {
 		std::clog << "database/error: Invalid song ID for song: " + s->artist + " - " + s->title << std::endl;
 		std::clog << "database/error: message: " << e.what() << std::endl;
-		return 0;
+		throw;
 	}
 }
 

--- a/game/database.cc
+++ b/game/database.cc
@@ -148,6 +148,7 @@ unsigned Database::getHiscore(SongPtr const& s) const {
 		return m_hiscores.getHiscore(songid);
 	} catch (const std::exception& e) {
 		std::clog << "database/error: Invalid song ID for song: " + s->artist + " - " + s->title << std::endl;
+		std::clog << "database/error: message: " << e.what() << std::endl;
 		return 0;
 	}
 }

--- a/game/database.hh
+++ b/game/database.hh
@@ -89,7 +89,8 @@ public: // methods for database queries
 	void queryPerPlayerHiscore(std::ostream & os, std::string const& track = std::string()) const;
 
 	bool hasHiscore(Song const& s) const;
-	unsigned getHiscore(const Song& s) const;
+	unsigned getHiscore(Song const& s) const;
+	unsigned getHiscore(SongPtr const& s) const;
 	bool noPlayers() const;
 
 private:

--- a/game/song.hh
+++ b/game/song.hh
@@ -8,6 +8,7 @@
 #include <nlohmann/json.hpp>
 
 #include <cstdint>
+#include <memory>
 #include <stdexcept>
 #include <string>
 
@@ -133,6 +134,8 @@ private:
 	unsigned int m_linenum;
 	bool m_silent;
 };
+
+using SongPtr = std::shared_ptr<Song>;
 
 /// Print a SongParserException in a format suitable for the logging system.
 std::ostream& operator<<(std::ostream& os, SongParserException const& e);

--- a/game/songitems.cc
+++ b/game/songitems.cc
@@ -36,7 +36,7 @@ SongId SongItems::addSongItem(std::string const& artist, std::string const& titl
 	SongItem si;
 	si.id = _id.value_or(assign_id_internal());
 	songMetadata collateInfo {{"artist", artist}, {"title", title}};
-	UnicodeUtil::collate(collateInfo);		
+	UnicodeUtil::collate(collateInfo);
 	si.artist = collateInfo["artist"];
 	si.title = collateInfo["title"];
 	std::pair<songs_t::iterator, bool> ret = m_songs.insert(si);
@@ -77,6 +77,15 @@ std::optional<SongId> SongItems::lookup(Song const& song) const {
 	});
 	if (si != m_songs.end()) return si->id;
 	return std::nullopt;
+}
+
+SongId SongItems::getSongId(SongPtr const& song) const {
+	auto const it = std::find_if(m_songs.begin(), m_songs.end(), [song](auto const& item){ return item.song == song;});
+
+	if(it  == m_songs.end())
+		throw std::logic_error("SongItems::getSongId: Did not find an item matching to song!");
+
+	return it->id;
 }
 
 std::optional<std::string> SongItems::lookup(const SongId &id) const {

--- a/game/songitems.cc
+++ b/game/songitems.cc
@@ -48,13 +48,14 @@ SongId SongItems::addSongItem(std::string const& artist, std::string const& titl
 	return si.id;
 }
 
-void SongItems::addSong(std::shared_ptr<Song> song) {
+void SongItems::addSong(SongPtr song) {
 	SongItem si;
 	// Do NOT use .value_or() here; it gets evaluated and addSongItem() runs regardless of whether we have a value, which results in duplicate entries in the database.
 	auto val = lookup(song);
 	si.id = val ? val.value() : (addSongItem(song->artist, song->title));;
 	auto it = m_songs.find(si);
-	if (it == m_songs.end()) throw SongItemsException("Cant find song which was added just before");
+	if (it == m_songs.end())
+		throw SongItemsException("Cant find song which was added just before");
 	// it->song.reset(song); // does not work, it is a read only structure...
 
 	// fill up the rest of the information
@@ -82,7 +83,7 @@ std::optional<SongId> SongItems::lookup(Song const& song) const {
 SongId SongItems::getSongId(SongPtr const& song) const {
 	auto const it = std::find_if(m_songs.begin(), m_songs.end(), [song](auto const& item){ return item.song == song;});
 
-	if(it  == m_songs.end())
+	if(it == m_songs.end())
 		throw std::logic_error("SongItems::getSongId: Did not find an item matching to song!");
 
 	return it->id;

--- a/game/songitems.hh
+++ b/game/songitems.hh
@@ -86,6 +86,8 @@ public:
 	std::optional<SongId> lookup(std::shared_ptr<Song> song) const { if (song) return lookup(*song); return std::nullopt; };
 	std::optional<SongId> lookup(Song const& song) const;
 
+	SongId getSongId(SongPtr const&) const;
+
 	/**Lookup the artist + title for a specific song.
 	  @return "Unknown Song" if nothing is found.
 	  */
@@ -96,6 +98,6 @@ public:
 private:
 	SongId assign_id_internal() const;
 
-	typedef std::set<SongItem> songs_t;
+	using songs_t = std::set<SongItem>;
 	songs_t m_songs;
 };

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -24,9 +24,9 @@
 #include <fstream>
 #include <nlohmann/json.hpp>
 
-Songs::Songs(Database & database, std::string const& songlist): 
-  m_songlist(songlist), 
-  m_database(database), 
+Songs::Songs(Database & database, std::string const& songlist):
+  m_songlist(songlist),
+  m_database(database),
   m_order(config["songs/sort-order"].ui()) {
 	m_updateTimer.setTarget(getInf()); // Using this as a simple timer counting seconds
 	reload();
@@ -279,7 +279,7 @@ void Songs::reload_internal(fs::path const& parent) {
 					std::shared_lock<std::shared_mutex> l(m_mutex);
 					for(auto const& song: m_songs) {
 						if(s->filename.extension() != song->filename.extension() && s->filename.stem() == song->filename.stem() &&
-							    s->title == song->title && s->artist == song->artist) {
+								s->title == song->title && s->artist == song->artist) {
 							std::clog << "songs/info: >>> Found additional song file: " << s->filename << " for: " << song->filename << std::endl;
 							AdditionalFileIndex = &song - &m_songs[0];
 						}
@@ -351,7 +351,7 @@ void Songs::filter_internal() {
 			std::string charset = UnicodeUtil::getCharset(m_filter);
 			icu::UnicodeString filter = ((charset == "UTF-8") ? icu::UnicodeString::fromUTF8(m_filter) : icu::UnicodeString(m_filter.c_str(), charset.c_str()));
 			UErrorCode icuError = U_ZERO_ERROR;
-			
+
 			std::shared_lock<std::shared_mutex> l(m_mutex);
 			std::copy_if (m_songs.begin(), m_songs.end(), std::back_inserter(filtered), [&](std::shared_ptr<Song> it){
 			// Filter by type first.
@@ -508,7 +508,7 @@ void Songs::sortChange(SortChange diff) {
 
 void Songs::sortSpecificChange(unsigned short sortOrder, bool descending) {
 	if(sortOrder < orders) m_order = sortOrder;
-	else m_order = 0; 
+	else m_order = 0;
 	RestoreSel restore(*this);
 	config["songs/sort-order"].ui() = m_order;
 	sort_internal(descending);
@@ -517,7 +517,7 @@ void Songs::sortSpecificChange(unsigned short sortOrder, bool descending) {
 void Songs::sort_internal(bool descending) {
 	if(m_order == 0)
 		std::stable_sort(m_filtered.begin(), m_filtered.end(), customComparator(&Song::randomIdx, true));
-	else {        
+	else {
 		auto begin = m_filtered.begin();
 		auto end = m_filtered.end();
 
@@ -529,9 +529,9 @@ void Songs::sort_internal(bool descending) {
 		  case 5: std::sort(begin, end, customComparator(&Song::path, !descending)); break;
 		  case 6: std::sort(begin, end, customComparator(&Song::language, !descending)); break;
 		  case 7: std::sort(begin, end, [this, &descending](SongPtr const& a, SongPtr const& b){
-				const auto scoreA = m_database.getHiscore(*a);              
-				const auto scoreB = m_database.getHiscore(*b);              
-				return scoreA > scoreB ? !descending : descending;              
+				const auto scoreA = m_database.getHiscore(a);
+				const auto scoreB = m_database.getHiscore(b);
+				return scoreA > scoreB ? !descending : descending;
 			}); break;
 		  default: throw std::logic_error("Internal error: unknown sort order in Songs::sortChange");
 		}
@@ -552,7 +552,7 @@ namespace {
 			std::cerr << "Songlist error handling cover image: " << e.what() << std::endl;
 		}
 	}
-	
+
 	template<typename SongCollection>
 	void dumpXML(SongCollection const& svec, std::string const& filename) {
 		xmlpp::Document doc;

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -536,17 +536,23 @@ void Songs::sort_internal(bool descending) {
 				auto result = std::map<SongPtr, int>{};
 
 				std::for_each(begin, end, [&result, this](SongPtr const& song) {
-					result[song] = m_database.getHiscore(song);
+					try {
+						result[song] = m_database.getHiscore(song);
+					}
+					catch(std::exception const&) {
+						result[song] = 0;
+					}
 				});
 
-				return result;}();
+				return result;
+			}();
 
-				std::sort(begin, end, [&songToHiscore, &descending](SongPtr const& a, SongPtr const& b){
-					const auto scoreA = songToHiscore.find(a)->second;
-					const auto scoreB = songToHiscore.find(b)->second;
-					return scoreA > scoreB ? !descending : descending;
-				});
-			}
+			std::sort(begin, end, [&songToHiscore, &descending](SongPtr const& a, SongPtr const& b){
+				auto const scoreA = songToHiscore.find(a)->second;
+				auto const scoreB = songToHiscore.find(b)->second;
+				return scoreA > scoreB ? !descending : descending;
+			});
+		  }
 		  break;
 		  default: throw std::logic_error("Internal error: unknown sort order in Songs::sortChange");
 		}


### PR DESCRIPTION
### What does this PR do?

A bugfix for SongItems::lookup slows down the sorting of songs by score. This PR speed up the sorting.

### Closes Issue(s)

None

### Motivation

Better user experience

