### PR TITLE
Add classes and functions for stack trace handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,15 +8,15 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 if(NOT PERFORMOUS_VERSION)
-    message("No project version specified. Determining latest tag..")
-    include(GetGitRevisionDescription)
-    git_describe(PROJECT_VERSION --tags)
-    if(NOT PROJECT_VERSION)
-        message("No project version found. Falling back onto default versioning strategy.")
-        set(PROJECT_VERSION "1.2+")
-    endif()
+	message("No project version specified. Determining latest tag..")
+	include(GetGitRevisionDescription)
+	git_describe(PROJECT_VERSION --tags)
+	if(NOT PROJECT_VERSION)
+		message("No project version found. Falling back onto default versioning strategy.")
+		set(PROJECT_VERSION "1.2+")
+	endif()
 else()
-    set(PROJECT_VERSION "${PERFORMOUS_VERSION}")
+	set(PROJECT_VERSION "${PERFORMOUS_VERSION}")
 endif()
 string(TIMESTAMP YEAR "%Y")
 
@@ -44,7 +44,7 @@ if (APPLE)
 		message (STATUS "Checking macOS deployment target... ${CMAKE_OSX_DEPLOYMENT_TARGET}")
 		if (${CMAKE_OSX_DEPLOYMENT_TARGET} VERSION_GREATER_EQUAL 10.15)
 			message (STATUS "Targetting macOS 10.15 or newer, enabling std::filesystem")
-                else ()
+				else ()
 			set(USE_BOOST_FS TRUE)
 		endif()
 	else()
@@ -66,6 +66,7 @@ elseif(APPLE)
 else()
 	set(SHARE_INSTALL_DEFAULT "share/games/performous")
 	set(LOCALE_DIR_DEFAULT "share/locale")
+	add_link_options(-rdynamic)
 endif()
 
 set(SHARE_INSTALL "${SHARE_INSTALL_DEFAULT}" CACHE STRING "Data file install path. Must be a relative path (from CMAKE_INSTALL_PREFIX), with no trailing slash.")
@@ -94,13 +95,13 @@ add_subdirectory(docs)
 if(NOT APPLE)
   # uninstall target
   if(NOT TARGET uninstall)
-    configure_file(
-      "${CMAKE_CURRENT_SOURCE_DIR}/cmake/uninstall.cmake.in"
-      "${CMAKE_CURRENT_BINARY_DIR}/cmake/uninstall.cmake"
-      IMMEDIATE @ONLY)
+	configure_file(
+	  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/uninstall.cmake.in"
+	  "${CMAKE_CURRENT_BINARY_DIR}/cmake/uninstall.cmake"
+	  IMMEDIATE @ONLY)
 
-    add_custom_target(uninstall
-      COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake/uninstall.cmake)
+	add_custom_target(uninstall
+	  COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake/uninstall.cmake)
   endif()
 endif()
 

--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14.5)
 
-file(GLOB SOURCE_FILES "*.cc")
+file(GLOB SOURCE_FILES "*.cc" "misc/*.cc")
 file(GLOB HEADER_FILES "*.hh" "libda/*.hpp")
 
 # Fs is compiled/linked separately to ease switch boost/c++17
@@ -75,15 +75,15 @@ target_link_libraries(performous PRIVATE ${Boost_LIBRARIES})
 add_library(fs STATIC fs.cc)
 target_include_directories(fs PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 if (USE_BOOST_FS)
-    find_package(Boost 1.55 REQUIRED COMPONENTS filesystem)
+	find_package(Boost 1.55 REQUIRED COMPONENTS filesystem)
 
-    message (STATUS "Using boost::filesystem")
-    target_link_libraries(fs PUBLIC Boost::filesystem)
-    target_compile_definitions(fs PUBLIC -DUSE_BOOST_FS)
+	message (STATUS "Using boost::filesystem")
+	target_link_libraries(fs PUBLIC Boost::filesystem)
+	target_compile_definitions(fs PUBLIC -DUSE_BOOST_FS)
 else()
-    find_package(Filesystem REQUIRED)
-    message (STATUS "Using std::filesystem")
-    target_link_libraries(fs PRIVATE std::filesystem)
+	find_package(Filesystem REQUIRED)
+	message (STATUS "Using std::filesystem")
+	target_link_libraries(fs PRIVATE std::filesystem)
 endif()
 
 find_package(ICU 60 REQUIRED uc data i18n io)
@@ -288,19 +288,19 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
 if(WIN32)
 	install(CODE [[
-        file(GET_RUNTIME_DEPENDENCIES
-            RESOLVED_DEPENDENCIES_VAR deps_resolved
-            UNRESOLVED_DEPENDENCIES_VAR deps_unresolved
-            EXECUTABLES $<TARGET_FILE:performous>
-            PRE_EXCLUDE_REGEXES "api-ms-*" "ext-ms-*"
-            POST_EXCLUDE_REGEXES ".*system32/.*\\.dll"
-            )
-        message(STATUS "Resolving runtime dependencies for $<TARGET_FILE:performous>")
-        foreach(dep ${deps_resolved})
-            file(INSTALL ${dep} DESTINATION ${CMAKE_INSTALL_PREFIX})
-        endforeach()
-        foreach(dep ${deps_unresolved})
-            message(WARNING "Runtime dependency ${dep} could not be resolved.")
-        endforeach()
-        ]])
+		file(GET_RUNTIME_DEPENDENCIES
+			RESOLVED_DEPENDENCIES_VAR deps_resolved
+			UNRESOLVED_DEPENDENCIES_VAR deps_unresolved
+			EXECUTABLES $<TARGET_FILE:performous>
+			PRE_EXCLUDE_REGEXES "api-ms-*" "ext-ms-*"
+			POST_EXCLUDE_REGEXES ".*system32/.*\\.dll"
+			)
+		message(STATUS "Resolving runtime dependencies for $<TARGET_FILE:performous>")
+		foreach(dep ${deps_resolved})
+			file(INSTALL ${dep} DESTINATION ${CMAKE_INSTALL_PREFIX})
+		endforeach()
+		foreach(dep ${deps_unresolved})
+			message(WARNING "Runtime dependency ${dep} could not be resolved.")
+		endforeach()
+		]])
 endif()

--- a/game/misc/exceptionwithstacktrace.cc
+++ b/game/misc/exceptionwithstacktrace.cc
@@ -1,0 +1,15 @@
+#include "exceptionwithstacktrace.hh"
+
+ExceptionWithStackTrace::ExceptionWithStackTrace(std::string const& message)
+: m_message(message), m_trace(StackFrame::getStackTrace(1)) {
+}
+
+char const* ExceptionWithStackTrace::what() const noexcept {
+	return m_message.c_str();
+}
+
+StackTrace const& ExceptionWithStackTrace::getStackTrace() const {
+	return m_trace;
+}
+
+

--- a/game/misc/exceptionwithstacktrace.hh
+++ b/game/misc/exceptionwithstacktrace.hh
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "stacktrace.hh"
+
+#include <stdexcept>
+
+class ExceptionWithStackTrace : public std::exception {
+public:
+	ExceptionWithStackTrace(std::string const& message);
+	~ExceptionWithStackTrace() override = default;
+
+	char const* what() const noexcept override;
+
+	StackTrace const& getStackTrace() const;
+
+private:
+	std::string const m_message;
+	StackTrace const m_trace;
+};
+
+

--- a/game/misc/stacktrace.cc
+++ b/game/misc/stacktrace.cc
@@ -1,0 +1,83 @@
+#include "stacktrace.hh"
+
+#include <execinfo.h>
+#include <cxxabi.h>
+
+StackTrace StackFrame::getStackTrace(size_t skipFrames) {
+	void* addrlist[256];
+
+	auto addrlen = backtrace(addrlist, sizeof(addrlist) / sizeof(void*));
+
+	if (addrlen == 0)
+	return {};
+
+	auto result = std::vector<StackFrame>();
+	auto symbollist = backtrace_symbols(addrlist, addrlen);
+	size_t funcnamesize = 256;
+	char* funcname = (char*)malloc(funcnamesize);
+
+	for (auto i = 1 + skipFrames; i < addrlen; ++i) {
+		//std::cout << i << ": " << symbollist[i] << std::endl;
+		char *begin_name = 0, *begin_offset = 0, *end_offset = 0;
+
+		// find parentheses and +address offset surrounding the mangled name:
+		// ./module(function+0x15c) [0x8048a6d]
+		for (char *p = symbollist[i]; *p; ++p) {
+			if (*p == '(')
+				begin_name = p;
+			else if (*p == '+')
+				begin_offset = p;
+			else if (*p == ')' && begin_offset) {
+				end_offset = p;
+				break;
+			}
+		}
+
+		if (begin_name && begin_offset && end_offset && begin_name < begin_offset)
+		{
+			*begin_name++ = '\0';
+			*begin_offset++ = '\0';
+			*end_offset = '\0';
+
+			// mangled name is now in [begin_name, begin_offset) and caller
+			// offset in [begin_offset, end_offset). now apply
+			// __cxa_demangle():
+
+			int status;
+			char* ret = abi::__cxa_demangle(begin_name, funcname, &funcnamesize, &status);
+			if (status == 0) {
+				result.emplace_back(StackFrame(ret));
+				funcname = ret;
+			}
+			else {
+				// demangling failed. Output function name as a C function with  no arguments.
+				result.emplace_back(StackFrame(begin_name));
+			}
+		}
+		else {
+			// couldn't parse the line? print the whole line.
+			result.emplace_back(StackFrame(symbollist[i]));
+		}
+	}
+
+	free(funcname);
+	free(symbollist);
+
+	return result;
+}
+
+StackFrame::StackFrame(std::string const& info)
+: m_info(info) {
+}
+
+std::string const& StackFrame::getInfo() const {
+   return m_info;
+}
+
+
+std::ostream& operator<<(std::ostream& os, std::vector<StackFrame> const& stack) {
+	for(auto const& frame : stack)
+		os << frame.getInfo() << std::endl;
+
+	return os;
+}

--- a/game/misc/stacktrace.hh
+++ b/game/misc/stacktrace.hh
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <iostream>
+
+class StackFrame;
+
+using StackTrace = std::vector<StackFrame>;
+
+class StackFrame {
+public:
+	static StackTrace getStackTrace(size_t skipFrames = 0);
+
+	std::string const& getInfo() const;
+
+private:
+	StackFrame(std::string const& info);
+
+private:
+	std::string m_info;
+};
+
+std::ostream& operator<<(std::ostream& os, StackTrace const& stack);

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -1,25 +1,30 @@
 cmake_minimum_required(VERSION 3.15)
 
-set(SOURCE_FILES 
-    "colortest.cc"
-    "configitemtest.cc"
-    "fixednotegraphscalertest.cc"
-    "notegraphscalerfactorytest.cc"
-    "utiltest.cc"
+set(SOURCE_FILES
+	"colortest.cc"
+	"configitemtest.cc"
+	"exceptionwithstacktracetest.cc"
+	"fixednotegraphscalertest.cc"
+	"notegraphscalerfactorytest.cc"
+	"stacktracetest.cc"
+	"utiltest.cc"
 )
-set(GAME_SOURCES 
-    "../game/color.cc"
-    "../game/configitem.cc"
-    "../game/dynamicnotegraphscaler.cc"
-    "../game/fixednotegraphscaler.cc"
-    "../game/musicalscale.cc"
-    "../game/notes.cc"
-    "../game/notegraphscalerfactory.cc"
+set(GAME_SOURCES
+	"../game/color.cc"
+	"../game/configitem.cc"
+	"../game/dynamicnotegraphscaler.cc"
+	"../game/fixednotegraphscaler.cc"
+	"../game/musicalscale.cc"
+	"../game/notes.cc"
+	"../game/notegraphscalerfactory.cc"
+	"../game/misc/stacktrace.cc"
+	"../game/misc/exceptionwithstacktrace.cc"
 )
 
-set(SOURCES ${SOURCE_FILES} ${HEADER_FILES} ${GAME_SOURCES})
+set(SOURCES ${SOURCE_FILES} ${GAME_SOURCES})
 
 add_executable(performous_test ${SOURCES})
+add_link_options(-rdynamic)
 
 find_package(Boost 1.55 REQUIRED COMPONENTS program_options iostreams system locale)
 target_link_libraries(performous_test PRIVATE ${Boost_LIBRARIES})
@@ -29,6 +34,6 @@ target_link_libraries(performous_test PRIVATE fmt::fmt)
 
 target_link_libraries(performous_test PRIVATE GTest::GTest GTest::Main)
 
-target_include_directories(performous_test PRIVATE "..")
+target_include_directories(performous_test PRIVATE ..)
 
 gtest_discover_tests(performous_test)

--- a/testing/common.hh
+++ b/testing/common.hh
@@ -3,6 +3,16 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
+using ::testing::AllOf;
+using ::testing::AnyOf;
 using ::testing::ElementsAre;
+using ::testing::Eq;
+using ::testing::Ge;
+using ::testing::Gt;
+using ::testing::HasSubstr;
 using ::testing::IsEmpty;
+using ::testing::Le;
+using ::testing::Lt;
+using ::testing::Ne;
+using ::testing::StrEq;
 

--- a/testing/exceptionwithstacktracetest.cc
+++ b/testing/exceptionwithstacktracetest.cc
@@ -1,0 +1,27 @@
+#include "common.hh"
+
+#include "game/misc/exceptionwithstacktrace.hh"
+
+#define NO_INLINE __attribute__((noinline, externally_visible))
+
+void NO_INLINE fail(std::string const& message) {
+	throw ExceptionWithStackTrace(message);
+}
+
+TEST(UnitTest_ExceptionWithStackTrace, test) {
+	try {
+		fail("Error occured!");
+
+		FAIL();
+	}
+	catch(ExceptionWithStackTrace const& e) {
+		auto const trace = e.getStackTrace();
+
+		ASSERT_THAT(trace.size(), Gt(0));
+		EXPECT_THAT(trace[0].getInfo(), HasSubstr("fail"));
+		EXPECT_THAT(e.what(), StrEq("Error occured!"));
+
+		std::cout << trace;
+	}
+}
+

--- a/testing/stacktracetest.cc
+++ b/testing/stacktracetest.cc
@@ -1,0 +1,80 @@
+#include "common.hh"
+
+#include "game/misc/stacktrace.hh"
+
+#define NO_INLINE __attribute__((noinline, externally_visible))
+
+StackTrace NO_INLINE f_i(int depth = 0) {
+	if(depth == 0)
+		return StackFrame::getStackTrace();
+
+	return f_i(depth - 1);
+}
+
+struct TestClass {
+	NO_INLINE TestClass() {
+		trace = StackFrame::getStackTrace();
+	}
+
+	StackTrace NO_INLINE f() const {
+		return StackFrame::getStackTrace();
+	}
+
+	StackTrace NO_INLINE f_i(int) {
+		return StackFrame::getStackTrace();
+	}
+
+	StackTrace NO_INLINE f2() {
+		return ::f_i(0);
+	}
+
+	StackTrace trace;
+};
+
+TEST(UnitTest_StackTrace, ctor) {
+	auto const trace = TestClass().trace;
+
+	ASSERT_THAT(trace.size(), Gt(0));
+	EXPECT_THAT(trace[0].getInfo(), HasSubstr("TestClass::TestClass()"));
+}
+
+TEST(UnitTest_StackTrace, member_function_void) {
+	auto const trace = TestClass().f();
+
+	ASSERT_THAT(trace.size(), Gt(0));
+	EXPECT_THAT(trace[0].getInfo(), AllOf(HasSubstr("f_i"), HasSubstr("int")));
+	std::cout << trace;
+}
+
+TEST(UnitTest_StackTrace, member_function_int) {
+	auto const trace = TestClass().f_i(0);
+
+	ASSERT_THAT(trace.size(), Gt(0));
+	EXPECT_THAT(trace[0].getInfo(), AllOf(HasSubstr("f_i"), HasSubstr("int")));
+	std::cout << trace;
+}
+
+TEST(UnitTest_StackTrace, member_function_nested) {
+	auto const trace = TestClass().f2();
+
+	ASSERT_THAT(trace.size(), Gt(1));
+	EXPECT_THAT(trace[0].getInfo(), AllOf(HasSubstr("f_i"), HasSubstr("int")));
+	EXPECT_THAT(trace[1].getInfo(), AllOf(HasSubstr("f2"), HasSubstr("")));
+
+	std::cout << trace;
+}
+
+TEST(UnitTest_StackTrace, function_int) {
+	auto const trace = f_i(0);
+
+	ASSERT_THAT(trace.size(), Gt(0));
+	EXPECT_THAT(trace[0].getInfo(), AllOf(HasSubstr("f_i"), HasSubstr("int")));
+}
+
+TEST(UnitTest_StackTrace, function_int_2) {
+	auto const trace = f_i(1);
+
+	ASSERT_THAT(trace.size(), Gt(1));
+	EXPECT_THAT(trace[0].getInfo(), AllOf(HasSubstr("f_i"), HasSubstr("int")));
+	EXPECT_THAT(trace[1].getInfo(), AllOf(HasSubstr("f_i"), HasSubstr("int")));
+}

--- a/testing/utiltest.cc
+++ b/testing/utiltest.cc
@@ -1,33 +1,33 @@
-#include <gtest/gtest.h>
+#include "common.hh"
 
 #include "game/util.hh"
 
 namespace {
-    TEST(UnitTest_Utils, clamp) {
-        EXPECT_EQ(0.0, clamp(-1.0, 0.0, 1.0));
-        EXPECT_EQ(0.5, clamp(0.5, 0.0, 1.0));
-        EXPECT_EQ(1.0, clamp(2.0, 0.0, 1.0));
-    }
+	TEST(UnitTest_Utils, clamp) {
+		EXPECT_EQ(0.0, clamp(-1.0, 0.0, 1.0));
+		EXPECT_EQ(0.5, clamp(0.5, 0.0, 1.0));
+		EXPECT_EQ(1.0, clamp(2.0, 0.0, 1.0));
+	}
 
-    TEST(UnitTest_Utils, smoothstep_1) {
-        EXPECT_EQ(0.0, smoothstep(0));
-        EXPECT_EQ(0.5, smoothstep(0.5));
-        EXPECT_EQ(1.0, smoothstep(1.0));
-    }
+	TEST(UnitTest_Utils, smoothstep_1) {
+		EXPECT_EQ(0.0, smoothstep(0));
+		EXPECT_EQ(0.5, smoothstep(0.5));
+		EXPECT_EQ(1.0, smoothstep(1.0));
+	}
 
-    TEST(UnitTest_Utils, smoothstep_1_clamping) {
-        EXPECT_EQ(0.0, smoothstep(-1.0));
-        EXPECT_EQ(1.0, smoothstep(2.0));
-    }
+	TEST(UnitTest_Utils, smoothstep_1_clamping) {
+		EXPECT_EQ(0.0, smoothstep(-1.0));
+		EXPECT_EQ(1.0, smoothstep(2.0));
+	}
 
-    TEST(UnitTest_Utils, smoothstep_3) {
-        EXPECT_EQ(0.0, smoothstep(-1., 1., -1.0));
-        EXPECT_EQ(0.5, smoothstep(-1., 1., 0.0));
-        EXPECT_EQ(1.0, smoothstep(-1., 1., 1.0));
-    }
+	TEST(UnitTest_Utils, smoothstep_3) {
+		EXPECT_EQ(0.0, smoothstep(-1., 1., -1.0));
+		EXPECT_EQ(0.5, smoothstep(-1., 1., 0.0));
+		EXPECT_EQ(1.0, smoothstep(-1., 1., 1.0));
+	}
 
-    TEST(UnitTest_Utils, smoothstep_3_clamping) {
-        EXPECT_EQ(0.0, smoothstep(-1., 1., -2.0));
-        EXPECT_EQ(1.0, smoothstep(-1., 1., 2.0));
-    }
-} 
+	TEST(UnitTest_Utils, smoothstep_3_clamping) {
+		EXPECT_EQ(0.0, smoothstep(-1., 1., -2.0));
+		EXPECT_EQ(1.0, smoothstep(-1., 1., 2.0));
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Add classes and functions for stack trace handling which could help debugging.

### Closes Issue(s)

None

### Motivation

Make it easier for developers to debug and catch errors.

### Additional Notes

Only gcc supported. Had to add mac os and windows.
