### PR TITLE
Fix a couple warnings in sample.hpp and the ringbuffer.

### DIFF
--- a/game/libda/sample.hpp
+++ b/game/libda/sample.hpp
@@ -70,10 +70,17 @@ namespace da {
 	static inline int conv_to_s24_fast(sample_t s) { return static_cast<int>(s * max_s24); }
 	static inline int conv_to_s32_fast(sample_t s) { return static_cast<int>(s * max_s32); }
 
-	template <typename ValueType> class step_iterator: public std::iterator<std::random_access_iterator_tag, ValueType> {
+	template <typename ValueType> class step_iterator {
 		ValueType* m_pos;
 		std::ptrdiff_t m_step;
-	  public:
+
+	public:
+		using iterator_category = std::random_access_iterator_tag;
+		using value_type = ValueType;
+		using difference_type = ValueType;
+		using pointer = ValueType*;
+		using reference = ValueType&;
+
 		step_iterator(ValueType* pos, std::ptrdiff_t step): m_pos(pos), m_step(step) {}
 		ValueType& operator*() { return *m_pos; }
 		step_iterator operator+(std::ptrdiff_t rhs) { return step_iterator(m_pos + m_step * rhs, m_step); }

--- a/game/ringbuffer.hh
+++ b/game/ringbuffer.hh
@@ -1,33 +1,34 @@
 #pragma once
 
 #include <atomic>
+#include <cstddef>
 
 /// Lock-free ring buffer. Discards oldest data on overflow (not strictly thread-safe).
-template <std::size_t SIZE> class RingBuffer {
+template <std::ptrdiff_t SIZE> class RingBuffer {
   public:
-	constexpr static std::size_t capacity = SIZE;
+	constexpr static std::ptrdiff_t capacity = SIZE;
 
 	template <typename InIt> void insert(InIt begin, InIt end);
 	/// Read data from current position if there is enough data to fill the range (otherwise return false). Does not move read pointer.
 	template <typename OutIt> bool read(OutIt begin, OutIt end);
-	void pop(std::size_t n); ///< Move reading pointer forward.
-	std::size_t size() const;
+	void pop(std::ptrdiff_t n); ///< Move reading pointer forward.
+	std::ptrdiff_t size() const;
 
   private:
-	static std::size_t modulo(std::size_t idx);  ///< Modulo operation with proper rounding (handles slightly "negative" idx as well)
+	static std::ptrdiff_t modulo(std::ptrdiff_t idx);  ///< Modulo operation with proper rounding (handles slightly "negative" idx as well)
 
-	constexpr static std::size_t buffersize = SIZE + 1;
+	constexpr static std::ptrdiff_t buffersize = SIZE + 1;
 	float m_buf[buffersize];
 	// The indices of the next read/write operations. read == write implies that buffer is empty.
-	std::atomic<std::size_t> m_read{ 0 };
-	std::atomic<std::size_t> m_write{ 0 };
+	std::atomic<std::ptrdiff_t> m_read{ 0 };
+	std::atomic<std::ptrdiff_t> m_write{ 0 };
 };
 
-template <std::size_t SIZE>
+template <std::ptrdiff_t SIZE>
 template <typename InIt>
 void RingBuffer<SIZE>::insert(InIt begin, InIt end) {
-	std::size_t r = m_read;  // The read position
-	std::size_t w = m_write;  // The write position
+	std::ptrdiff_t r = m_read;  // The read position
+	std::ptrdiff_t w = m_write;  // The write position
 	bool overflow = false;
 	while (begin != end) {
 		m_buf[w] = *begin++;  // Copy sample
@@ -40,29 +41,29 @@ void RingBuffer<SIZE>::insert(InIt begin, InIt end) {
 		m_read = modulo(w + 1);  // Reset read pointer on overflow
 }
 
-template <std::size_t SIZE>
+template <std::ptrdiff_t SIZE>
 template <typename OutIt>
 bool RingBuffer<SIZE>::read(OutIt begin, OutIt end) {
-	std::size_t requestedELements = end - begin;
+	std::ptrdiff_t requestedELements = end - begin;
 	if (size() < requestedELements) // Not enough audio available
 		return false;
-	std::size_t r = m_read;
+	std::ptrdiff_t r = m_read;
 	while (begin != end)  // Copy audio to output iterator
 		*begin++ = m_buf[r++ % buffersize];
 	return true;
 }
 
-template <std::size_t SIZE>
-void RingBuffer<SIZE>::pop(std::size_t n) {
+template <std::ptrdiff_t SIZE>
+void RingBuffer<SIZE>::pop(std::ptrdiff_t n) {
 	m_read = modulo(m_read + n);
 }
 
-template <std::size_t SIZE>
-std::size_t RingBuffer<SIZE>::size() const {
+template <std::ptrdiff_t SIZE>
+std::ptrdiff_t RingBuffer<SIZE>::size() const {
 	return modulo(m_write - m_read);
 }
 
-template <std::size_t SIZE>
-std::size_t RingBuffer<SIZE>::modulo(std::size_t idx) {
+template <std::ptrdiff_t SIZE>
+std::ptrdiff_t RingBuffer<SIZE>::modulo(std::ptrdiff_t idx) {
 	return (buffersize + idx) % buffersize;
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/performous/performous/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

Fixes the deprecated `std::iterator` usage in sample.hpp, as well as a sign mismatch warning introduced in the ringbuffer.

<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

<!-- List here all the issues closed by this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
