### PR TITLE
Disable shortcut keys when a menu is open

### DIFF
--- a/game/controllers-keyboard.cc
+++ b/game/controllers-keyboard.cc
@@ -26,8 +26,8 @@ namespace input {
 			// Switch modes and update m_mod only when no buttons are pressed
 			// (avoids buttons getting stuck on mode change)
 			if (m_pressed.empty()) {
-				// The mods that we consider modifiers here: only left Ctrl/Cmd and Alt
-				m_mod = sdlEv.key.keysym.mod & (Platform::shortcutModifier(false) | KMOD_LALT);
+				// The mods that we consider modifiers here: only Ctrl/Cmd and Alt
+				m_mod = sdlEv.key.keysym.mod & (Platform::shortcutModifier() | KMOD_LALT);
 				// Enable/disable keyboard instruments based on current config
 				std::string msg;
 				if (g_enableInstruments) {
@@ -129,7 +129,7 @@ namespace input {
 				if (k == SDL_SCANCODE_PAGEDOWN) return ButtonId::GENERIC_MOREDOWN;
 				if (k == SDL_SCANCODE_PAUSE) return ButtonId::GENERIC_PAUSE;
 			}
-			else if (m_mod == Platform::shortcutModifier(false)) {
+			else if (m_mod == Platform::shortcutModifier()) {
 				if (k == SDL_SCANCODE_UP) return ButtonId::GENERIC_VOLUME_UP;
 				if (k == SDL_SCANCODE_DOWN) return ButtonId::GENERIC_VOLUME_DOWN;
 				if (k == SDL_SCANCODE_P) return ButtonId::GENERIC_PAUSE;

--- a/game/controllers-keyboard.cc
+++ b/game/controllers-keyboard.cc
@@ -61,7 +61,7 @@ namespace input {
 			switch (event.hw) {
 				// Guitar on keyboard
 				case SDL_SCANCODE_BACKSPACE: button = to_underlying(ButtonId::GUITAR_WHAMMY); goto guitar_process;
-				case SDL_SCANCODE_RCTRL: case SDL_SCANCODE_RALT: button = to_underlying(ButtonId::GUITAR_GODMODE); goto guitar_process;
+				case SDL_SCANCODE_BACKSLASH: case SDL_SCANCODE_SLASH: button = to_underlying(ButtonId::GUITAR_GODMODE); goto guitar_process;
 				case SDL_SCANCODE_RSHIFT: button = to_underlying(ButtonId::GUITAR_PICK_UP); goto guitar_process;
 				case SDL_SCANCODE_RETURN: case SDL_SCANCODE_KP_ENTER: button = to_underlying(ButtonId::GUITAR_PICK_DOWN); goto guitar_process;
 				case SDL_SCANCODE_F5: case SDL_SCANCODE_5: case SDL_SCANCODE_B: button++; [[fallthrough]];

--- a/game/screen_sing.cc
+++ b/game/screen_sing.cc
@@ -383,10 +383,13 @@ void ScreenSing::manageEvent(input::NavEvent const& event) {
 
 void ScreenSing::manageEvent(SDL_Event event) {
 	keyPressed = true;
+	// Check to see if a menu is open and bail out before changes can be made
+	if (m_score_window.get() || m_menu.isOpen()) return;
+	for (auto& i: m_instruments) if (!i->menuOpen()) return;
 	double time = m_audio.getPosition();
 	SDL_Scancode key = event.key.keysym.scancode;
-	// Ctrl combinations that can be used while performing (not when score dialog is displayed)
-	if (event.type == SDL_KEYDOWN && (event.key.keysym.mod & Platform::shortcutModifier(false)) && !m_score_window.get()) {
+	// Ctrl combinations that can be used while performing
+	if (event.type == SDL_KEYDOWN && (event.key.keysym.mod & Platform::shortcutModifier())) {
 		if (key == SDL_SCANCODE_C) {
 			m_audio.toggleCenterChannelSuppressor();
 			++config["audio/suppress_center_channel"];


### PR DESCRIPTION
### What does this PR do?

- Disable shortcut keys while a menu is active.
- Enable right modifier key for shortcuts and in line with the behaviour elsewhere.

### Motivation

I attempted to seek with a menu open and it started playing again despite the menu still being open.

### Additional Notes

Consensus was to disable the shortcuts while menus were open.
