### PR TITLE
Add mappings for Dforce Deluxe Dance + Pump pad

### DIFF
--- a/data/config/controllers.xml
+++ b/data/config/controllers.xml
@@ -394,6 +394,23 @@
 				<button hw="14" map="down" />
 			</mapping>
 		</controller>
+		<controller type="dancepad" name="DANCEPAD_DFORCE_DANCE_PUMP">
+			<description>Dforce (Deluxe) Dance + Pump Pad</description>
+			<device regex="USB Joystick" />
+			<mapping>
+				<button hw="0" map="up" />
+				<button hw="1" map="down" />
+				<button hw="2" map="left" />
+				<button hw="3" map="right" />
+				<!-- button 4 is the center button -->
+				<button hw="5" map="down-right" />
+				<button hw="6" map="up-left" />
+				<button hw="7" map="up-right" />
+				<button hw="8" map="down-left" />
+				<button hw="9" map="start" />
+				<axis hw="1" positive="cancel" />
+			</mapping>
+		</controller>
 		<controller type="keytar" name="KEYTAR_GENERIC">
 			<description>Generic keytar</description>
 			<device regex="NO MATCH" />


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/performous/performous/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

Add mappings for https://dancepadmania.com/product/pumpdeluxe/

### Closes Issue(s)

N/A

### Motivation

I wanted to use performous with my new dance pad.


### More

- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

I got these mappings from the pad I ordered at
<https://dancepadmania.com/product/pumpdeluxe/>. I'm guessing the
mappings are the same for the basic version
<https://dancepadmania.com/product/pump-basic-dance-pad/> too, but I
don't have one to test.

Some fields from lsusb that might be useful if other fields other than
iProduct can be matched in the future:

```
  idVendor           0x0e8f GreenAsia Inc.
  idProduct          0x0035
  iManufacturer           0
  iProduct                2 USB Joystick
  iSerial                 0
```