### PR TITLE
TranslationEngine: fix possible segfault

### DIFF
--- a/game/configuration.cc
+++ b/game/configuration.cc
@@ -235,7 +235,7 @@ void writeConfig(bool system) {
 			else { entryNode->set_attribute("value", std::to_string(oldValue)); }
 		}
 		else if (name == "game/language") {
-			auto currentLanguageStr = Game::getSingletonPtr()->getCurrentLanguage();
+			auto currentLanguageStr = TranslationEngine::getCurrentLanguage().second;
 			auto newLanguagestr = item.getEnumName();
 			auto currentLanguageId = LanguageToLanguageId(currentLanguageStr);
 			auto newLanguageId = LanguageToLanguageId(newLanguagestr);
@@ -243,7 +243,7 @@ void writeConfig(bool system) {
 				std::cout << "Wanting to change something, old value: '" << currentLanguageStr << "' new value: '" << newLanguagestr << "'" << std::endl;
 				entryNode->set_attribute("value", std::to_string(newLanguageId));
 				config["game/language"].selectEnum(newLanguagestr);
-				Game::getSingletonPtr()->setLanguage(newLanguagestr);
+				TranslationEngine::setLanguage(newLanguagestr, true);
 			}
 			else {
 				entryNode->set_attribute("value", std::to_string(currentLanguageId));

--- a/game/game.cc
+++ b/game/game.cc
@@ -10,12 +10,11 @@
 #include <stdexcept>
 #include <cstdlib>
 
-Game::Game(Window& _window, Audio& _audio, TranslationEngine& _translationEngine):
+Game::Game(Window& _window, Audio& _audio):
   m_audio(_audio), m_window(_window), m_finished(false), newScreen(), currentScreen(), currentPlaylist(),
   m_timeToFadeIn(), m_timeToFadeOut(), m_timeToShow(), m_message(),
   m_messagePopup(0.0, 1.0), m_textMessage(findFile("message_text.svg"), config["graphic/text_lod"].f()),
-  m_loadingProgress(0.0f), m_logo(findFile("logo.svg")), m_logoAnim(0.0, 0.5),
-  m_translationEngine(_translationEngine)
+  m_loadingProgress(0.0f), m_logo(findFile("logo.svg")), m_logoAnim(0.0, 0.5)
 {
 	m_textMessage.dimensions.middle().center(-0.05f);
 }
@@ -142,11 +141,6 @@ void Game::drawNotifications() {
 
 void Game::finished() {
 	m_finished = true;
-}
-
-std::string Game::getCurrentLanguageCode() {
-	std::string lang = m_translationEngine.getCurrentLanguage().first;
-	return lang.substr(0, lang.size() - 6);
 }
 
 Game::~Game() {

--- a/game/game.hh
+++ b/game/game.hh
@@ -21,7 +21,7 @@
 class Game: public Singleton <Game> {
   public:
 	/// constructor
-	Game(Window& window, Audio& audio, TranslationEngine& translationEngine);
+	Game(Window& window, Audio& audio);
 	~Game();
 	/// Adds a screen to the manager
 	void addScreen(std::unique_ptr<Screen> s) { 
@@ -76,9 +76,6 @@ class Game: public Singleton <Game> {
 	void drawLogo();
 	///global playlist access
 	PlayList& getCurrentPlayList() { return currentPlaylist; }
-	void setLanguage(const std::string& language) { m_translationEngine.setLanguage(language, true); };
-	std::string getCurrentLanguage() const { return m_translationEngine.getCurrentLanguage().second; };
-	std::string getCurrentLanguageCode();
 #ifdef USE_WEBSERVER
 	void notificationFromWebserver(std::string message) { m_webserverMessage = message; }
 	std::string subscribeWebserverMessages() { return m_webserverMessage; }
@@ -111,7 +108,6 @@ private:
 	AnimValue m_dialogTimeOut;
 	// Dialog members
 	std::unique_ptr<Dialog> m_dialog;
-	TranslationEngine& m_translationEngine;
 #ifdef USE_WEBSERVER
 	std::string m_webserverMessage = "Trying to connect to webserver";
 #endif

--- a/game/i18n.cc
+++ b/game/i18n.cc
@@ -120,7 +120,7 @@ std::string TranslationEngine::getLanguageByKey(const std::string& languageKey) 
 	return allLanguages.at(languageKey);
 }
 
-const std::pair<std::string, std::string>& TranslationEngine::getCurrentLanguage() const { 
+const std::pair<std::string, std::string>& TranslationEngine::getCurrentLanguage() const {
 	return m_currentLanguage; 
 }
 

--- a/game/i18n.cc
+++ b/game/i18n.cc
@@ -131,7 +131,7 @@ std::pair<std::string, std::string> const& TranslationEngine::getCurrentLanguage
 
 std::string TranslationEngine::getCurrentLanguageCode() {
 	std::string lang(getCurrentLanguage().first);
-	return lang.substr(0, lang.size() - 6);
+	return lang.substr(0, lang.find('.'));
 }
 
 std::map<std::string, std::string> TranslationEngine::GetAllLanguages(bool refresh) {

--- a/game/i18n.hh
+++ b/game/i18n.hh
@@ -10,21 +10,22 @@
 
 class TranslationEngine {
 public:
-	TranslationEngine(const char *package);
+	TranslationEngine();
 
-	void initializeAllLanguages();
-	void setLanguage(const std::string& language, bool fromSettings = false);
-	std::string getLanguageByHumanReadableName(const std::string& language);
-	std::string getLanguageByKey(const std::string& languageKey);
-	const std::pair<std::string, std::string>& getCurrentLanguage() const;
-	std::map<std::string, std::string> GetAllLanguages(bool refresh = false);
+	static void initializeAllLanguages();
+	static void setLanguage(const std::string& language, bool fromSettings = false);
+	static std::string getLanguageByHumanReadableName(const std::string& language);
+	static std::string getLanguageByKey(const std::string& languageKey);
+	static std::string getCurrentLanguageCode();
+	static std::pair<std::string, std::string> const& getCurrentLanguage();
+	static std::map<std::string, std::string> GetAllLanguages(bool refresh = false);
 
 private:
-	std::vector<std::string> getLocalePaths() const;
+	static std::vector<std::string> getLocalePaths();
     
 private:
-	std::pair<std::string, std::string> m_currentLanguage{"en_US.UTF-8", "English" };
-	std::string m_package;
-	boost::locale::generator m_gen;
-	std::map<std::string, std::string> m_languages;
+	static std::pair<std::string, std::string> m_currentLanguage;
+	static std::string m_package;
+	static boost::locale::generator m_gen;
+	static std::map<std::string, std::string> m_languages;
 };

--- a/game/i18n.hh
+++ b/game/i18n.hh
@@ -23,7 +23,7 @@ private:
 	std::vector<std::string> getLocalePaths() const;
     
 private:
-	std::pair<std::string, std::string> m_currentLanguage;
+	std::pair<std::string, std::string> m_currentLanguage{"en_US.UTF-8", "English" };
 	std::string m_package;
 	boost::locale::generator m_gen;
 	std::map<std::string, std::string> m_languages;

--- a/game/main.cc
+++ b/game/main.cc
@@ -100,7 +100,7 @@ void mainLoop(std::string const& songlist) {
 	std::clog << "core/notice: Starting the audio subsystem (errors printed on console may be ignored)." << std::endl;
 	Audio audio;
 	std::clog << "core/info: Loading assets." << std::endl;
-	TranslationEngine localization(PACKAGE);
+	TranslationEngine localization;
 	TextureLoader m_loader;
 	Backgrounds backgrounds;
 	Database database(getConfigDir() / "database.xml");
@@ -109,7 +109,7 @@ void mainLoop(std::string const& songlist) {
 
 	Window window{};
 
-	Game gm(window, audio, localization);
+	Game gm(window, audio);
 	WebServer server(songs);
 
 	// Load audio samples

--- a/game/menu.cc
+++ b/game/menu.cc
@@ -69,7 +69,7 @@ void Menu::action(int dir) {
 
 				if (current().value->getName() == "game/language") {
 					auto &value = config["game/language"];
-					Game::getSingletonPtr()->setLanguage(value.getValue());
+					TranslationEngine::setLanguage(value.getValue(), true);
 				} else if (current().value->getName() == "graphic/stereo3d") {
 					try {
 						std::clog << "video/info: Stereo 3D configuration changed, will reset shaders.\n";
@@ -79,7 +79,7 @@ void Menu::action(int dir) {
 						current().value->b() = false; // Disable 3D if shader fails
 						throw;
 					}
-                                }
+								}
 			}
 			break;
 		}

--- a/game/players.cc
+++ b/game/players.cc
@@ -8,8 +8,6 @@
 #include <algorithm>
 #include <unicode/stsearch.h>
 
-icu::ErrorCode Players::m_icuError = icu::ErrorCode();
-
 void Players::load(xmlpp::NodeSet const& n) {
 	for (auto const& elem: n) {
 		xmlpp::Element& element = dynamic_cast<xmlpp::Element&>(*elem);
@@ -112,10 +110,15 @@ void Players::filter_internal() {
 		fplayers_t filtered;
 		if (m_filter.empty()) filtered = fplayers_t(m_players.begin(), m_players.end());
 		else {
-			icu::UnicodeString filter = icu::UnicodeString::fromUTF8(m_filter);
+
+			auto filter = icu::UnicodeString::fromUTF8(
+				UnicodeUtil::convertToUTF8(m_filter)
+				);
+			icu::ErrorCode icuError;
+
 			std::copy_if (m_players.begin(), m_players.end(), std::back_inserter(filtered), [&](PlayerItem it){
-			icu::StringSearch search = icu::StringSearch(filter, icu::UnicodeString::fromUTF8(it.name), UnicodeUtil::m_searchCollator.get(), nullptr, m_icuError);
-			return (search.first(m_icuError) != USEARCH_DONE);
+			icu::StringSearch search = icu::StringSearch(filter, icu::UnicodeString::fromUTF8(it.name), UnicodeUtil::m_searchCollator.get(), nullptr, icuError);
+			return (search.first(icuError) != USEARCH_DONE);
 			});
 		}
 		m_filtered.swap(filtered);

--- a/game/players.hh
+++ b/game/players.hh
@@ -81,8 +81,6 @@ class Players {
 private:
 	PlayerId assign_id_internal(); /// returns the next available id
 	void filter_internal();
-	static icu::ErrorCode m_icuError;
-	static icu::RuleBasedCollator icuCollator;
 
 private:
 	players_t m_players;

--- a/game/songparser.cc
+++ b/game/songparser.cc
@@ -71,7 +71,8 @@ SongParser::SongParser(Song& s): m_song(s) {
 		}
 		else {
 			std::string ss = UnicodeUtil::convertToUTF8(m_ss.str(), s.filename.string());
-			if (smCheck (ss)) {type = Type::SM; } else if (txtCheck (ss)) {
+			if (smCheck (ss)) type = Type::SM;
+			else if (txtCheck (ss)) {
 				type = Type::TXT;
 			}
 			else if (iniCheck (ss)) {

--- a/game/songparser.cc
+++ b/game/songparser.cc
@@ -70,16 +70,17 @@ SongParser::SongParser(Song& s): m_song(s) {
 			type = Type::XML;	// XMLPP should deal with encoding so we don't have to.
 		}
 		else {
-			UnicodeUtil::convertToUTF8(m_ss.str(), s.filename.string());
-			if (smCheck (m_ss.str())) {type = Type::SM; } else if (txtCheck (m_ss.str())) {
+			std::string ss = UnicodeUtil::convertToUTF8(m_ss.str(), s.filename.string());
+			if (smCheck (ss)) {type = Type::SM; } else if (txtCheck (ss)) {
 				type = Type::TXT;
 			}
-			else if (iniCheck (m_ss.str())) {
+			else if (iniCheck (ss)) {
 				type = Type::INI;
 			}
 			else {
 				throw SongParserException (s, "Does not look like a song file (wrong header)", 1, true);
 			}
+			m_ss.str(ss);
 		}
 		// Header already parsed?
 		if (s.loadStatus == Song::LoadStatus::HEADER) {

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -351,8 +351,10 @@ void Songs::filter_internal() {
 			std::shared_lock<std::shared_mutex> l(m_mutex);
 			filtered = m_songs;
 		} else {
-			std::string charset = UnicodeUtil::getCharset(m_filter);
-			icu::UnicodeString filter = UnicodeUtil::getConverter(UnicodeUtil::getCharset(m_filter)).convertToUTF8(m_filter);
+		
+			auto filter = icu::UnicodeString::fromUTF8(
+				UnicodeUtil::convertToUTF8(m_filter)
+				);
 			icu::ErrorCode icuError;
 
 			std::shared_lock<std::shared_mutex> l(m_mutex);

--- a/game/unicode.cc
+++ b/game/unicode.cc
@@ -81,7 +81,7 @@ std::string UnicodeUtil::convertToUTF8 (std::string_view str, std::string _filen
 			ustring.toLower();
 			break;
 		case CaseMapping::TITLE:
-			ustring.toTitle(0, icu::Locale(Game::getSingletonPtr()->getCurrentLanguageCode().c_str()), U_TITLECASE_NO_LOWERCASE);
+			ustring.toTitle(0, icu::Locale(TranslationEngine::getCurrentLanguageCode().c_str()), U_TITLECASE_NO_LOWERCASE);
 			break;
 		case CaseMapping::NONE:
 			break;

--- a/game/unicode.cc
+++ b/game/unicode.cc
@@ -70,7 +70,7 @@ std::string UnicodeUtil::convertToUTF8 (std::string_view str, std::string _filen
 			if (!_filename.empty()) std::clog << "unicode/info: " << _filename << " does not appear to be UTF-8; (" << charset << ") detected." << std::endl; 
 			ustring = UnicodeUtil::getConverter(charset).convertToUTF8(str);
 		}
-	else { ustring = icu::UnicodeString::fromUTF8(str); }
+	else { ustring = icu::UnicodeString::fromUTF8(str.data()); }
 	switch(toCase) {
 		case CaseMapping::UPPER:
 			ustring.toUpper();

--- a/game/unicode.hh
+++ b/game/unicode.hh
@@ -38,7 +38,7 @@ class UnicodeUtil {
 
 	static std::string getCharset(std::string_view str);
 	static Converter& getConverter(std::string const& s);
-	static bool removeUTF8BOM(std::string_view str);
+	static bool removeUTF8BOM(std::string_view& str);
 	
 	public:
 	UnicodeUtil() = delete;

--- a/game/unicode.hh
+++ b/game/unicode.hh
@@ -36,7 +36,7 @@ class UnicodeUtil {
 	static std::map<std::string, Converter> m_converters;
 	enum class CaseMapping { LOWER, UPPER, TITLE, NONE };
 
-	static std::string getCharset(std::string_view str);
+	static std::string getCharset(std::string_view& str);
 	static Converter& getConverter(std::string const& s);
 	static bool removeUTF8BOM(std::string_view& str);
 	

--- a/game/video_driver.cc
+++ b/game/video_driver.cc
@@ -17,6 +17,8 @@
 #include <SDL_video.h>
 #include <cstdint>
 
+#define stringify( name ) #name
+
 namespace {
 	float s_width;
 	float s_height;
@@ -24,13 +26,13 @@ namespace {
 	/// Tests for success when destoryed.
 	struct GLattrSetter {
 		GLattrSetter(SDL_GLattr attr, int value): m_attr(attr), m_value(value) {
-			if (SDL_GL_SetAttribute(attr, value)) std::clog << "video/warning: Error setting GLattr " << m_attr << std::endl;
+			if (SDL_GL_SetAttribute(attr, value)) std::clog << "video/warning: Error setting GLattr " << stringify(m_attr) << std::endl;
 		}
 		~GLattrSetter() {
 			int value;
 			SDL_GL_GetAttribute(m_attr, &value);
 			if (value != m_value)
-				std::clog << "video/warning: Error setting GLattr " << m_attr
+				std::clog << "video/warning: Error setting GLattr " << stringify (m_attr)
 				<< ": requested " << m_value << ", got " << value << std::endl;
 		}
 		SDL_GLattr m_attr;
@@ -65,6 +67,11 @@ Window::Window() : screen(nullptr, &SDL_DestroyWindow), glContext(nullptr, &SDL_
 	SDL_JoystickEventState(SDL_ENABLE);
 	{ // Setup GL attributes for context creation
 		SDL_SetHintWithPriority("SDL_HINT_VIDEO_HIGHDPI_DISABLED", "0", SDL_HINT_DEFAULT);
+		GLattrSetter attr_hw(SDL_GL_ACCELERATED_VISUAL, 1);
+		GLattrSetter attr_flush(SDL_GL_CONTEXT_RELEASE_BEHAVIOR, SDL_GL_CONTEXT_RELEASE_BEHAVIOR_FLUSH);
+		GLattrSetter attr_glmaj(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+		GLattrSetter attr_glmin(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+		GLattrSetter attr_glprof(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
 		GLattrSetter attr_r(SDL_GL_RED_SIZE, 8);
 		GLattrSetter attr_g(SDL_GL_GREEN_SIZE, 8);
 		GLattrSetter attr_b(SDL_GL_BLUE_SIZE, 8);
@@ -72,9 +79,6 @@ Window::Window() : screen(nullptr, &SDL_DestroyWindow), glContext(nullptr, &SDL_
 		GLattrSetter attr_buf(SDL_GL_BUFFER_SIZE, 32);
 		GLattrSetter attr_d(SDL_GL_DEPTH_SIZE, 24);
 		GLattrSetter attr_db(SDL_GL_DOUBLEBUFFER, 1);
-		GLattrSetter attr_glmaj(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-		GLattrSetter attr_glmin(SDL_GL_CONTEXT_MINOR_VERSION, 3);
-		GLattrSetter attr_glprof(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
 		Uint32 flags = SDL_WINDOW_HIDDEN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_OPENGL;
 		if (config["graphic/highdpi"].b()) { flags |= SDL_WINDOW_ALLOW_HIGHDPI; }
 		else { SDL_SetHintWithPriority("SDL_HINT_VIDEO_HIGHDPI_DISABLED", "1", SDL_HINT_OVERRIDE); }

--- a/osx-utils/performous-app-build.sh
+++ b/osx-utils/performous-app-build.sh
@@ -219,10 +219,10 @@ function finalize_bundle {
 
 	cd $ETCDIR/fonts
 	PREFIX_REGEX=$(echo ${PREFIXDIR} | sed -e 's|\/|\\\/|g')
-	sed -i '' -e "s|${PREFIX_REGEX}\/share|\.\.\/\.\.\/\.\.\/Resources|g" fonts.conf
+	sed -i '' -e "s|<dir>${PREFIX_REGEX}\/share|<dir prefix='relative'>\.\.\/\.\.\/\.\.\/Resources|g" fonts.conf
 	sed -i '' -e "s|${PREFIX_REGEX}\/var\/cache|\~\/\.cache|g" fonts.conf
 	sed -i '' -e 's|\<\!-- Font directory list --\>|\<\!-- Font directory list --\>\
-	<dir>\.\.\/\.\.\/pixmaps</dir>|g' fonts.conf
+	<dir prefix="relative">\.\.\/\.\.\/pixmaps</dir>|g' fonts.conf
 }
 
 


### PR DESCRIPTION
@ooshlablu reported seeing a crash on macOS after my second Unicode PR. I haven’t been able to reproduce it but from the trace, I’m thinking the issue must be that it’s trying to use “m_currentLanguage” before the class has finished constructing.

If so, it can probably be fixed by giving it a default value.

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/performous/performous/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

<!-- List here all the issues closed by this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
