### PR TITLE
fix/uint config mismatch

### DIFF
--- a/game/configitem.hh
+++ b/game/configitem.hh
@@ -27,7 +27,6 @@ class ConfigItem {
 	ConfigItem& operator--() { return incdec(-1); } ///< decrements config value
 	/// Is the current value the same as the default value (factory setting or system setting)
 	bool isDefault(bool factory = false) const { return isDefaultImpl(factory ? m_factoryDefaultValue : m_defaultValue); }
-	std::string get_type() const { return m_type; } ///< get the field type
 	std::string getType() const { return m_type; } ///< get the field type
 	void setType(std::string const& type) { m_type = type; }
 	int& i(); ///< Access integer item

--- a/game/menu.cc
+++ b/game/menu.cc
@@ -25,7 +25,7 @@ bool MenuOption::isActive() const {
 	if (type == Type::OPEN_SUBMENU && options.empty()) return false;
 	if (type == Type::CHANGE_VALUE) {
 		if (!value) return false;
-		if (value->get_type() == "option_list" && value->ol().size() <= 1) return false;
+		if (value->getType() == "option_list" && value->ol().size() <= 1) return false;
 	}
 	return true;
 }


### PR DESCRIPTION
This was considered in the original implementation of the unsigned configitems. It was later removed in (presumably) a merge error.

I’ve also removed a duplicate function, probably due to the same thing.

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/performous/performous/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

#838 
<!-- List here all the issues closed by this pull request. -->

### Motivation
QA
<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
