### PR TITLE
Some more fixes for UnicodeUtil

### DIFF
--- a/data/config/schema.xml
+++ b/data/config/schema.xml
@@ -97,6 +97,7 @@ to save the current settings to XML.
 	</entry>
 	<entry name="game/language" type="uint" value="1337">
 		<limits>
+		<enum/>
 			<!-- enum options will be added dynamically according to detected interfaces. -->
 		</limits>
 		<short>Language</short>

--- a/game/configitem.cc
+++ b/game/configitem.cc
@@ -65,7 +65,7 @@ ConfigItem& ConfigItem::incdec(int dir) {
 	} else if (m_type == "uint") {
 		unsigned short& val = std::get<unsigned short>(m_value);
 		int value = static_cast<int>(val);
-		int step = std::get<unsigned short>(m_step);
+		int step = static_cast<int>(std::get<unsigned short>(m_step));
 		int min = static_cast<int>(std::get<unsigned short>(m_min));
 		int max = static_cast<int>(std::get<unsigned short>(m_max));
 		val = static_cast<unsigned short>(clamp(((value + dir * step) / step) * step, min, max));
@@ -172,7 +172,7 @@ std::string const ConfigItem::getValue() const {
 		return numericFormat<int>(m_value, m_multiplier, m_step) + _(m_unit);
 	}
 	if (m_type == "uint") {
-		unsigned val = ui();
+		unsigned short val = ui();
 		if (val < m_enums.size())
 			return m_enums[val];
 		return numericFormat<unsigned short>(m_value, m_multiplier, m_step) + _(m_unit);

--- a/game/configitem.cc
+++ b/game/configitem.cc
@@ -211,7 +211,7 @@ void ConfigItem::selectEnum(std::string const& name) {
 
 
 std::string const ConfigItem::getEnumName() const {
-	auto const& val = ui();
+	unsigned short const& val = ui();
 	if (val < m_enums.size())
 		return m_enums[val];
 

--- a/game/configitem.hh
+++ b/game/configitem.hh
@@ -61,7 +61,7 @@ class ConfigItem {
 	void selectEnum(std::string const& name); ///< Set integer value by enum name
 	std::string const getEnumName() const; ///< Returns the selected enum option's text
 	std::vector<std::string>& getEnum() { return m_enums; }
-	int getSelection() const { return m_sel; }
+	unsigned short getSelection() const { return m_sel; }
 
 	NumericValue& getMin();
 	NumericValue& getMax();
@@ -90,7 +90,7 @@ class ConfigItem {
 	NumericValue m_step, m_min, m_max;
 	NumericValue m_multiplier;
 	std::string m_unit;
-	int m_sel = 0;
+	unsigned short m_sel = 0;
 	std::function<std::string(ConfigItem const&)> m_getValue;
 };
 

--- a/game/configuration.cc
+++ b/game/configuration.cc
@@ -186,8 +186,8 @@ fs::path userConfFile;
 
 namespace {
 	std::string getValue_language(ConfigItem const& item) {
-		int autoLanguageType = 1337;
-		int val = LanguageToLanguageId(item.getEnumName()); // In the case of the language, val is the real value while m_value is the enum case for its cosmetic name.
+		unsigned short autoLanguageType = 1337;
+		unsigned short val = LanguageToLanguageId(item.getEnumName()); // In the case of the language, val is the real value while m_value is the enum case for its cosmetic name.
 		std::string languageName = (val != autoLanguageType) ? item.getEnumName() : "Auto";
 		return languageName;
 	}
@@ -371,7 +371,7 @@ void readConfigXML(fs::path const& file, unsigned mode) {
 	}
 }
 
-unsigned int LanguageToLanguageId(const std::string& name) {
+unsigned short LanguageToLanguageId(const std::string& name) {
 	if (name == "Asturian") return 1;
 	if (name == "Danish") return 2;
 	if (name == "German") return 3;

--- a/game/configuration.cc
+++ b/game/configuration.cc
@@ -22,25 +22,14 @@
 
 class ConfigItemXMLLoader {
 public:
-	void update(ConfigItem&, xmlpp::Element& elem, int mode); ///< Load XML config file, elem = Entry, mode = 0 for schema, 1 for system config and 2 for user config
+	void update(ConfigItem&, xmlpp::Element& elem, unsigned mode); ///< Load XML config file, elem = Entry, mode = 0 for schema, 1 for system config and 2 for user config
 
 private:
-	template <typename T> void updateNumeric(ConfigItem&, xmlpp::Element& elem, int mode); ///< Used internally for loading XML
+	template <typename T> void updateNumeric(ConfigItem& item, xmlpp::Element& elem, unsigned mode); ///< Used internally for loading XML
 	void verifyType(std::string const& t) const; ///< throws std::logic_error if t != type
 };
 
 namespace {
-
-	template <typename T, typename VariantAll, typename VariantNum> std::string numericFormat(ConfigItem& item, VariantAll const& value, VariantNum const& multiplier, VariantNum const& step) {
-		// Find suitable precision (not very useful for integers, but this code is generic...)
-		T m = std::get<T>(multiplier);
-		T s = std::abs<T>(m * std::get<T>(step));
-		int precision = 0;
-		while (s > static_cast<T>(0) && (s *= static_cast<T>(10)) < static_cast<T>(10)) ++precision;
-		// Not quite sure how to format this with FMT
-		return fmt::format("{:.{}f}", double(m) * std::get<T>(value), precision);
-	}
-
 	std::string getText(xmlpp::Element const& elem) {
 		auto n = xmlpp::get_first_child_text(elem);  // Returns NULL if there is no text
 		return n ? std::string(n->get_content()) : std::string();
@@ -72,7 +61,7 @@ namespace {
 	}
 }
 
-template <typename T> void ConfigItemXMLLoader::updateNumeric(ConfigItem& item, xmlpp::Element& elem, int mode) {
+template <typename T> void ConfigItemXMLLoader::updateNumeric(ConfigItem& item, xmlpp::Element& elem, unsigned mode) {
 	auto ns = elem.find("limits");
 	if (!ns.empty()) setLimits<T>(dynamic_cast<xmlpp::Element&>(*ns[0]), item.getMin(), item.getMax(), item.getStep());
 	else if (mode == 0) throw XMLError(elem, "child element limits missing");
@@ -102,7 +91,7 @@ template <typename T> void ConfigItemXMLLoader::updateNumeric(ConfigItem& item, 
 	}
 }
 
-void ConfigItemXMLLoader::update(ConfigItem& item, xmlpp::Element& elem, int mode) {
+void ConfigItemXMLLoader::update(ConfigItem& item, xmlpp::Element& elem, unsigned mode) {
 	try {
 		if (mode == 0) {
 			item.setName(getAttribute(elem, "name"));

--- a/game/configuration.cc
+++ b/game/configuration.cc
@@ -142,7 +142,7 @@ void ConfigItemXMLLoader::update(ConfigItem& item, xmlpp::Element& elem, int mod
 				if (!n2.empty()) {
 					for (auto it2 = n2.begin(), end2 = n2.end(); it2 != end2; ++it2) {
 						xmlpp::Element& elem2 = dynamic_cast<xmlpp::Element&>(**it2);
-						item.getEnum().push_back(getText(elem2));
+						if (!getText(elem2).empty()) item.getEnum().push_back(getText(elem2));
 					}
 					item.getMin() = static_cast<unsigned short>(0);
 					item.getMax() = static_cast<unsigned short>(item.getEnum().size() - 1);

--- a/game/configuration.hh
+++ b/game/configuration.hh
@@ -32,6 +32,6 @@ struct MenuEntry {
 	std::vector<std::string> items; ///< selectable options
 };
 
-unsigned int LanguageToLanguageId(const std::string& name);
+unsigned short LanguageToLanguageId(const std::string& name);
 using ConfigMenu = std::vector<MenuEntry>;
 extern ConfigMenu configMenu;

--- a/game/players.cc
+++ b/game/players.cc
@@ -114,7 +114,7 @@ void Players::filter_internal() {
 		else {
 			icu::UnicodeString filter = icu::UnicodeString::fromUTF8(m_filter);
 			std::copy_if (m_players.begin(), m_players.end(), std::back_inserter(filtered), [&](PlayerItem it){
-			icu::StringSearch search = icu::StringSearch(filter, icu::UnicodeString::fromUTF8(it.name), &UnicodeUtil::m_searchCollator, nullptr, m_icuError);
+			icu::StringSearch search = icu::StringSearch(filter, icu::UnicodeString::fromUTF8(it.name), UnicodeUtil::m_searchCollator.get(), nullptr, m_icuError);
 			return (search.first(m_icuError) != USEARCH_DONE);
 			});
 		}

--- a/game/players.cc
+++ b/game/players.cc
@@ -114,7 +114,7 @@ void Players::filter_internal() {
 		else {
 			icu::UnicodeString filter = icu::UnicodeString::fromUTF8(m_filter);
 			std::copy_if (m_players.begin(), m_players.end(), std::back_inserter(filtered), [&](PlayerItem it){
-			icu::StringSearch search = icu::StringSearch(filter, icu::UnicodeString::fromUTF8(it.name), &UnicodeUtil::m_dummyCollator, nullptr, m_icuError);
+			icu::StringSearch search = icu::StringSearch(filter, icu::UnicodeString::fromUTF8(it.name), &UnicodeUtil::m_searchCollator, nullptr, m_icuError);
 			return (search.first(m_icuError) != USEARCH_DONE);
 			});
 		}

--- a/game/players.cc
+++ b/game/players.cc
@@ -8,7 +8,7 @@
 #include <algorithm>
 #include <unicode/stsearch.h>
 
-UErrorCode Players::m_icuError = U_ZERO_ERROR;
+icu::ErrorCode Players::m_icuError = icu::ErrorCode();
 
 void Players::load(xmlpp::NodeSet const& n) {
 	for (auto const& elem: n) {

--- a/game/players.hh
+++ b/game/players.hh
@@ -7,11 +7,9 @@
 #include <string>
 #include <stdexcept>
 
-#include <unicode/tblcoll.h>
-#include <unicode/unistr.h>
-#include <unicode/utypes.h>
 
 #include "player.hh"
+#include "unicode.hh"
 #include "animvalue.hh"
 #include "libxml++.hh"
 
@@ -83,7 +81,7 @@ class Players {
 private:
 	PlayerId assign_id_internal(); /// returns the next available id
 	void filter_internal();
-	static UErrorCode m_icuError;
+	static icu::ErrorCode m_icuError;
 	static icu::RuleBasedCollator icuCollator;
 
 private:

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -353,7 +353,7 @@ void Songs::filter_internal() {
 		} else {
 			std::string charset = UnicodeUtil::getCharset(m_filter);
 			icu::UnicodeString filter = UnicodeUtil::getConverter(UnicodeUtil::getCharset(m_filter)).convertToUTF8(m_filter);
-			UErrorCode icuError = U_ZERO_ERROR;
+			icu::ErrorCode icuError;
 
 			std::shared_lock<std::shared_mutex> l(m_mutex);
 			std::copy_if (m_songs.begin(), m_songs.end(), std::back_inserter(filtered), [&](std::shared_ptr<Song> it){
@@ -412,9 +412,9 @@ namespace {
 		bool operator()(Song const& left , Song const& right) {
 			icu::UnicodeString leftVal = icu::UnicodeString::fromUTF8(left.*m_field);
 			icu::UnicodeString rightVal = icu::UnicodeString::fromUTF8(right.*m_field);
-			UErrorCode sortError = U_ZERO_ERROR;
+			icu::ErrorCode sortError;
 			UCollationResult result = UnicodeUtil::m_sortCollator.compare(leftVal, rightVal, sortError);
-			if (U_SUCCESS(sortError)) {
+			if (sortError.isSuccess()) {
 				return result == UCOL_LESS ? m_ascending : !m_ascending;
 			}
 			else {
@@ -498,11 +498,7 @@ void Songs::sortChange(SortChange diff) {
 		case 4:
 		 [[fallthrough]];
 		case 6:
-			UErrorCode collatorError = U_ZERO_ERROR;
-			UnicodeUtil::m_sortCollator.setAttribute(UCOL_STRENGTH, (config["game/case-sorting"].b()) ? UCOL_TERTIARY : UCOL_SECONDARY, collatorError);
-			if (U_FAILURE(collatorError)) {
-				std::clog << "sorting/error: Unable to change collator strength." << std::endl;
-			}
+			UnicodeUtil::m_sortCollator.setStrength(config["game/case-sorting"].b() ? icu::Collator::TERTIARY : icu::Collator::SECONDARY);
 			break;
 		}
 	sort_internal();

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -352,7 +352,7 @@ void Songs::filter_internal() {
 			filtered = m_songs;
 		} else {
 			std::string charset = UnicodeUtil::getCharset(m_filter);
-			icu::UnicodeString filter = ((charset == "UTF-8") ? icu::UnicodeString::fromUTF8(m_filter) : icu::UnicodeString(m_filter.c_str(), charset.c_str()));
+			icu::UnicodeString filter = UnicodeUtil::getConverter(UnicodeUtil::getCharset(m_filter)).convertToUTF8(m_filter);
 			UErrorCode icuError = U_ZERO_ERROR;
 
 			std::shared_lock<std::shared_mutex> l(m_mutex);

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -367,7 +367,7 @@ void Songs::filter_internal() {
 
 		  // If search is not empty, filter by search term.
 				if (!m_filter.empty()) {
-					icu::StringSearch search = icu::StringSearch(filter, icu::UnicodeString::fromUTF8((*it).strFull()), &UnicodeUtil::m_searchCollator, nullptr, icuError);
+					icu::StringSearch search = icu::StringSearch(filter, icu::UnicodeString::fromUTF8((*it).strFull()), UnicodeUtil::m_searchCollator.get(), nullptr, icuError);
 					return (search.first(icuError) != USEARCH_DONE);
 					}
 
@@ -413,7 +413,7 @@ namespace {
 			icu::UnicodeString leftVal = icu::UnicodeString::fromUTF8(left.*m_field);
 			icu::UnicodeString rightVal = icu::UnicodeString::fromUTF8(right.*m_field);
 			icu::ErrorCode sortError;
-			UCollationResult result = UnicodeUtil::m_sortCollator.compare(leftVal, rightVal, sortError);
+			UCollationResult result = UnicodeUtil::m_sortCollator->compare(leftVal, rightVal, sortError);
 			if (sortError.isSuccess()) {
 				return result == UCOL_LESS ? m_ascending : !m_ascending;
 			}
@@ -498,7 +498,7 @@ void Songs::sortChange(SortChange diff) {
 		case 4:
 		 [[fallthrough]];
 		case 6:
-			UnicodeUtil::m_sortCollator.setStrength(config["game/case-sorting"].b() ? icu::Collator::TERTIARY : icu::Collator::SECONDARY);
+			UnicodeUtil::m_sortCollator->setStrength(config["game/case-sorting"].b() ? icu::Collator::TERTIARY : icu::Collator::SECONDARY);
 			break;
 		}
 	sort_internal();

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -529,7 +529,7 @@ void Songs::sort_internal(bool descending) {
 		  case 6: std::sort(begin, end, customComparator(&Song::language, !descending)); break;
 		  case 7: {
 			auto const songToHiscore = [begin, end, this](){
-				auto result = std::map<SongPtr, int>{};
+				auto result = std::map<SongPtr, unsigned>{};
 
 				std::for_each(begin, end, [&result, this](SongPtr const& song) {
 					try {

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -367,7 +367,7 @@ void Songs::filter_internal() {
 
 		  // If search is not empty, filter by search term.
 				if (!m_filter.empty()) {
-					icu::StringSearch search = icu::StringSearch(filter, icu::UnicodeString::fromUTF8((*it).strFull()), &UnicodeUtil::m_dummyCollator, nullptr, icuError);
+					icu::StringSearch search = icu::StringSearch(filter, icu::UnicodeString::fromUTF8((*it).strFull()), &UnicodeUtil::m_searchCollator, nullptr, icuError);
 					return (search.first(icuError) != USEARCH_DONE);
 					}
 

--- a/game/unicode.cc
+++ b/game/unicode.cc
@@ -10,9 +10,8 @@
 #include <unicode/ubidi.h>
 #include "compact_enc_det/compact_enc_det.h"
 
-icu::ErrorCode UnicodeUtil::m_staticIcuError = icu::ErrorCode();
-icu::RuleBasedCollator UnicodeUtil::m_searchCollator (icu::UnicodeString (""), icu::Collator::PRIMARY, m_staticIcuError);
-icu::RuleBasedCollator UnicodeUtil::m_sortCollator  (nullptr, icu::Collator::SECONDARY, m_staticIcuError);
+std::unique_ptr<icu::RuleBasedCollator> UnicodeUtil::m_searchCollator = nullptr;
+std::unique_ptr<icu::RuleBasedCollator> UnicodeUtil::m_sortCollator = nullptr;
 
 std::map<std::string, Converter> UnicodeUtil::m_converters{};
 

--- a/game/unicode.cc
+++ b/game/unicode.cc
@@ -10,8 +10,8 @@
 #include <unicode/ubidi.h>
 #include "compact_enc_det/compact_enc_det.h"
 
-std::unique_ptr<icu::RuleBasedCollator> UnicodeUtil::m_searchCollator = nullptr;
-std::unique_ptr<icu::RuleBasedCollator> UnicodeUtil::m_sortCollator = nullptr;
+std::unique_ptr<icu::RuleBasedCollator> UnicodeUtil::m_searchCollator;
+std::unique_ptr<icu::RuleBasedCollator> UnicodeUtil::m_sortCollator;
 
 std::map<std::string, Converter> UnicodeUtil::m_converters{};
 
@@ -20,12 +20,10 @@ Converter::Converter(std::string const& codepage): m_codepage(codepage), m_conve
 	if (m_error.isFailure()) throw std::runtime_error("unicode/error: " + std::to_string(m_error.get()) + ": " + std::string(m_error.errorName()));
 }
 
-Converter::Converter(Converter&& c) noexcept: m_codepage(std::move(c.m_codepage)), m_converter(std::move(c.m_converter)), m_error(std::move(c.m_error)) {}
-
-void Converter::reset() {
-	std::scoped_lock l(m_lock);
-	if (m_converter) ucnv_reset(m_converter.get());
-}
+Converter::Converter(Converter&& c) noexcept:
+	m_codepage(std::move(c.m_codepage)),
+	m_converter(std::move(c.m_converter)),
+	m_error(std::move(c.m_error)) {}
 
 icu::UnicodeString Converter::convertToUTF8(std::string_view sv) {
 	std::scoped_lock l(m_lock);

--- a/game/unicode.cc
+++ b/game/unicode.cc
@@ -11,7 +11,7 @@
 #include "compact_enc_det/compact_enc_det.h"
 
 icu::ErrorCode UnicodeUtil::m_staticIcuError = icu::ErrorCode();
-icu::RuleBasedCollator UnicodeUtil::m_dummyCollator (icu::UnicodeString (""), icu::Collator::PRIMARY, m_staticIcuError);
+icu::RuleBasedCollator UnicodeUtil::m_searchCollator (icu::UnicodeString (""), icu::Collator::PRIMARY, m_staticIcuError);
 icu::RuleBasedCollator UnicodeUtil::m_sortCollator  (nullptr, icu::Collator::SECONDARY, m_staticIcuError);
 
 std::string UnicodeUtil::getCharset (std::string_view str) {

--- a/game/unicode.hh
+++ b/game/unicode.hh
@@ -21,14 +21,12 @@ struct Converter {
 	Converter(Converter&& c) noexcept;
 	Converter(Converter& c) = delete;
 	Converter(Converter const& c) = delete;	
-	~Converter() {};
 
 	icu::UnicodeString convertToUTF8(std::string_view sv); ///< Do the actual conversion.
 
 	private:
 	std::string m_codepage;
 	std::unique_ptr<UConverter, decltype(&ucnv_close)> m_converter;
-	void reset(); ///< UConverters are state machines and need to be reset after each use.
 	icu::ErrorCode m_error;
 	std::mutex m_lock;
 };

--- a/game/unicode.hh
+++ b/game/unicode.hh
@@ -26,6 +26,6 @@ class UnicodeUtil {
 	static std::string toLower (std::string_view str);
 	static std::string toUpper (std::string_view str);
 	static std::string toTitle (std::string_view str);
-	static icu::RuleBasedCollator m_dummyCollator;
+	static icu::RuleBasedCollator m_searchCollator;
 	static icu::RuleBasedCollator m_sortCollator;
 };

--- a/game/unicode.hh
+++ b/game/unicode.hh
@@ -22,9 +22,9 @@ struct Converter {
 	Converter(Converter& c) = delete;
 	Converter(Converter const& c) = delete;	
 	~Converter() {};
-	
+
 	icu::UnicodeString convertToUTF8(std::string_view sv); ///< Do the actual conversion.
-	
+
 	private:
 	std::string m_codepage;
 	std::unique_ptr<UConverter, decltype(&ucnv_close)> m_converter;
@@ -34,22 +34,25 @@ struct Converter {
 };
 
 class UnicodeUtil {
-	static icu::ErrorCode m_staticIcuError;
-	enum class CaseMapping { LOWER, UPPER, TITLE, NONE };
+	friend class Songs;
 	static std::map<std::string, Converter> m_converters;
+	enum class CaseMapping { LOWER, UPPER, TITLE, NONE };
+
+	static std::string getCharset(std::string_view str);
+	static Converter& getConverter(std::string const& s);
+	static bool removeUTF8BOM(std::string_view str);
+	
 	public:
 	UnicodeUtil() = delete;
 	~UnicodeUtil() = delete;
 	static void collate (songMetadata& stringmap);
-	static std::string getCharset(std::string_view str);
 	static std::string convertToUTF8 (std::string_view str, std::string _filename = std::string(), CaseMapping toCase = CaseMapping::NONE, bool assumeUTF8 = false);
-	static bool removeUTF8BOM(std::string_view str);
 	static bool caseEqual (std::string_view lhs, std::string_view rhs, bool assumeUTF8 = false);
 	static bool isRTL(std::string_view str); ///< FIXME: This won't be used for now, but it might be useful if we eventually implement RTL translations. As-is, at least on my mac, Performous is refusing to render Arabic text, although it might be a font issue.
 	static std::string toLower (std::string_view str);
 	static std::string toUpper (std::string_view str);
 	static std::string toTitle (std::string_view str);
-	static icu::RuleBasedCollator m_searchCollator;
-	static icu::RuleBasedCollator m_sortCollator;
-	static Converter& getConverter(std::string const& s);
+
+	static std::unique_ptr<icu::RuleBasedCollator> m_searchCollator;
+	static std::unique_ptr<icu::RuleBasedCollator> m_sortCollator;
 };


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/performous/performous/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

Chiefly two things:

1) Manually instantiate UConverters. Why? The UnicodeString constructor we were using was essentially creating and destroying one of these on each invocation. Now we create them when we need them, and they stay around until the app quits.

2) Implement locale-aware sorting and searching. This means the sorting and searching should now behave appropriately according to the language selected in the Performous configuration.

And, there's also some minor fixes and clean-up.

<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

<!-- List here all the issues closed by this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
