### PR TITLE
Move SDL_Quit() to the Window destructor.

### DIFF
--- a/game/video_driver.cc
+++ b/game/video_driver.cc
@@ -60,7 +60,6 @@ GLuint Window::m_vbo = 0;
 GLint Window::bufferOffsetAlignment = -1;
 
 Window::Window() : screen(nullptr, &SDL_DestroyWindow), glContext(nullptr, &SDL_GL_DeleteContext) {
-	std::atexit(SDL_Quit);
 	if (SDL_Init(SDL_INIT_VIDEO|SDL_INIT_JOYSTICK))
 		throw std::runtime_error(std::string("SDL_Init failed: ") + SDL_GetError());
 	SDL_JoystickEventState(SDL_ENABLE);
@@ -241,6 +240,7 @@ Window::~Window() {
 	glDeleteBuffers(1, &m_vbo);
 	glDeleteBuffers(1, &m_ubo);
 	glDeleteVertexArrays(1, &m_vao);
+	SDL_Quit();
 }
 
 void Window::blank() {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/performous/performous/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

We posted this bug upstream over at https://github.com/libsdl-org/SDL/issues/5912 but nobody could reproduce it. @ooshlablu later said this happens after a crash. My hypothesis is we were not cleaning SDL up on abnormal exit, which could maybe cause the issue?

I'm mentioning upstream also so it can be definitely documented that this was the cause, in case this does work.

<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

Theoretically, close #800.

<!-- List here all the issues closed by this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
