### PR TITLE
Fix sigsegv in drawCovers().

### DIFF
--- a/game/screen_songs.cc
+++ b/game/screen_songs.cc
@@ -399,7 +399,7 @@ void ScreenSongs::drawCovers() {
 	double beat = 0.5 + m_idleTimer.get() / 2.0;  // 30 BPM
 	if (ss > 0) {
 		// Use actual song BPM. FIXME: Should only do this if currentId is also playing.
-		if (m_songs.currentPtr()->music == m_playing) {
+		if (m_songs.currentPtr() && m_songs.currentPtr()->music == m_playing) {
 				if (m_songs.currentPtr()->hasControllers() || !m_songs.currentPtr()->beats.empty()) {
 				double t = m_audio.getPosition() - config["audio/video_delay"].f();
 				Song::Beats const& beats = m_songs.current().beats;
@@ -409,7 +409,7 @@ void ScreenSongs::drawCovers() {
 					beat = (t - t1) / (t2 - t1);
 				}
 			}
-			else if (m_songs.currentPtr() && !m_songs.currentPtr()->m_bpms.empty()) {
+			else if (!m_songs.currentPtr()->m_bpms.empty()) {
 				float tempo = static_cast<float>(m_songs.currentPtr()->m_bpms.front().step * 4.0);
 				if (static_cast<unsigned>(tempo) <= 100u) tempo *= 2.0f;
 				else if (static_cast<unsigned>(tempo) > 400u) tempo /= 4.0f;


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/performous/performous/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

Fixes a potential `nullptr` dereference in `drawCovers`.

<!-- A brief description of the change being made with this pull request. -->

@ooshlablu noticed a crash in screeen_songs while testing #545.

Upon investigating I reproduced it and tracked it here. No idea why it's not causing a crash on master but did on the PR.

### Closes Issue(s)

<!-- List here all the issues closed by this pull request. -->

### Motivation

QA

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
