### PR TITLE
Kill Ubuntu 18.04 from CI, fix other minor issues.

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -49,7 +49,7 @@ jobs:
           echo "::set-output name=version_minor::$(cut -d '.' -f 2 <<< $(git describe --tags --abbrev=0 || echo 1.0.0))"
           echo "::set-output name=version_patch::$(cut -d '.' -f 3 <<< $(git describe --tags --abbrev=0 || echo 1.0.0))"
           echo "::set-output name=version_tweak::0"
-          echo "::set-output name=complete_version::$(if [ $GITHUB_REF_TYPE == 'tag' ]; then echo $GITHUB_REF_NAME; elif [ $GITHUB_REF_TYPE == 'branch' ] && [ $GITHUB_REF_NAME == 'master' ]; then echo $LATEST_FULL_TAG_VERSION-beta; elif [ $GITHUB_REF_TYPE == 'branch' ] && [ $GITHUB_REF_NAME != 'master' ]; then echo $LATEST_TAG_VERSION-${{github.event.pull_request.number}}-${GITHUB_SHA::7}-alpha; fi)"
+          echo "::set-output name=complete_version::$(if [ $GITHUB_REF_TYPE = 'tag' ]; then echo $GITHUB_REF_NAME; elif [ $GITHUB_REF_TYPE = 'branch' ] && [ $GITHUB_REF_NAME = 'master' ]; then echo $LATEST_FULL_TAG_VERSION-beta; elif [ $GITHUB_REF_TYPE = 'branch' ] && [ $GITHUB_REF_NAME != 'master' ]; then echo $LATEST_TAG_VERSION-${{github.event.pull_request.number}}-${GITHUB_SHA::7}-alpha; fi)"
           rm -rf performous
 
   # Set up a release that packages will be published to.
@@ -102,7 +102,6 @@ jobs:
           # Images must be added to 
           # https://github.com/performous/performous-docker with
           # a successful run on master before they can be used here
-          - ubuntu18.04
           - ubuntu20.04
           - ubuntu22.04
           - fedora34
@@ -159,18 +158,14 @@ jobs:
           . /etc/os-release
 
           ## Set up some special cmake flags for fedora
-          if [ "${ID}" == "fedora" ]; then
+          if ([ "${ID}" = "fedora" ]); then
             EXTRA_CMAKE_ARGS="-DUSE_BOOST_REGEX=1"
           fi
 
-          if ([ "${ID}" = "ubuntu" ] && [ "${VERSION_ID}" = "18.04" ]) || ([ "${ID}" = "debian" ] && [ "${VERSION_ID}" = "10" ]); then
-            # Ubuntu 18.04 and Debian Buster has system Aubio 0.4.5, this is not enough
+          if ([ "${ID}" = "debian" ] && [ "${VERSION_ID}" = "10" ]); then
+            # Debian Buster has system Aubio 0.4.5, this is not enough
             # because performous requires a minimum version of 0.4.9.
             EXTRA_CMAKE_ARGS="${EXTRA_CMAKE_ARGS} -DSELF_BUILT_AUBIO=ALWAYS -DSELF_BUILT_JSON=ALWAYS"
-            if ([ "${ID}" = "ubuntu" ]); then
-              export CC=gcc-8
-              export CXX=g++-8
-            fi
           fi
 
           ## Figure out what type of packages we need to generate

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Latest builds
 - [Windows (MSVC)](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-msvc.exe.zip)
 - [Windows (MinGW-w64)](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-mingw-w64.exe.zip)
 - [Mac OS X](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest.dmg.zip)
-- [Linux - Ubuntu 18.04](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-ubuntu_18.04.deb.zip)
 - [Linux - Ubuntu 20.04](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-ubuntu_20.04.deb.zip)
 - [Linux - Ubuntu 22.04](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-ubuntu_22.04.deb.zip)
 - [Linux - Debian 10](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-debian_10.deb.zip)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/performous/performous/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

I've removed 18.04 support from the docker images, as well as fixed a couple minor issues (like using an official backport of libfmt 6.1.2 for debian 10, instead of 5.2.1) chiefly because #545 can't build against Boost < 1.66.0 and libfmt 4.0 (that's particularly ancient).

This PR fixes the actual CI script to account for these changes, as well as fixing some errors in the syntax of `if` statements under `/bin/sh`

<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

<!-- List here all the issues closed by this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
