### PR TITLE
Fix a bug in ConfigItem::addEnum

### DIFF
--- a/game/configitem.cc
+++ b/game/configitem.cc
@@ -37,24 +37,44 @@ ConfigItem::ConfigItem(OptionList opts)
 : m_type("option_list"), m_value(opts) {
 }
 
-ConfigItem::NumericValue& ConfigItem::getMin() {
+ConfigItem::NumericValue ConfigItem::getMin() const {
 	return m_min;
 }
 
-ConfigItem::NumericValue& ConfigItem::getMax() {
+void ConfigItem::setMin(NumericValue min) {
+	m_min = min;
+}
+
+ConfigItem::NumericValue ConfigItem::getMax() const {
 	return m_max;
 }
 
-ConfigItem::NumericValue& ConfigItem::getStep() {
+void ConfigItem::setMax(NumericValue max) {
+	m_max = max;
+}
+
+ConfigItem::NumericValue ConfigItem::getStep() const {
 	return m_step;
 }
 
-ConfigItem::NumericValue& ConfigItem::getMultiplier() {
+void ConfigItem::setStep(NumericValue step) {
+	m_step = step;
+}
+
+ConfigItem::NumericValue ConfigItem::getMultiplier() const {
 	return m_multiplier;
 }
 
-std::string& ConfigItem::getUnit() {
+void ConfigItem::setMultiplier(NumericValue multiplier) {
+	m_multiplier = multiplier;
+}
+
+std::string const& ConfigItem::getUnit() const {
 	return m_unit;
+}
+
+void ConfigItem::setUnit(std::string const& unit) {
+	m_unit = unit;
 }
 
 ConfigItem& ConfigItem::incdec(int dir) {
@@ -193,19 +213,20 @@ std::string const ConfigItem::getValue() const {
 	throw std::logic_error("ConfigItem::getValue doesn't know type '" + m_type + "'");
 }
 
-void ConfigItem::addEnum(std::string name) {
+void ConfigItem::addEnum(std::string const& name) {
 	verifyType("uint");
-	if (find(m_enums.begin(),m_enums.end(),name) == m_enums.end()) {
+	if (find(m_enums.begin(), m_enums.end(), name) == m_enums.end())
 		m_enums.push_back(name);
-	}
+
 	m_min = static_cast<unsigned short>(0);
 	m_max = static_cast<unsigned short>(m_enums.size() - 1);
-	m_min = static_cast<unsigned short>(1);
+	m_step = static_cast<unsigned short>(1);
 }
 
 void ConfigItem::selectEnum(std::string const& name) {
 	auto it = std::find(m_enums.begin(), m_enums.end(), name);
-	if (it == m_enums.end()) throw std::runtime_error("Enum value " + name + " not found in " + m_shortDesc);
+	if (it == m_enums.end())
+		throw std::runtime_error("Enum value " + name + " not found in " + m_shortDesc);
 	ui() = static_cast<unsigned short>(it - m_enums.begin());
 }
 

--- a/game/configitem.cc
+++ b/game/configitem.cc
@@ -37,46 +37,6 @@ ConfigItem::ConfigItem(OptionList opts)
 : m_type("option_list"), m_value(opts) {
 }
 
-ConfigItem::NumericValue ConfigItem::getMin() const {
-	return m_min;
-}
-
-void ConfigItem::setMin(NumericValue min) {
-	m_min = min;
-}
-
-ConfigItem::NumericValue ConfigItem::getMax() const {
-	return m_max;
-}
-
-void ConfigItem::setMax(NumericValue max) {
-	m_max = max;
-}
-
-ConfigItem::NumericValue ConfigItem::getStep() const {
-	return m_step;
-}
-
-void ConfigItem::setStep(NumericValue step) {
-	m_step = step;
-}
-
-ConfigItem::NumericValue ConfigItem::getMultiplier() const {
-	return m_multiplier;
-}
-
-void ConfigItem::setMultiplier(NumericValue multiplier) {
-	m_multiplier = multiplier;
-}
-
-std::string const& ConfigItem::getUnit() const {
-	return m_unit;
-}
-
-void ConfigItem::setUnit(std::string const& unit) {
-	m_unit = unit;
-}
-
 ConfigItem& ConfigItem::incdec(int dir) {
 	if (m_type == "int") {
 		int& val = std::get<int>(m_value);

--- a/game/configitem.hh
+++ b/game/configitem.hh
@@ -57,17 +57,22 @@ class ConfigItem {
 	std::string const getValue() const; ///< Get a human-readable representation of the current value
 	std::string const getOldValue() const { return m_oldValue; } ///< Get a human-readable representation of a previous value.
 	void setOldValue(std::string const& value) { m_oldValue = value; } ///< Store the current value before changing it, for later comparison.
-	void addEnum(std::string name); ///< Dynamically adds an enum to all values
+	void addEnum(std::string const& name); ///< Dynamically adds an enum to all values
 	void selectEnum(std::string const& name); ///< Set integer value by enum name
 	std::string const getEnumName() const; ///< Returns the selected enum option's text
 	std::vector<std::string>& getEnum() { return m_enums; }
 	unsigned short getSelection() const { return m_sel; }
 
-	NumericValue& getMin();
-	NumericValue& getMax();
-	NumericValue& getStep();
-	NumericValue& getMultiplier();
-	std::string& getUnit();
+	NumericValue getMin() const;
+	void setMin(NumericValue);
+	NumericValue getMax() const;
+	void setMax(NumericValue);
+	NumericValue getStep() const;
+	void setStep(NumericValue);
+	NumericValue getMultiplier() const;
+	void setMultiplier(NumericValue);
+	std::string const& getUnit() const;
+	void setUnit(std::string const&);
 
 	void setGetValueFunction(std::function<std::string(ConfigItem const&)> f) { m_getValue = f; }
 
@@ -87,7 +92,8 @@ class ConfigItem {
 	Value m_defaultValue; ///< The value from config schema or system config
 	std::string m_oldValue; ///< A previous value, as output by getValue().
 	std::vector<std::string> m_enums; ///< Enum value titles
-	NumericValue m_step, m_min, m_max;
+	NumericValue m_step{1};
+	NumericValue m_min, m_max;
 	NumericValue m_multiplier;
 	std::string m_unit;
 	unsigned short m_sel = 0;

--- a/game/configitem.hh
+++ b/game/configitem.hh
@@ -63,23 +63,18 @@ class ConfigItem {
 	std::vector<std::string>& getEnum() { return m_enums; }
 	unsigned short getSelection() const { return m_sel; }
 
-	NumericValue getMin() const;
-	void setMin(NumericValue);
-	NumericValue getMax() const;
-	void setMax(NumericValue);
-	NumericValue getStep() const;
-	void setStep(NumericValue);
-	NumericValue getMultiplier() const;
-	void setMultiplier(NumericValue);
-	std::string const& getUnit() const;
-	void setUnit(std::string const&);
-
 	void setGetValueFunction(std::function<std::string(ConfigItem const&)> f) { m_getValue = f; }
 
   private:
 	void verifyType(std::string const& t) const; ///< throws std::logic_error if t != type
 	ConfigItem& incdec(int dir); ///< Increment/decrement by dir steps (must be -1 or 1)
 	bool isDefaultImpl(Value const& defaultValue) const;
+
+  public:
+	NumericValue m_step{1};
+	NumericValue m_min, m_max;
+	NumericValue m_multiplier;
+	std::string m_unit;
 
   private:
 	std::string m_keyName; ///< The config key in the schema file.
@@ -92,10 +87,6 @@ class ConfigItem {
 	Value m_defaultValue; ///< The value from config schema or system config
 	std::string m_oldValue; ///< A previous value, as output by getValue().
 	std::vector<std::string> m_enums; ///< Enum value titles
-	NumericValue m_step{1};
-	NumericValue m_min, m_max;
-	NumericValue m_multiplier;
-	std::string m_unit;
 	unsigned short m_sel = 0;
 	std::function<std::string(ConfigItem const&)> m_getValue;
 };

--- a/game/configuration.cc
+++ b/game/configuration.cc
@@ -59,29 +59,42 @@ namespace {
 		a = e.get_attribute("step");
 		if (a) step = sconv<T>(a->get_value());
 	}
+	template <typename T> void setLimits(xmlpp::Element& e, ConfigItem& item) {
+		decltype(item.getMin()) min;
+		decltype(item.getMax()) max;
+		decltype(item.getStep()) step;
+
+		setLimits<T>(e, min, max, step);
+
+		item.setMin(min);
+		item.setMax(max);
+		item.setStep(step);
+	}
 }
 
 template <typename T> void ConfigItemXMLLoader::updateNumeric(ConfigItem& item, xmlpp::Element& elem, unsigned mode) {
 	auto ns = elem.find("limits");
-	if (!ns.empty()) setLimits<T>(dynamic_cast<xmlpp::Element&>(*ns[0]), item.getMin(), item.getMax(), item.getStep());
-	else if (mode == 0) throw XMLError(elem, "child element limits missing");
+	if (!ns.empty())
+		setLimits<T>(dynamic_cast<xmlpp::Element&>(*ns[0]), item);
+	else if (mode == 0)
+		throw XMLError(elem, "child element limits missing");
 	ns = elem.find("ui");
 	// Default values
 	if (mode == 0) {
-		item.getUnit().clear();
-		item.getMultiplier() = static_cast<T>(1);
+		item.setUnit({});
+		item.setMultiplier(static_cast<T>(1));
 	}
 	if (!ns.empty()) {
 		xmlpp::Element& e = dynamic_cast<xmlpp::Element&>(*ns[0]);
 		try {
-			item.getUnit() = getAttribute(e, "unit");
+			item.setUnit(getAttribute(e, "unit"));
 		}
 		catch (...) {
 		}
 		std::string m;
 		try {
 			m = getAttribute(e, "multiplier");
-			item.getMultiplier() = sconv<T>(m);
+			item.setMultiplier(sconv<T>(m));
 		}
 		catch (XMLError&) {
 		}
@@ -393,8 +406,10 @@ void readConfig() {
 	pathInit();
 	// Populate themes
 	ConfigItem& ci = config["game/theme"];
-	for (std::string const& theme : getThemes()) ci.addEnum(theme);
-	if (ci.ui() == 1337) ci.selectEnum("default");  // Select the default theme if nothing is selected
+	for (auto const& theme : getThemes())
+		ci.addEnum(theme);
+	if (ci.ui() == 1337)
+		ci.selectEnum("default");  // Select the default theme if nothing is selected
 }
 
 void populateBackends(const std::list<std::string>& backendList) {

--- a/game/configuration.cc
+++ b/game/configuration.cc
@@ -60,15 +60,7 @@ namespace {
 		if (a) step = sconv<T>(a->get_value());
 	}
 	template <typename T> void setLimits(xmlpp::Element& e, ConfigItem& item) {
-		decltype(item.getMin()) min;
-		decltype(item.getMax()) max;
-		decltype(item.getStep()) step;
-
-		setLimits<T>(e, min, max, step);
-
-		item.setMin(min);
-		item.setMax(max);
-		item.setStep(step);
+		setLimits<T>(e, item.m_min, item.m_max, item.m_step);
 	}
 }
 
@@ -81,20 +73,20 @@ template <typename T> void ConfigItemXMLLoader::updateNumeric(ConfigItem& item, 
 	ns = elem.find("ui");
 	// Default values
 	if (mode == 0) {
-		item.setUnit({});
-		item.setMultiplier(static_cast<T>(1));
+		item.m_unit = {};
+		item.m_multiplier = static_cast<T>(1);
 	}
 	if (!ns.empty()) {
 		xmlpp::Element& e = dynamic_cast<xmlpp::Element&>(*ns[0]);
 		try {
-			item.setUnit(getAttribute(e, "unit"));
+			item.m_unit = getAttribute(e, "unit");
 		}
 		catch (...) {
 		}
 		std::string m;
 		try {
 			m = getAttribute(e, "multiplier");
-			item.setMultiplier(sconv<T>(m));
+			item.m_multiplier = sconv<T>(m);
 		}
 		catch (XMLError&) {
 		}
@@ -146,9 +138,9 @@ void ConfigItemXMLLoader::update(ConfigItem& item, xmlpp::Element& elem, unsigne
 						xmlpp::Element& elem2 = dynamic_cast<xmlpp::Element&>(**it2);
 						if (!getText(elem2).empty()) item.getEnum().push_back(getText(elem2));
 					}
-					item.getMin() = static_cast<unsigned short>(0);
-					item.getMax() = static_cast<unsigned short>(item.getEnum().size() - 1);
-					item.getStep() = static_cast<unsigned short>(1);
+					item.m_min = static_cast<unsigned short>(0);
+					item.m_max = static_cast<unsigned short>(item.getEnum().size() - 1);
+					item.m_step = static_cast<unsigned short>(1);
 				}
 			}
 			updateNumeric<unsigned short>(item, elem, mode);

--- a/testing/configitemtest.cc
+++ b/testing/configitemtest.cc
@@ -294,5 +294,49 @@ namespace {
 
 		EXPECT_EQ(0, item.getSelection());
 	}
+
+	TEST(UnitTest_ConfigItem, increase) {
+		auto item = ConfigItem(static_cast<unsigned short>(0));
+
+		item.addEnum("C");
+		item.addEnum("A");
+		item.addEnum("B");
+
+		EXPECT_EQ(0, item.ui());
+
+		++item;
+
+		EXPECT_EQ(1, item.ui());
+
+		++item;
+
+		EXPECT_EQ(2, item.ui());
+
+		++item;
+
+		EXPECT_EQ(2, item.ui());
+	}
+
+	TEST(UnitTest_ConfigItem, decrease) {
+		auto item = ConfigItem(static_cast<unsigned short>(2));
+
+		item.addEnum("C");
+		item.addEnum("A");
+		item.addEnum("B");
+
+		EXPECT_EQ(2, item.ui());
+
+		--item;
+
+		EXPECT_EQ(1, item.ui());
+
+		--item;
+
+		EXPECT_EQ(0, item.ui());
+
+		--item;
+
+		EXPECT_EQ(0, item.ui());
+	}
 }
 


### PR DESCRIPTION
### What does this PR do?

In ConfigItem::addEnum a typo is fixed that results in not initializing
m_step so that calculations do division by zero.

Also ConfigItem get setters for some values to deny setting the values
by getters.

### Closes Issue(s)

Closes #812 -> Division by zero since `m_step` wasn't correctly set.
