### PR TITLE
fix highscore not showing and track with no vocal

### DIFF
--- a/game/screen_sing.cc
+++ b/game/screen_sing.cc
@@ -266,7 +266,7 @@ void ScreenSing::activateNextScreen()
 	}
 
 	// Score window visible -> Enter quits to Players Screen
-	if(!config["game/karaoke_mode"].ui() && !m_song->hasDance() &&!m_song->hasDrums() &&!m_song->hasGuitars()) {
+	if(!config["game/karaoke_mode"].ui()) {
 		Screen* s = getGame().getScreen("Players");
 		ScreenPlayers* ss = dynamic_cast<ScreenPlayers*> (s);
 		assert(ss);

--- a/game/song.cc
+++ b/game/song.cc
@@ -181,11 +181,12 @@ VocalTrack& Song::getVocalTrack(std::string vocalTrack) {
 
 VocalTrack& Song::getVocalTrack(unsigned idx) {
 	if (idx >= static_cast<unsigned>(vocalTracks.size())) {
-		throw std::logic_error("Index " + std::to_string(idx) + " out of bounds in Song::getVocalTrack (size: " + std::to_string(vocalTracks.size()) +").");
-	}
-	VocalTracks::iterator it = vocalTracks.begin();
-	std::advance(it, idx);
-	return it->second;
+        return dummyVocal;
+	} else {
+        VocalTracks::iterator it = vocalTracks.begin();
+        std::advance(it, idx);
+        return it->second;
+    }
 }
 
 double Song::getDurationSeconds() {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/performous/performous/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

adding again the screen at the end of a song for the high score with instrument not only with vocal

### Motivation

i usually use with with instrument and almost never for sing, so it was frustrating not having any highscore

### Additional Notes

i only tested it with few songs with and without vocal and it seems to be working
i had to edit the getVocalTrack function otherwise it will crash on track without vocal

updated to new master, #803 
