### PR TITLE
Fix/mute vocal track

### DIFF
--- a/data/config/schema.xml
+++ b/data/config/schema.xml
@@ -389,6 +389,10 @@ to save the current settings to XML.
 		<short>Suppress center channel</short>
 		<long>Suppress audio of center channel (e.g. vocals).</long>
 	</entry>
+	<entry name="audio/mute_vocals_track" type="bool" value="false">
+		<short>Mute the vocals track</short>
+		<long>Mute the vocals track if a vocals.ogg is found.</long>
+	</entry>
 
 	<!-- Paths -->
 	<entry name="paths/songs" type="string_list" hidden="false">

--- a/game/screen_sing.cc
+++ b/game/screen_sing.cc
@@ -246,7 +246,12 @@ void ScreenSing::instrumentLayout(double time) {
 			if (cs.first > 0) level = cs.second / cs.first;
 			if (m_song->music.size() <= 1) level = std::max(0.333, level);
 		}
-		m_audio.streamFade(name, level);
+		if (name == "Vocals") {
+			m_audio.streamFade(name, config["audio/mute_vocals_track"].b() ? 0.0 : 1.0);
+		}
+		else {
+			m_audio.streamFade(name, level);
+		}
 		if (pitchbend.find(locName) != pitchbend.end()) {
 			CountSum cs = pitchbend[locName];
 			level = cs.second;
@@ -393,7 +398,11 @@ void ScreenSing::manageEvent(SDL_Event event) {
 			dispInFlash(config["audio/suppress_center_channel"]);
 		}
 		if (key == SDL_SCANCODE_S) m_audio.toggleSynth(m_song->getVocalTrack(m_selectedTrack).notes);
-		if (key == SDL_SCANCODE_V) m_audio.streamFade("vocals", event.key.keysym.mod & KMOD_SHIFT ? 1.0 : 0.0);
+		if (key == SDL_SCANCODE_V) {
+			config["audio/mute_vocals_track"].b() = !config["audio/mute_vocals_track"].b();
+			m_audio.streamFade("Vocals", config["audio/mute_vocals_track"].b() ? 0.0 : 1.0);
+			dispInFlash(config["audio/mute_vocals_track"]);
+		}
 		if (key == SDL_SCANCODE_K)  { // Toggle karaoke mode
 			if(config["game/karaoke_mode"].ui() >=2) config["game/karaoke_mode"].ui() = 0;
 			else ++config["game/karaoke_mode"];


### PR DESCRIPTION
### What does this PR do?

* Updates vcpkg to the latest master version.
* Fixes a bug where the vocal track would always be set to 1.0 instead of the toggled setting the user setted.
    * Use `ctrl + v` to toggle the mute/unmute of the vocal track.
    * Use a song which contains a `vocals.ogg` file. 
* Adds an entry to config to save the prefered way for this.

### Closes Issue(s)

Closes #811

### Motivation

This bug was introduced a long time ago and ever since it didn't work anymore. Thanks for @Cossey to point this out


### More

- [x] Updated https://github.com/performous/performous/wiki/Real-karaoke to match the correct behavior