### PR TITLE
Fedora 34 is retired, 37 is new

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -97,11 +97,11 @@ jobs:
           - os: debian
             version: 11
           - os: fedora
-            version: 34
-          - os: fedora
             version: 35
           - os: fedora
             version: 36
+          - os: fedora
+            version: 37
     steps:
       - name: Container name
         run: |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Latest builds
 - [Linux - Ubuntu 22.04](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-ubuntu_22.04.deb.zip)
 - [Linux - Debian 10](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-debian_10.deb.zip)
 - [Linux - Debian 11](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-debian_11.deb.zip)
-- [Linux - Fedora 34](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-fedora_34.rpm.zip)
 - [Linux - Fedora 35](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-fedora_35.rpm.zip)
 - [Linux - Fedora 36](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-fedora_36.rpm.zip)
+- [Linux - Fedora 37](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-fedora_37.rpm.zip)
 - [Linux - AppImage](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest.AppImage.zip)


### PR DESCRIPTION
### What does this PR do?

Retires Fedora 34, which has been out of support for a while now and adds Fedora 37 which is the latest and greatest.