### PR TITLE
Try a specific revision for the MSVC build

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -46,6 +46,7 @@ jobs:
           triplet: x64-windows-release
           extra-args: --clean-after-build
           cache-key: win64-vcpkg
+          revision: 4715616818c2ac225a13dd05e31c3bbbf904ec65
 
       - name: Run cmake to configure the project and build it
         env:


### PR DESCRIPTION
### What does this PR do?
Locks the `vcpkg` version to `master` for now at least. There was an issue with `libiconv` where the deps disappeared from the download mirror: https://github.com/performous/performous/actions/runs/4002705248/jobs/6870182159

Unfortunately, that issue popped up and was cleaned up last week, which was one week after the latest release. This will likely be resolved in the near-ish future when a new `vcpkg` release is made.

### Closes Issue(s)
No linked issue, but our master branch is currently broken since some of the deps `404` when trying to build on the master branch.

### Motivation

I noticed that the master builds were failing after https://github.com/performous/performous/pull/846 was merged.