### PR TITLE
Sort options by file time and by most sung

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,5 +1,3 @@
-## DELETE ME
-
 name: Build Linux Packages
 
 on:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,3 +1,5 @@
+## DELETE ME
+
 name: Build Linux Packages
 
 on:

--- a/data/config/schema.xml
+++ b/data/config/schema.xml
@@ -106,6 +106,7 @@ to save the current settings to XML.
 	<entry name="game/datetime_format" type="option_list" value="0">
 		<stringvalue>%X %d.%m.%Y</stringvalue>
 		<stringvalue>%Y-%m-%d %X</stringvalue>
+		<stringvalue>%c</stringvalue>
 		<short>Date time format</short>
 		<long>Define how date time should be displayed.</long>
 	</entry>

--- a/data/config/schema.xml
+++ b/data/config/schema.xml
@@ -103,6 +103,12 @@ to save the current settings to XML.
 		<short>Language</short>
 		<long>Language to show Performous in</long>
 	</entry>
+	<entry name="game/datetime_format" type="string" value="0">
+		<stringvalue>%X %d.%m.%Y</stringvalue>
+		<stringvalue>%Y-%m-%d %X</stringvalue>
+		<short>Date time format</short>
+		<long>Define how date time should be displayed.</long>
+	</entry>
 	<entry name="game/webserver_access" type="uint" value="0">
 		<limits>
 			<enum>Disabled</enum>
@@ -194,7 +200,7 @@ to save the current settings to XML.
 	</entry>
 	<entry name="game/instruments" type="string_list">
 		<!-- Should be SDL_ID:{GUITAR_GUITARHERO|GUITAR_GUITARHERO_XPLORER|GUITAR_ROCKBAND_PS3|GUITAR_ROCKBAND_XB360|DRUMS_GUITARHERO|DRUMS_ROCKBAND_PS3|DRUMS_ROCKBAND_XB360|DRUMS_MIDI|DANCEPAD_GENERIC|DANCEPAD_TIGERGAME|DANCEPAD_2TECH}
-		     example:
+			 example:
 			<stringvalue>0:GUITAR_GUITARHERO</stringvalue>
 		-->
 		<short>Joystick configuration</short>
@@ -205,7 +211,7 @@ to save the current settings to XML.
 		<long>Regex for matching the MIDI devices to use. The default is to use all available devices.</long>
 		<stringvalue></stringvalue>
 	</entry>
-<!-- 
+<!--
 	<entry name="game/fallback_encoding" type="int" value="2">
 		<limits>
 			<enum>CP1250</enum>
@@ -222,7 +228,7 @@ to save the current settings to XML.
 		<long>Pick the text codec used for song files that are not UTF-8.</long>
 	</entry>
  -->
- 
+
 	<entry name="game/sorting_ignore" type="string_list">
 		<stringvalue>The</stringvalue>
 		<stringvalue>A</stringvalue>
@@ -233,7 +239,7 @@ to save the current settings to XML.
 		<short>Word Collation</short>
 		<long>Words that should be ignored when sorting.</long>
 	</entry>
- 
+
 	<!-- Graphic preferences -->
 	<entry name="graphic/window_width" type="int" value="1366" hidden="true">
 		<ui unit=" pixels" />

--- a/data/config/schema.xml
+++ b/data/config/schema.xml
@@ -103,7 +103,7 @@ to save the current settings to XML.
 		<short>Language</short>
 		<long>Language to show Performous in</long>
 	</entry>
-	<entry name="game/datetime_format" type="string" value="0">
+	<entry name="game/datetime_format" type="option_list" value="0">
 		<stringvalue>%X %d.%m.%Y</stringvalue>
 		<stringvalue>%Y-%m-%d %X</stringvalue>
 		<short>Date time format</short>

--- a/data/config/schema.xml
+++ b/data/config/schema.xml
@@ -103,7 +103,7 @@ to save the current settings to XML.
 		<short>Language</short>
 		<long>Language to show Performous in</long>
 	</entry>
-	<entry name="game/datetime_format" type="option_list" value="0">
+	<entry name="game/datetime_format" type="option_list" value="%c">
 		<stringvalue>%H:%M %d.%m.%Y</stringvalue>
 		<stringvalue>%H:%M %m/%d/%Y </stringvalue>
 		<stringvalue>%Y-%m-%d %H:%M</stringvalue>

--- a/data/config/schema.xml
+++ b/data/config/schema.xml
@@ -104,8 +104,9 @@ to save the current settings to XML.
 		<long>Language to show Performous in</long>
 	</entry>
 	<entry name="game/datetime_format" type="option_list" value="0">
-		<stringvalue>%X %d.%m.%Y</stringvalue>
-		<stringvalue>%Y-%m-%d %X</stringvalue>
+		<stringvalue>%H:%M %d.%m.%Y</stringvalue>
+		<stringvalue>%H:%M %m/%d/%Y </stringvalue>
+		<stringvalue>%Y-%m-%d %H:%M</stringvalue>
 		<stringvalue>%c</stringvalue>
 		<short>Date time format</short>
 		<long>Define how date time should be displayed.</long>

--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14.5)
 
-file(GLOB SOURCE_FILES "*.cc" "graphic/*.cc")
-file(GLOB HEADER_FILES "*.hh" "graphic/*.hh" "libda/*.hpp")
+file(GLOB SOURCE_FILES "*.cc" "graphic/*.cc" "songorder/*.cc")
+file(GLOB HEADER_FILES "*.hh" "graphic/*.hh" "songorder/*.hh" "libda/*.hpp")
 
 # Fs is compiled/linked separately to ease switch boost/c++17
 list(REMOVE_ITEM SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/fs.cc)

--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -1,7 +1,18 @@
 cmake_minimum_required(VERSION 3.14.5)
 
-file(GLOB SOURCE_FILES "*.cc" "graphic/*.cc" "songorder/*.cc")
-file(GLOB HEADER_FILES "*.hh" "graphic/*.hh" "songorder/*.hh" "libda/*.hpp")
+file(GLOB SOURCE_FILES
+	"*.cc"
+	"graphic/*.cc"
+	"songorder/*.cc"
+	"utils/*.cc"
+)
+file(GLOB HEADER_FILES
+	"*.hh"
+	"graphic/*.hh"
+	"songorder/*.hh"
+	"utils/*.hh"
+	"libda/*.hpp"
+)
 
 # Fs is compiled/linked separately to ease switch boost/c++17
 list(REMOVE_ITEM SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/fs.cc)

--- a/game/configitem.cc
+++ b/game/configitem.cc
@@ -63,6 +63,10 @@ ConfigItem& ConfigItem::incdec(int dir) {
 	return *this;
 }
 
+bool ConfigItem::isDefault(bool factory) const {
+	return isDefaultImpl(factory ? m_factoryDefaultValue : m_defaultValue);
+}
+
 bool ConfigItem::isDefaultImpl(ConfigItem::Value const& defaultValue) const {
 	if (m_type == "bool") return std::get<bool>(m_value) == std::get<bool>(defaultValue);
 	if (m_type == "int") return std::get<int>(m_value) == std::get<int>(defaultValue);
@@ -70,7 +74,9 @@ bool ConfigItem::isDefaultImpl(ConfigItem::Value const& defaultValue) const {
 	if (m_type == "float") return std::get<float>(m_value) == std::get<float>(defaultValue);
 	if (m_type == "string") return std::get<std::string>(m_value) == std::get<std::string>(defaultValue);
 	if (m_type == "string_list") return std::get<StringList>(m_value) == std::get<StringList>(defaultValue);
-	if (m_type == "option_list") return std::get<OptionList>(m_value) == std::get<OptionList>(defaultValue);
+	if (m_type == "option_list") {
+		return false;
+	}
 	throw std::logic_error("ConfigItem::is_default doesn't know type '" + m_type + "'");
 }
 

--- a/game/configitem.cc
+++ b/game/configitem.cc
@@ -112,6 +112,13 @@ std::string& ConfigItem::s() {
 	verifyType("string");
 	return std::get<std::string>(m_value);
 }
+std::string ConfigItem::s(std::string const& defaultValue) const {
+	verifyType("string");
+
+	auto const result = std::get<std::string>(m_value);
+
+	return result.empty() ? defaultValue : result;
+}
 ConfigItem::StringList& ConfigItem::sl() {
 	verifyType("string_list");
 	return std::get<StringList>(m_value);

--- a/game/configitem.hh
+++ b/game/configitem.hh
@@ -26,7 +26,7 @@ class ConfigItem {
 	ConfigItem& operator++() { return incdec(1); } ///< increments config value
 	ConfigItem& operator--() { return incdec(-1); } ///< decrements config value
 	/// Is the current value the same as the default value (factory setting or system setting)
-	bool isDefault(bool factory = false) const { return isDefaultImpl(factory ? m_factoryDefaultValue : m_defaultValue); }
+	bool isDefault(bool factory = false) const;
 	std::string getType() const { return m_type; } ///< get the field type
 	void setType(std::string const& type) { m_type = type; }
 	int& i(); ///< Access integer item

--- a/game/configitem.hh
+++ b/game/configitem.hh
@@ -36,6 +36,7 @@ class ConfigItem {
 	bool& b(); ///< Access boolean item
 	float& f(); ///< Access floating-point item
 	std::string& s(); ///< Access string item
+	std::string s(std::string const& defaultValue) const; ///< Access string item
 	StringList& sl(); ///< Access stringlist item
 	OptionList& ol(); ///< Access optionlist item
 	std::string& so(); ///< Access currently selected string option

--- a/game/configuration.cc
+++ b/game/configuration.cc
@@ -221,14 +221,17 @@ namespace {
 void writeConfig(Game& game, bool system) {
 	xmlpp::Document doc;
 	auto nodeRoot = doc.create_root_node("performous");
-	bool dirty = false;
+	auto dirty = false;
 	for (auto& elem : config) {
 		ConfigItem& item = elem.second;
-		std::string name = elem.first;
-		if (item.isDefault(system) && name != "audio/backend" && name != "graphic/stereo3d") continue; // No need to save settings with default values
+		auto const name = elem.first;
+		auto const type = item.getType();
+
+		if (item.isDefault(system) && name != "audio/backend" && name != "graphic/stereo3d")
+			continue; // No need to save settings with default values
+
 		dirty = true;
 		xmlpp::Element* entryNode = xmlpp::add_child_element(nodeRoot, "entry");
-		auto type = item.getType();
 
 		entryNode->set_attribute("type", type);
 		entryNode->set_attribute("name", name);

--- a/game/configuration.cc
+++ b/game/configuration.cc
@@ -227,8 +227,9 @@ void writeConfig(Game& game, bool system) {
 		auto const name = elem.first;
 		auto const type = item.getType();
 
-		if (item.isDefault(system) && name != "audio/backend" && name != "graphic/stereo3d")
+		if (item.isDefault(system) && name != "audio/backend" && name != "graphic/stereo3d") {
 			continue; // No need to save settings with default values
+		}
 
 		dirty = true;
 		xmlpp::Element* entryNode = xmlpp::add_child_element(nodeRoot, "entry");
@@ -274,8 +275,9 @@ void writeConfig(Game& game, bool system) {
 		else if (type == "float") entryNode->set_attribute("value", std::to_string(item.f()));
 		else if (type == "string") xmlpp::add_child_element(entryNode, "stringvalue")->add_child_text(item.s());
 		else if (type == "string_list") {
-			for (auto const& str : item.sl())
+			for (auto const& str : item.sl()) {
 				xmlpp::add_child_element(entryNode, "stringvalue")->add_child_text(str);
+			}
 		}
 		else if (type == "option_list") {
 			//TODO: Write selected also (as attribute?)

--- a/game/configuration.cc
+++ b/game/configuration.cc
@@ -284,9 +284,10 @@ void writeConfig(Game& game, bool system) {
 			auto const selectedValue = item.so();
 			xmlpp::add_child_element(entryNode, "stringvalue")->add_child_text(selectedValue);
 
-			for (auto const& str : item.ol())
+			for (auto const& str : item.ol()) {
 				if(str != selectedValue)
 					xmlpp::add_child_element(entryNode, "stringvalue")->add_child_text(str);
+			}
 		}
 	}
 	fs::path const& conf = system ? systemConfFile : userConfFile;

--- a/game/configuration.hh
+++ b/game/configuration.hh
@@ -13,7 +13,6 @@
 
 
 using Config = ConfigItemMap;
-using Config = std::map<std::string, ConfigItem>;
 extern Config config; ///< A global variable that contains all config items
 
 /** Read config schema and configuration from XML files **/

--- a/game/database.cc
+++ b/game/database.cc
@@ -95,8 +95,9 @@ bool Database::reachedHiscore(std::shared_ptr<Song> s) const {
 std::vector<HiscoreItem> Database::queryPerSongHiscore(std::shared_ptr<Song> s, std::string const& track) const {
 	auto const maybe_songid = m_songs.lookup(s);
 
-	if (!maybe_songid)
+	if (!maybe_songid) {
 		return {}; // song not yet in database.
+	}
 
 	auto const songid = maybe_songid.value();
 

--- a/game/database.cc
+++ b/game/database.cc
@@ -153,3 +153,15 @@ unsigned Database::getHiscore(SongPtr const& s) const {
 	}
 }
 
+std::vector<HiscoreItem> Database::getHiscores(SongPtr const& s) const {
+	try {
+		auto const songid = m_songs.getSongId(s);
+
+		return m_hiscores.getHiscores(songid);
+	} catch (const std::exception& e) {
+		std::clog << "database/error: Invalid song ID for song: " + s->artist + " - " + s->title << std::endl;
+		std::clog << "database/error: message: " << e.what() << std::endl;
+		throw;
+	}
+}
+

--- a/game/database.hh
+++ b/game/database.hh
@@ -70,6 +70,7 @@ public: // methods for database management
 
 	/**A facade for Players::addPlayer.*/
 	void addPlayer(std::string const& name, std::string const& picture = "", std::optional<PlayerId> id = std::nullopt);
+	Players const& getPlayers() const;
 	/**A facade for SongItems::addSong.*/
 	void addSong(std::shared_ptr<Song> s);
 	/**A facade for Hiscore::addHiscore.
@@ -84,9 +85,7 @@ public: // methods for database queries
 	 */
 	bool reachedHiscore(std::shared_ptr<Song> s) const;
 
-	void queryOverallHiscore(std::ostream & os, std::string const& track = std::string()) const;
-	void queryPerSongHiscore(std::ostream & os, std::shared_ptr<Song> s, std::string const& track = std::string()) const;
-	void queryPerPlayerHiscore(std::ostream & os, std::string const& track = std::string()) const;
+	std::vector<HiscoreItem> queryPerSongHiscore(std::shared_ptr<Song> s, std::string const& track = {}) const;
 
 	bool hasHiscore(Song const& s) const;
 	unsigned getHiscore(Song const& s) const;

--- a/game/database.hh
+++ b/game/database.hh
@@ -91,6 +91,7 @@ public: // methods for database queries
 	bool hasHiscore(Song const& s) const;
 	unsigned getHiscore(Song const& s) const;
 	unsigned getHiscore(SongPtr const& s) const;
+	std::vector<HiscoreItem> getHiscores(SongPtr const& s) const;
 	bool noPlayers() const;
 
 private:

--- a/game/hiscore.cc
+++ b/game/hiscore.cc
@@ -9,24 +9,32 @@
 #include <stdexcept>
 
 bool Hiscore::reachedHiscore(unsigned score, SongId songid, unsigned short level, std::string const& track) const {
-	if (score > 10000) throw std::logic_error("Invalid score value");
-	if (score < 2000) return false; // come on, did you even try to sing?
+	if (score > 10000)
+		throw std::logic_error("Invalid score value");
+	if (score < 2000)
+		return false; // come on, did you even try to sing?
 
 	unsigned position = 0;
 	for (auto const& elem: m_hiscore) {
 		if (elem.songid != songid) continue;
 		if (elem.track != track) continue;
 		if (elem.level != level) continue;
-		if (score > elem.score) return true; // seems like you are in top 3!
-		if (++position == 3) return false; // not in top 3 -> leave
+		if (score > elem.score) return true;
+		if (++position == 16) return false;
 	}
 	return true; // nothing found for that song -> true
 }
 
 void Hiscore::addHiscore(unsigned score, const PlayerId& playerid, SongId songid, unsigned short level, std::string const& track) {
-	if (track.empty()) throw std::runtime_error("No track given");
-	if (!reachedHiscore(score, songid, level, track)) return;
-	m_hiscore.insert(HiscoreItem(score, playerid, songid, level, track));
+	addHiscore({score, playerid, songid, level, track});
+}
+
+void Hiscore::addHiscore(HiscoreItem&& item) {
+	if (item.track.empty())
+		throw std::runtime_error("No track given");
+	if (!reachedHiscore(item.score, item.songid, item.level, item.track))
+		return;
+	m_hiscore.insert(std::move(item));
 }
 
 Hiscore::HiscoreVector Hiscore::queryHiscore(std::optional<PlayerId> playerid, std::optional<SongId> songid, std::string const& track, std::optional<unsigned> max) const {
@@ -49,23 +57,34 @@ bool Hiscore::hasHiscore(const SongId& songid) const {
 }
 
 unsigned Hiscore::getHiscore(SongId songid) const {
-	for (auto const& score: m_hiscore) 
-		if (songid == score.songid && currentLevel() == score.level) 
+	for (auto const& score: m_hiscore)
+		if (songid == score.songid && currentLevel() == score.level)
 			return score.score;
 	return 0;
+}
+
+std::vector<HiscoreItem> Hiscore::getHiscores(SongId songid) const {
+	auto scores = std::vector<HiscoreItem>{};
+
+	for (auto const& score: m_hiscore)
+		if (songid == score.songid && currentLevel() == score.level)
+			scores.emplace_back(score);
+
+	return scores;
 }
 
 void Hiscore::load(xmlpp::NodeSet const& nodes) {
 	for (auto const& n: nodes) {
 		xmlpp::Element& element = dynamic_cast<xmlpp::Element&>(*n);
 		xmlpp::Attribute* a_playerid = element.get_attribute("playerid");
-		if (!a_playerid) throw std::runtime_error("Attribute playerid not found");
+		if (!a_playerid)
+			throw std::runtime_error("Attribute playerid not found");
 		xmlpp::Attribute* a_songid = element.get_attribute("songid");
-		if (!a_songid) throw std::runtime_error("Attribute songid not found");
+		if (!a_songid)
+			throw std::runtime_error("Attribute songid not found");
 		xmlpp::Attribute* a_track = element.get_attribute("track");
 		xmlpp::Attribute* a_level = element.get_attribute("level");
-
-
+		xmlpp::Attribute* a_time = element.get_attribute("unixtime");
 
 		PlayerId playerid = stou(a_playerid->get_value());
 		SongId songid = stou(a_songid->get_value());
@@ -74,10 +93,15 @@ void Hiscore::load(xmlpp::NodeSet const& nodes) {
 			level = static_cast<unsigned short>(stou(a_level->get_value()));
 
 		auto tn = xmlpp::get_first_child_text(element);
-		if (!tn) throw std::runtime_error("Score not found");
+		if (!tn)
+			throw std::runtime_error("Score not found");
 		unsigned score = stou(tn->get_content());
+		auto unixtime = std::chrono::seconds{};
 
-		addHiscore(score, playerid, songid, level, a_track ? a_track->get_value() : "vocals");
+		if(a_time)
+			unixtime = std::chrono::seconds(stou(a_time->get_value()));
+
+		addHiscore({score, playerid, songid, level, a_track ? a_track->get_value() : "vocals", unixtime});
 	}
 }
 
@@ -88,6 +112,7 @@ void Hiscore::save(xmlpp::Element *hiscores) {
 		hiscore->set_attribute("songid", std::to_string(h.songid));
 		hiscore->set_attribute("track", h.track);
 		hiscore->set_attribute("level", std::to_string(h.level));
+		hiscore->set_attribute("unixtime", std::to_string(h.unixtime.count()));
 		hiscore->add_child_text(std::to_string(h.score));
 	}
 }

--- a/game/hiscore.cc
+++ b/game/hiscore.cc
@@ -75,11 +75,8 @@ unsigned Hiscore::getHiscore(SongId songid) const {
 std::vector<HiscoreItem> Hiscore::getHiscores(SongId songid) const {
 	auto scores = std::vector<HiscoreItem>{};
 
-	for (auto const& score: m_hiscore) {
-		if (songid == score.songid && currentLevel() == score.level) {
-			scores.emplace_back(score);
-		}
-	}
+	std::copy_if(m_hiscore.begin(), m_hiscore.end(), std::back_inserter(scores),
+		[&](auto const& score){return songid == score.songid && currentLevel() == score.level;});
 
 	return scores;
 }

--- a/game/hiscore.cc
+++ b/game/hiscore.cc
@@ -8,13 +8,13 @@
 #include <sstream>
 #include <stdexcept>
 
-const unsigned Hiscore::MaximumScorePoints = 2000;
-const unsigned Hiscore::MinimumRecognizedScorePoints = 10000;
+const unsigned Hiscore::MaximumScorePoints = 10000;
+const unsigned Hiscore::MinimumRecognizedScorePoints = 2000;
 const unsigned Hiscore::MaximumStoredScores = 16;
 
 bool Hiscore::reachedHiscore(unsigned score, SongId songid, unsigned short level, std::string const& track) const {
 	if (score > MaximumScorePoints) {
-		throw std::logic_error("Invalid score value");
+		throw std::logic_error("Invalid score value, maximum is " + std::to_string(MaximumScorePoints) + " but got " + std::to_string(score));
 	}
 	if (score < MinimumRecognizedScorePoints) {
 		return false; // come on, did you even try to sing?

--- a/game/hiscore.hh
+++ b/game/hiscore.hh
@@ -38,16 +38,19 @@ public:
 	  HiscoreException will be raised.
 	  */
 	void addHiscore(unsigned score, const PlayerId& playerid, SongId songid, unsigned short level, std::string const& track);
+	void addHiscore(HiscoreItem&&);
 
 	using HiscoreVector = std::vector<HiscoreItem>;
 
 	/// This queries the database for a sorted vector of highscores. The defaults mean to query everything.
 	/// @param max limits the number of elements returned.
 	unsigned getHiscore(unsigned songid) const;
+	std::vector<HiscoreItem> getHiscores(unsigned songid) const;
 	HiscoreVector queryHiscore(std::optional<PlayerId> playerid, std::optional<SongId> songid, std::string const& track, std::optional<unsigned> max = std::nullopt) const;
 	bool hasHiscore(const SongId& songid) const;
 	std::size_t size() const { return m_hiscore.size(); }
-private:
+
+  private:
 	using hiscore_t = std::multiset<HiscoreItem>;
 	hiscore_t m_hiscore;
 	unsigned short currentLevel() const;

--- a/game/hiscore.hh
+++ b/game/hiscore.hh
@@ -11,6 +11,10 @@
 
 class Hiscore {
 public:
+	static const unsigned MaximumScorePoints;
+	static const unsigned MinimumRecognizedScorePoints;
+	static const unsigned MaximumStoredScores;
+
 	void load(xmlpp::NodeSet const& n);
 	void save(xmlpp::Element *players);
 

--- a/game/hiscoreitem.hh
+++ b/game/hiscoreitem.hh
@@ -1,13 +1,20 @@
 #pragma once
 
+#include <chrono>
 #include <string>
 
 /// This struct holds together information for a single item of a highscore.
 struct HiscoreItem {
 	unsigned score, playerid, songid, level;
 	std::string track;
-	HiscoreItem(unsigned score, unsigned playerid, unsigned songid, unsigned level, std::string const& track):
-	  score(score), playerid(playerid), songid(songid), level(level), track(track) {}
+	std::chrono::seconds unixtime;
+
+	HiscoreItem(unsigned score, unsigned playerid, unsigned songid, unsigned level, std::string const& track, std::chrono::seconds unixtime = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()))
+	: score(score), playerid(playerid), songid(songid), level(level), track(track), unixtime(unixtime) {
+	}
+
 	/// Operator for sorting by score. Reverse order, so that highest is first!
-	bool operator<(HiscoreItem const& other) const { return other.score < score; }
+	bool operator<(HiscoreItem const& other) const {
+		return other.score < score;
+	}
 };

--- a/game/screen_songs.cc
+++ b/game/screen_songs.cc
@@ -366,8 +366,9 @@ std::string ScreenSongs::getHighScoreText() const {
 			stream.width(25);
 			stream << std::left << m_database.getPlayers().lookup(hi.playerid).value_or("Unknown player Id " + std::to_string(hi.playerid));
 
-			if(hi.unixtime.count())
+			if(hi.unixtime.count()) {
 				stream << " \t" << format(hi.unixtime, datetimeFormat);
+			}
 
 			stream << "\n";
 		}

--- a/game/screen_songs.cc
+++ b/game/screen_songs.cc
@@ -361,15 +361,13 @@ std::string ScreenSongs::getHighScoreText() const {
 	for (auto const& score: scoresByTrack) {
 		stream << score.first << ":\n";
 		for (auto const& hi: score.second) {
-			auto const time = static_cast<std::time_t>(hi.unixtime.count());
-
 			stream.width(10);
 			stream << std::right << hi.score<< " \t";
 			stream.width(25);
 			stream << std::left << m_database.getPlayers().lookup(hi.playerid).value_or("Unknown player Id " + std::to_string(hi.playerid));
 
 			if(time)
-				stream << " \t" << std::put_time(std::localtime(&time), datetimeFormat.c_str());
+				stream << " \t" << format(hi.unixtime, datetimeFormat);
 
 			stream << "\n";
 		}

--- a/game/screen_songs.cc
+++ b/game/screen_songs.cc
@@ -348,7 +348,7 @@ void ScreenSongs::draw() {
 
 std::string ScreenSongs::getHighScoreText() const {
 	auto const scores = m_database.queryPerSongHiscore(m_songs.currentPtr());
-	auto const datetimeFormat = config["game/datetime_format"].s("%X %d-%m-%Y");
+	auto const datetimeFormat = config["game/datetime_format"].so();
 	auto const maxLines = 8;
 
 	// Reorder hiscores by track / score

--- a/game/screen_songs.cc
+++ b/game/screen_songs.cc
@@ -366,7 +366,7 @@ std::string ScreenSongs::getHighScoreText() const {
 			stream.width(25);
 			stream << std::left << m_database.getPlayers().lookup(hi.playerid).value_or("Unknown player Id " + std::to_string(hi.playerid));
 
-			if(time)
+			if(hi.unixtime.count())
 				stream << " \t" << format(hi.unixtime, datetimeFormat);
 
 			stream << "\n";

--- a/game/screen_songs.cc
+++ b/game/screen_songs.cc
@@ -356,25 +356,33 @@ std::string ScreenSongs::getHighScoreText() const {
 	for (auto const& hi: scores)
 		scoresByTrack[hi.track].insert(hi);
 
+	auto const scoreFormatter = [](auto& stream, auto const& score){
+		stream << std::setw(10) << std::right << score << " \t";
+	};
+	auto const playerFormatter = [this](auto& stream, auto const& playerId) {
+		const auto player = m_database.getPlayers().lookup(playerId);
+
+		stream << std::setw(25) << std::left << player.value_or("Unknown player Id " + std::to_string(playerId));
+	};
+	auto const timeFormatter = [datetimeFormat](auto& stream, auto const& unixtime){
+		if(unixtime.count()) {
+			stream << " \t" << format(unixtime, datetimeFormat);
+		}
+	};
 	auto stream = std::stringstream();
 	auto n = 0;
-	for (auto const& score: scoresByTrack) {
-		stream << score.first << ":\n";
-		for (auto const& hi: score.second) {
-			stream.width(10);
-			stream << std::right << hi.score<< " \t";
-			stream.width(25);
-			stream << std::left << m_database.getPlayers().lookup(hi.playerid).value_or("Unknown player Id " + std::to_string(hi.playerid));
-
-			if(hi.unixtime.count()) {
-				stream << " \t" << format(hi.unixtime, datetimeFormat);
-			}
-
+	for (auto const& [track, scores]: scoresByTrack) {
+		stream << track << ":\n";
+		for (auto const& score: scores) {
+			scoreFormatter(stream, score.score);
+			playerFormatter(stream, score.playerid);
+			timeFormatter(stream, score.unixtime);
 			stream << "\n";
 		}
 		stream << "\n";
-		if(++n == maxLines)
+		if(++n == maxLines) {
 			break;
+		}
 	}
 
 	return stream.str();

--- a/game/screen_songs.cc
+++ b/game/screen_songs.cc
@@ -361,7 +361,7 @@ std::string ScreenSongs::getHighScoreText() const {
 	for (auto const& score: scoresByTrack) {
 		stream << score.first << ":\n";
 		for (auto const& hi: score.second) {
-			auto const time = hi.unixtime.count();
+			auto const time = static_cast<std::time_t>(hi.unixtime.count());
 
 			stream.width(10);
 			stream << std::right << hi.score<< " \t";

--- a/game/screen_songs.hh
+++ b/game/screen_songs.hh
@@ -50,6 +50,7 @@ private:
 	void sing(); ///< Enter singing screen with current playlist.
 	void createPlaylistMenu();
 	Texture* loadTextureFromMap(fs::path path);
+	std::string getHighScoreText() const;
 
 	Audio& m_audio;
 	Songs& m_songs;

--- a/game/song.hh
+++ b/game/song.hh
@@ -139,6 +139,7 @@ private:
 };
 
 using SongPtr = std::shared_ptr<Song>;
+using SongCollection = std::vector<SongPtr>;
 
 /// Print a SongParserException in a format suitable for the logging system.
 std::ostream& operator<<(std::ostream& os, SongParserException const& e);

--- a/game/songorder.hh
+++ b/game/songorder.hh
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "song.hh"
+
+#include <memory>
+#include <string>
+
+class Database;
+
+struct SongOrder {
+	virtual ~SongOrder() = default;
+
+	virtual std::string getDescription() const = 0;
+	virtual void prepare(SongCollection const&, Database const&) {}
+
+	virtual bool operator()(Song const& a, Song const& b) const = 0;
+};
+
+using SongOrderPtr = std::shared_ptr<SongOrder>;

--- a/game/songorder/artist_song_order.cc
+++ b/game/songorder/artist_song_order.cc
@@ -1,0 +1,10 @@
+#include "artist_song_order.hh"
+
+std::string ArtistSongOrder::getDescription() const {
+	return _("sorted by artist");
+}
+
+bool ArtistSongOrder::operator()(Song const& a, Song const& b) const {
+	return a.collateByArtist < b.collateByArtist;
+}
+

--- a/game/songorder/artist_song_order.cc
+++ b/game/songorder/artist_song_order.cc
@@ -1,7 +1,14 @@
 #include "artist_song_order.hh"
 
+#include "configuration.hh"
+#include "unicode.hh"
+
 std::string ArtistSongOrder::getDescription() const {
 	return _("sorted by artist");
+}
+
+void ArtistSongOrder::prepare(SongCollection const&, Database const&) {
+	UnicodeUtil::m_sortCollator->setStrength(config["game/case-sorting"].b() ? icu::Collator::TERTIARY : icu::Collator::SECONDARY);
 }
 
 bool ArtistSongOrder::operator()(Song const& a, Song const& b) const {

--- a/game/songorder/artist_song_order.hh
+++ b/game/songorder/artist_song_order.hh
@@ -4,5 +4,8 @@
 
 struct ArtistSongOrder : public SongOrder {
 	std::string getDescription() const override;
+
+	void prepare(SongCollection const&, Database const&) override;
+
 	bool operator()(Song const& a, Song const& b) const override;
 };

--- a/game/songorder/artist_song_order.hh
+++ b/game/songorder/artist_song_order.hh
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "songorder.hh"
+
+struct ArtistSongOrder : public SongOrder {
+	std::string getDescription() const override;
+	bool operator()(Song const& a, Song const& b) const override;
+};

--- a/game/songorder/edition_song_order.cc
+++ b/game/songorder/edition_song_order.cc
@@ -1,0 +1,11 @@
+#include "edition_song_order.hh"
+
+std::string EditionSongOrder::getDescription() const {
+	return _("sorted by edition");
+}
+
+bool EditionSongOrder::operator()(Song const& a, Song const& b) const {
+	return a.edition < b.edition;
+}
+
+

--- a/game/songorder/edition_song_order.cc
+++ b/game/songorder/edition_song_order.cc
@@ -1,7 +1,14 @@
 #include "edition_song_order.hh"
 
+#include "configuration.hh"
+#include "unicode.hh"
+
 std::string EditionSongOrder::getDescription() const {
 	return _("sorted by edition");
+}
+
+void EditionSongOrder::prepare(SongCollection const&, Database const&) {
+	UnicodeUtil::m_sortCollator->setStrength(config["game/case-sorting"].b() ? icu::Collator::TERTIARY : icu::Collator::SECONDARY);
 }
 
 bool EditionSongOrder::operator()(Song const& a, Song const& b) const {

--- a/game/songorder/edition_song_order.hh
+++ b/game/songorder/edition_song_order.hh
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "songorder.hh"
+
+struct EditionSongOrder : public SongOrder {
+	std::string getDescription() const override;
+	bool operator()(Song const& a, Song const& b) const override;
+};
+

--- a/game/songorder/edition_song_order.hh
+++ b/game/songorder/edition_song_order.hh
@@ -4,6 +4,9 @@
 
 struct EditionSongOrder : public SongOrder {
 	std::string getDescription() const override;
+
+	void prepare(SongCollection const&, Database const&) override;
+
 	bool operator()(Song const& a, Song const& b) const override;
 };
 

--- a/game/songorder/file_time_song_order.cc
+++ b/game/songorder/file_time_song_order.cc
@@ -13,7 +13,6 @@ namespace {
 	}
 }
 
-
 std::string FileTimeSongOrder::getDescription() const {
 	return _("sort by file time");
 }

--- a/game/songorder/file_time_song_order.cc
+++ b/game/songorder/file_time_song_order.cc
@@ -1,0 +1,36 @@
+#include "file_time_song_order.hh"
+
+#include <filesystem>
+
+namespace {
+	std::chrono::seconds getFileWriteTime(Song const& song) {
+		auto const time = std::filesystem::last_write_time(song.path);
+		auto const seconds = std::chrono::duration_cast<std::chrono::seconds>(time.time_since_epoch());
+
+		std::cout << song.path << ": " << seconds.count() << std::endl;
+
+		return seconds;
+	}
+}
+
+
+std::string FileTimeSongOrder::getDescription() const {
+	return _("sort by file time");
+}
+
+void FileTimeSongOrder::prepare(SongCollection const& songs, Database const&) {
+	auto begin = songs.begin();
+	auto end = songs.end();
+
+	std::for_each(begin, end, [&](SongPtr const& song) {
+		m_dateMap[song.get()] = getFileWriteTime(*song);
+	});
+}
+
+bool FileTimeSongOrder::operator()(const Song& a, const Song& b) const {
+	auto const dateA = m_dateMap.find(&a)->second;
+	auto const dateB = m_dateMap.find(&b)->second;
+
+	return dateA > dateB;
+}
+

--- a/game/songorder/file_time_song_order.hh
+++ b/game/songorder/file_time_song_order.hh
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "songorder.hh"
+
+#include <chrono>
+
+struct FileTimeSongOrder : public SongOrder {
+	std::string getDescription() const override;
+
+	void prepare(SongCollection const& , Database const&) override;
+
+	bool operator()(Song const& a, Song const& b) const override;
+
+  private:
+	std::map<Song const*, std::chrono::seconds> m_dateMap;
+};
+

--- a/game/songorder/genre_song_order.cc
+++ b/game/songorder/genre_song_order.cc
@@ -1,0 +1,10 @@
+#include "genre_song_order.hh"
+
+std::string GenreSongOrder::getDescription() const {
+	return _("sorted by genre");
+}
+
+bool GenreSongOrder::operator()(Song const& a, Song const& b) const {
+	return a.genre < b.genre;
+}
+

--- a/game/songorder/genre_song_order.cc
+++ b/game/songorder/genre_song_order.cc
@@ -1,7 +1,14 @@
 #include "genre_song_order.hh"
 
+#include "configuration.hh"
+#include "unicode.hh"
+
 std::string GenreSongOrder::getDescription() const {
 	return _("sorted by genre");
+}
+
+void GenreSongOrder::prepare(SongCollection const&, Database const&) {
+	UnicodeUtil::m_sortCollator->setStrength(config["game/case-sorting"].b() ? icu::Collator::TERTIARY : icu::Collator::SECONDARY);
 }
 
 bool GenreSongOrder::operator()(Song const& a, Song const& b) const {

--- a/game/songorder/genre_song_order.hh
+++ b/game/songorder/genre_song_order.hh
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "songorder.hh"
+
+struct GenreSongOrder : public SongOrder {
+	std::string getDescription() const override;
+	bool operator()(Song const& a, Song const& b) const override;
+};
+

--- a/game/songorder/genre_song_order.hh
+++ b/game/songorder/genre_song_order.hh
@@ -4,6 +4,9 @@
 
 struct GenreSongOrder : public SongOrder {
 	std::string getDescription() const override;
+
+	void prepare(SongCollection const&, Database const&) override;
+
 	bool operator()(Song const& a, Song const& b) const override;
 };
 

--- a/game/songorder/language_song_order.cc
+++ b/game/songorder/language_song_order.cc
@@ -1,7 +1,14 @@
 #include "language_song_order.hh"
 
+#include "configuration.hh"
+#include "unicode.hh"
+
 std::string LanguageSongOrder::getDescription() const {
 	return _("sorted by language");
+}
+
+void LanguageSongOrder::prepare(SongCollection const&, Database const&) {
+	UnicodeUtil::m_sortCollator->setStrength(config["game/case-sorting"].b() ? icu::Collator::TERTIARY : icu::Collator::SECONDARY);
 }
 
 bool LanguageSongOrder::operator()(Song const& a, Song const& b) const {

--- a/game/songorder/language_song_order.cc
+++ b/game/songorder/language_song_order.cc
@@ -1,0 +1,10 @@
+#include "language_song_order.hh"
+
+std::string LanguageSongOrder::getDescription() const {
+	return _("sorted by language");
+}
+
+bool LanguageSongOrder::operator()(Song const& a, Song const& b) const {
+	return a.language < b.language;
+}
+

--- a/game/songorder/language_song_order.hh
+++ b/game/songorder/language_song_order.hh
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "songorder.hh"
+
+struct LanguageSongOrder : public SongOrder {
+	std::string getDescription() const override;
+	bool operator()(Song const& a, Song const& b) const override;
+};
+

--- a/game/songorder/language_song_order.hh
+++ b/game/songorder/language_song_order.hh
@@ -4,6 +4,9 @@
 
 struct LanguageSongOrder : public SongOrder {
 	std::string getDescription() const override;
+
+	void prepare(SongCollection const&, Database const&) override;
+
 	bool operator()(Song const& a, Song const& b) const override;
 };
 

--- a/game/songorder/most_sung_song_order.cc
+++ b/game/songorder/most_sung_song_order.cc
@@ -1,0 +1,31 @@
+#include "most_sung_song_order.hh"
+
+#include "database.hh"
+
+std::string MostSungSongOrder::getDescription() const {
+	return _("sort by most sung");
+}
+
+void MostSungSongOrder::prepare(SongCollection const& songs, Database const& database) {
+	auto begin = songs.begin();
+	auto end = songs.end();
+
+	std::for_each(begin, end, [&](SongPtr const& song) {
+		try {
+			m_rateMap[song.get()] = database.getHiscores(song).size();
+		}
+		catch(std::exception const&) {
+			m_rateMap[song.get()] = 0;
+		}
+	});
+}
+
+bool MostSungSongOrder::operator()(const Song& a, const Song& b) const {
+	auto const rateA = m_rateMap.find(&a)->second;
+	auto const rateB = m_rateMap.find(&b)->second;
+
+	return rateA > rateB;
+}
+
+
+

--- a/game/songorder/most_sung_song_order.hh
+++ b/game/songorder/most_sung_song_order.hh
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "songorder.hh"
+
+struct MostSungSongOrder : public SongOrder {
+	std::string getDescription() const override;
+
+	void prepare(SongCollection const& songs, Database const& database) override;
+
+	bool operator()(Song const& a, Song const& b) const override;
+
+  private:
+	std::map<Song const*, unsigned> m_rateMap;
+};
+

--- a/game/songorder/most_sung_song_order.hh
+++ b/game/songorder/most_sung_song_order.hh
@@ -10,6 +10,6 @@ struct MostSungSongOrder : public SongOrder {
 	bool operator()(Song const& a, Song const& b) const override;
 
   private:
-	std::map<Song const*, unsigned> m_rateMap;
+	std::map<Song const*, size_t> m_rateMap;
 };
 

--- a/game/songorder/name_song_order.cc
+++ b/game/songorder/name_song_order.cc
@@ -1,0 +1,9 @@
+#include "name_song_order.hh"
+
+std::string NameSongOrder::getDescription() const {
+	return _("sorted by song");
+}
+
+bool NameSongOrder::operator()(Song const& a, Song const& b) const {
+	return a.collateByTitle < b.collateByTitle;
+}

--- a/game/songorder/name_song_order.cc
+++ b/game/songorder/name_song_order.cc
@@ -1,7 +1,14 @@
 #include "name_song_order.hh"
 
+#include "configuration.hh"
+#include "unicode.hh"
+
 std::string NameSongOrder::getDescription() const {
 	return _("sorted by song");
+}
+
+void NameSongOrder::prepare(SongCollection const&, Database const&) {
+	UnicodeUtil::m_sortCollator->setStrength(config["game/case-sorting"].b() ? icu::Collator::TERTIARY : icu::Collator::SECONDARY);
 }
 
 bool NameSongOrder::operator()(Song const& a, Song const& b) const {

--- a/game/songorder/name_song_order.hh
+++ b/game/songorder/name_song_order.hh
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "songorder.hh"
+
+struct NameSongOrder : public SongOrder {
+	std::string getDescription() const override;
+	bool operator()(Song const& a, Song const& b) const override;
+};
+

--- a/game/songorder/name_song_order.hh
+++ b/game/songorder/name_song_order.hh
@@ -4,6 +4,9 @@
 
 struct NameSongOrder : public SongOrder {
 	std::string getDescription() const override;
+
+	void prepare(SongCollection const&, Database const&) override;
+
 	bool operator()(Song const& a, Song const& b) const override;
 };
 

--- a/game/songorder/path_song_order.cc
+++ b/game/songorder/path_song_order.cc
@@ -1,0 +1,10 @@
+#include "path_song_order.hh"
+
+std::string PathSongOrder::getDescription() const {
+	return _("sorted by path");
+}
+
+bool PathSongOrder::operator()(Song const& a, Song const& b) const {
+	return a.path < b.path;
+}
+

--- a/game/songorder/path_song_order.hh
+++ b/game/songorder/path_song_order.hh
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "songorder.hh"
+
+struct PathSongOrder : public SongOrder {
+	std::string getDescription() const override;
+	bool operator()(Song const& a, Song const& b) const override;
+};
+

--- a/game/songorder/random_song_order.cc
+++ b/game/songorder/random_song_order.cc
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "random_song_order.hh"
+
+std::string RandomSongOrder::getDescription() const {
+	return _("random order");
+}
+
+bool RandomSongOrder::operator()(Song const& a, Song const& b) const {
+	return a.randomIdx < b.randomIdx;
+}
+

--- a/game/songorder/random_song_order.cc
+++ b/game/songorder/random_song_order.cc
@@ -1,5 +1,3 @@
-#pragma once
-
 #include "random_song_order.hh"
 
 std::string RandomSongOrder::getDescription() const {

--- a/game/songorder/random_song_order.hh
+++ b/game/songorder/random_song_order.hh
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "songorder.hh"
+
+struct RandomSongOrder : public SongOrder {
+	std::string getDescription() const override;
+	bool operator()(Song const& a, Song const& b) const override;
+};
+

--- a/game/songorder/score_song_order.cc
+++ b/game/songorder/score_song_order.cc
@@ -1,0 +1,29 @@
+#include "score_song_order.hh"
+
+#include "database.hh"
+
+std::string ScoreSongOrder::getDescription() const {
+	return _("sorted by score");
+}
+
+void ScoreSongOrder::prepare(SongCollection const& songs, Database const& database) {
+	auto begin = songs.begin();
+	auto end = songs.end();
+
+	std::for_each(begin, end, [&](SongPtr const& song) {
+		try {
+			m_scoreMap[song.get()] = database.getHiscore(song);
+		}
+		catch(std::exception const&) {
+			m_scoreMap[song.get()] = 0;
+		}
+	});
+}
+
+bool ScoreSongOrder::operator()(Song const& a, Song const& b) const {
+	auto const scoreA = m_scoreMap.find(&a)->second;
+	auto const scoreB = m_scoreMap.find(&b)->second;
+
+	return scoreA > scoreB;
+}
+

--- a/game/songorder/score_song_order.hh
+++ b/game/songorder/score_song_order.hh
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "songorder.hh"
+
+struct ScoreSongOrder : public SongOrder {
+	std::string getDescription() const override;
+
+	void prepare(SongCollection const& songs, Database const& database) override;
+
+	bool operator()(Song const& a, Song const& b) const override ;
+
+  private:
+	std::map<Song const*, unsigned> m_scoreMap;
+};
+

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -492,14 +492,17 @@ void Songs::sortChange(Game& game, SortChange diff) {
 
 	switch(diff) {
 		case SortChange::BACK:
-			if(m_order == 0)
+			if(m_order == 0) {
 				m_order = orders - 1;
-			else
+			}
+			else {
 				--m_order;
+			}
 		break;
 		case SortChange::FORWARD:
-			if(++m_order == orders)
+			if(++m_order == orders) {
 				m_order = 0;
+			}
 		break;
 		case SortChange::RESET:
 			m_order = 0;

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -13,8 +13,10 @@
 
 #include "songorder/artist_song_order.hh"
 #include "songorder/edition_song_order.hh"
+#include "songorder/file_time_song_order.hh"
 #include "songorder/genre_song_order.hh"
 #include "songorder/language_song_order.hh"
+#include "songorder/most_sung_song_order.hh"
 #include "songorder/name_song_order.hh"
 #include "songorder/path_song_order.hh"
 #include "songorder/random_song_order.hh"
@@ -41,6 +43,8 @@ namespace {
 		songs.addSongOrder(std::make_shared<PathSongOrder>());
 		songs.addSongOrder(std::make_shared<LanguageSongOrder>());
 		songs.addSongOrder(std::make_shared<ScoreSongOrder>());
+		songs.addSongOrder(std::make_shared<MostSungSongOrder>());
+		songs.addSongOrder(std::make_shared<FileTimeSongOrder>());
 	}
 }
 
@@ -485,10 +489,22 @@ std::string Songs::getSortDescription() const {
 
 void Songs::sortChange(Game& game, SortChange diff) {
 	auto const orders = static_cast<decltype(m_order)>(m_songOrders.size());
-	m_order = static_cast<unsigned short>(m_order + to_underlying(diff)) % orders;
 
-	if (m_order >= orders)
-		m_order += orders;
+	switch(diff) {
+		case SortChange::BACK:
+			if(m_order == 0)
+				m_order = orders - 1;
+			else
+				--m_order;
+		break;
+		case SortChange::FORWARD:
+			if(++m_order == orders)
+				m_order = 0;
+		break;
+		case SortChange::RESET:
+			m_order = 0;
+		break;
+	}
 
 	RestoreSel restore(*this);
 	config["songs/sort-order"].ui() = m_order;

--- a/game/songs.hh
+++ b/game/songs.hh
@@ -2,6 +2,10 @@
 
 #include "animvalue.hh"
 #include "fs.hh"
+#include "screen.hh"
+#include "songorder.hh"
+#include "utils/cycle.hh"
+
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
@@ -11,8 +15,6 @@
 #include <sstream>
 #include <thread>
 #include <vector>
-#include "screen.hh"
-#include "songorder.hh"
 #include <shared_mutex>
 
 class Game;
@@ -87,6 +89,13 @@ class Songs {
 	void LoadCache();
 	void CacheSonglist();
 
+	void dumpSongs_internal() const;
+	void reload_internal();
+	void reload_internal(fs::path const& p);
+	void randomize_internal();
+	void filter_internal();
+	void sort_internal(bool descending = false);
+
 	class RestoreSel;
 	std::string m_songlist;
 	// Careful the m_songs needs to be correctly locked when accessed, and
@@ -98,13 +107,7 @@ class Songs {
 	std::string m_filter;
 	Database & m_database;
 	unsigned short m_type = 0;
-	unsigned short m_order;  // Set by constructor
-	void dumpSongs_internal() const;
-	void reload_internal();
-	void reload_internal(fs::path const& p);
-	void randomize_internal();
-	void filter_internal();
-	void sort_internal(bool descending = false);
+	Cycle<unsigned short> m_order;  // Set by constructor
 	std::atomic<bool> m_dirty{ false };
 	std::atomic<bool> m_loading{ false };
 	std::unique_ptr<std::thread> m_thread;

--- a/game/songs.hh
+++ b/game/songs.hh
@@ -12,6 +12,7 @@
 #include <thread>
 #include <vector>
 #include "screen.hh"
+#include "songorder.hh"
 #include <shared_mutex>
 
 class Game;
@@ -80,14 +81,13 @@ class Songs {
 	std::atomic<bool> doneLoading{ false };
 	std::atomic<bool> displayedAlert{ false };
 	size_t loadedSongs() const { std::shared_lock<std::shared_mutex> l(m_mutex); return m_songs.size(); }
+	void addSongOrder(SongOrderPtr);
 
   private:
 	void LoadCache();
 	void CacheSonglist();
 
 	class RestoreSel;
-	using SongPtr = std::shared_ptr<Song>;
-	using SongCollection = std::vector<SongPtr>;
 	std::string m_songlist;
 	// Careful the m_songs needs to be correctly locked when accessed, and
 	// especially, the reload_internal thread expects to be the only thread
@@ -109,4 +109,5 @@ class Songs {
 	std::atomic<bool> m_loading{ false };
 	std::unique_ptr<std::thread> m_thread;
 	mutable std::shared_mutex m_mutex;
+	std::vector<SongOrderPtr> m_songOrders;
 };

--- a/game/util.cc
+++ b/game/util.cc
@@ -1,5 +1,7 @@
 #include "util.hh"
 
+#include <iomanip>
+#include <sstream>
 #include <stdexcept>
 
 // Only conversion types used in Performous are provided
@@ -20,4 +22,13 @@ unsigned stou(std::string const & str, size_t * idx, int base) {
 			uival = static_cast<unsigned>(result);
 		else throw std::out_of_range(str + " is out of range of unsigned.");
 	return uival;
+}
+
+std::string format(std::chrono::seconds const& unixtime, std::string const& format) {
+	auto const time = static_cast<std::time_t>(unixtime.count());
+	auto stream = std::stringstream();
+
+	stream << std::put_time(std::localtime(&time), format.c_str());
+
+	return stream.str();
 }

--- a/game/util.hh
+++ b/game/util.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <cstdint>
 #include <limits>
 #include <string>
@@ -50,6 +51,7 @@ struct UnlockGuard {
 };
 
 std::uint32_t stou(std::string const & str, size_t * idx = nullptr, int base = 10);
+std::string format(std::chrono::seconds const& unixtime, std::string const& format);
 
 /** Templated conversion from strongly typed enums to the underlying type. **/
 template <typename E>

--- a/game/utils/cycle.cc
+++ b/game/utils/cycle.cc
@@ -1,0 +1,1 @@
+#include "cycle.hh"

--- a/game/utils/cycle.hh
+++ b/game/utils/cycle.hh
@@ -1,0 +1,97 @@
+#pragma once
+
+template<class Type>
+class Cycle {
+  public:
+	Cycle(Type value = 0, Type max = 1, Type min = 0);
+
+	Type get() const;
+	Cycle& set(Type value);
+	Cycle& forward();
+	Cycle& backward();
+
+	operator Type() const;
+
+	Type getMin() const;
+	Type getMax() const;
+
+private:
+	Type m_min;
+	Type m_max;
+	Type m_value;
+};
+
+
+#include <stdexcept>
+
+template<class Type>
+Cycle<Type>::Cycle(Type value, Type max, Type min)
+: m_min(min), m_max(max), m_value(value) {
+	if(min >= max) {
+		throw std::logic_error("min must less than max");
+	}
+	if(value > max) {
+		throw std::logic_error("value must less or equal than max");
+	}
+	if(value < min) {
+		throw std::logic_error("value must greater or equal than min");
+	}
+}
+
+template<class Type>
+Type Cycle<Type>::get() const {
+	return m_value;
+}
+
+template<class Type>
+Cycle<Type>& Cycle<Type>::set(Type value) {
+	if(value > m_max) {
+		throw std::logic_error("value must less or equal than max");
+	}
+	if(value < m_min) {
+		throw std::logic_error("value must greater or equal than min");
+	}
+
+	m_value = value;
+
+	return *this;
+}
+
+template<class Type>
+Cycle<Type>& Cycle<Type>::forward() {
+	if(m_value == m_max) {
+		m_value = m_min;
+	}
+	else {
+		++m_value;
+	}
+
+	return *this;
+}
+
+template<class Type>
+Cycle<Type>& Cycle<Type>::backward() {
+	if(m_value == m_min) {
+		m_value = m_max;
+	}
+	else {
+		--m_value;
+	}
+
+	return *this;
+}
+
+template<class Type>
+Cycle<Type>::operator Type() const {
+	return m_value;
+}
+
+template<class Type>
+Type Cycle<Type>::getMin() const {
+	return m_min;
+}
+
+template<class Type>
+Type Cycle<Type>::getMax() const {
+	return m_max;
+}

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCE_FILES
 	"analyzertest.cc"
 	"colortest.cc"
 	"configitemtest.cc"
+	"cycletest.cc"
 	"fixednotegraphscalertest.cc"
 	"notegraphscalerfactorytest.cc"
 	"printer.cc"

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -20,6 +20,7 @@ set(GAME_SOURCES
 	"../game/notes.cc"
 	"../game/notegraphscalerfactory.cc"
 	"../game/tone.cc"
+	"../game/util.cc"
 )
 
 set(SOURCES ${SOURCE_FILES} ${HEADER_FILES} ${GAME_SOURCES})

--- a/testing/cycletest.cc
+++ b/testing/cycletest.cc
@@ -1,0 +1,64 @@
+#include "game/utils/cycle.hh"
+
+#include "common.hh"
+
+TEST(UnitTest_Cycle, default_ctor_short) {
+	EXPECT_EQ(0, Cycle<short>().get());
+	EXPECT_EQ(0, Cycle<short>().getMin());
+	EXPECT_EQ(1, Cycle<short>().getMax());
+}
+
+TEST(UnitTest_Cycle, default_ctor_unsigned_short) {
+	EXPECT_EQ(0, Cycle<unsigned short>().get());
+	EXPECT_EQ(0, Cycle<unsigned short>().getMin());
+	EXPECT_EQ(1, Cycle<unsigned short>().getMax());
+}
+
+TEST(UnitTest_Cycle, ctor_unsigned_short) {
+	EXPECT_EQ(2, Cycle<unsigned short>(2, 4, 1).get());
+	EXPECT_EQ(1, Cycle<unsigned short>(2, 4, 1).getMin());
+	EXPECT_EQ(4, Cycle<unsigned short>(2, 4, 1).getMax());
+}
+
+TEST(UnitTest_Cycle, ctor_short_bounds) {
+	EXPECT_THROW(Cycle<short>(2, 1, -1), std::logic_error);
+	EXPECT_NO_THROW(Cycle<short>(1, 1, -1));
+	EXPECT_NO_THROW(Cycle<short>(-1, 1, -1));
+	EXPECT_THROW(Cycle<short>(-2, 1, -1), std::logic_error);
+}
+
+TEST(UnitTest_Cycle, convert_operator) {
+	EXPECT_EQ(0, Cycle<unsigned short>(0, 2, 0));
+	EXPECT_EQ(1, Cycle<unsigned short>(1, 2, 0));
+	EXPECT_EQ(2, Cycle<unsigned short>(2, 2, 0));
+}
+
+TEST(UnitTest_Cycle, get) {
+	EXPECT_EQ(0, Cycle<unsigned short>(0, 2, 0).get());
+	EXPECT_EQ(1, Cycle<unsigned short>(1, 2, 0).get());
+	EXPECT_EQ(2, Cycle<unsigned short>(2, 2, 0).get());
+}
+
+TEST(UnitTest_Cycle, set) {
+	EXPECT_EQ(2, Cycle<unsigned short>(0, 2, 0).set(2));
+	EXPECT_EQ(0, Cycle<unsigned short>(1, 2, 0).set(0));
+	EXPECT_EQ(1, Cycle<unsigned short>(2, 2, 0).set(1));
+}
+
+TEST(UnitTest_Cycle, set_bounds) {
+	EXPECT_THROW(Cycle<unsigned short>(1, 2, 1).set(0), std::logic_error);
+	EXPECT_THROW(Cycle<unsigned short>(1, 2, 1).set(3), std::logic_error);
+}
+
+TEST(UnitTest_Cycle, forward) {
+	EXPECT_EQ(1, Cycle<unsigned short>(0, 2, 0).forward());
+	EXPECT_EQ(2, Cycle<unsigned short>(0, 2, 0).forward().forward());
+	EXPECT_EQ(0, Cycle<unsigned short>(0, 2, 0).forward().forward().forward());
+}
+
+TEST(UnitTest_Cycle, backward) {
+	EXPECT_EQ(2, Cycle<unsigned short>(0, 2, 0).backward());
+	EXPECT_EQ(1, Cycle<unsigned short>(0, 2, 0).backward().backward());
+	EXPECT_EQ(0, Cycle<unsigned short>(0, 2, 0).backward().backward().backward());
+}
+

--- a/testing/utiltest.cc
+++ b/testing/utiltest.cc
@@ -34,7 +34,11 @@ namespace {
 	TEST(UnitTest_Utils, format) {
 		auto const time = std::chrono::seconds(7260);
 
-		EXPECT_EQ("01/01/70 02:01", format(time, "%D %R"));
-		EXPECT_EQ("02:01:00 1970-01-01", format(time, "%T %F"));
+		// next two tests are not working when compiled with mingw. see https://sourceforge.net/p/mingw-w64/bugs/793/
+		//EXPECT_EQ("01/01/70 02:01", format(time, "%D %R"));
+		//EXPECT_EQ("02:01:00 1970-01-01", format(time, "%T %F"));
+		EXPECT_EQ("01/01/70 02:01", format(time, "%m/%d/%y %H:%M"));
+		EXPECT_EQ("02:01:00 1970-01-01", format(time, "%H:%M:%S %Y-%m-%d"));
+		EXPECT_EQ("02:01:00 1970-01-01", format(time, "%X %Y-%m-%d"));
 	}
 }

--- a/testing/utiltest.cc
+++ b/testing/utiltest.cc
@@ -3,31 +3,38 @@
 #include "game/util.hh"
 
 namespace {
-    TEST(UnitTest_Utils, clamp) {
-        EXPECT_EQ(0.0, clamp(-1.0, 0.0, 1.0));
-        EXPECT_EQ(0.5, clamp(0.5, 0.0, 1.0));
-        EXPECT_EQ(1.0, clamp(2.0, 0.0, 1.0));
-    }
+	TEST(UnitTest_Utils, clamp) {
+		EXPECT_EQ(0.0, clamp(-1.0, 0.0, 1.0));
+		EXPECT_EQ(0.5, clamp(0.5, 0.0, 1.0));
+		EXPECT_EQ(1.0, clamp(2.0, 0.0, 1.0));
+	}
 
-    TEST(UnitTest_Utils, smoothstep_1) {
-        EXPECT_EQ(0.0, smoothstep(0));
-        EXPECT_EQ(0.5, smoothstep(0.5));
-        EXPECT_EQ(1.0, smoothstep(1.0));
-    }
+	TEST(UnitTest_Utils, smoothstep_1) {
+		EXPECT_EQ(0.0, smoothstep(0));
+		EXPECT_EQ(0.5, smoothstep(0.5));
+		EXPECT_EQ(1.0, smoothstep(1.0));
+	}
 
-    TEST(UnitTest_Utils, smoothstep_1_clamping) {
-        EXPECT_EQ(0.0, smoothstep(-1.0));
-        EXPECT_EQ(1.0, smoothstep(2.0));
-    }
+	TEST(UnitTest_Utils, smoothstep_1_clamping) {
+		EXPECT_EQ(0.0, smoothstep(-1.0));
+		EXPECT_EQ(1.0, smoothstep(2.0));
+	}
 
-    TEST(UnitTest_Utils, smoothstep_3) {
-        EXPECT_EQ(0.0, smoothstep(-1., 1., -1.0));
-        EXPECT_EQ(0.5, smoothstep(-1., 1., 0.0));
-        EXPECT_EQ(1.0, smoothstep(-1., 1., 1.0));
-    }
+	TEST(UnitTest_Utils, smoothstep_3) {
+		EXPECT_EQ(0.0, smoothstep(-1., 1., -1.0));
+		EXPECT_EQ(0.5, smoothstep(-1., 1., 0.0));
+		EXPECT_EQ(1.0, smoothstep(-1., 1., 1.0));
+	}
 
-    TEST(UnitTest_Utils, smoothstep_3_clamping) {
-        EXPECT_EQ(0.0, smoothstep(-1., 1., -2.0));
-        EXPECT_EQ(1.0, smoothstep(-1., 1., 2.0));
-    }
-} 
+	TEST(UnitTest_Utils, smoothstep_3_clamping) {
+		EXPECT_EQ(0.0, smoothstep(-1., 1., -2.0));
+		EXPECT_EQ(1.0, smoothstep(-1., 1., 2.0));
+	}
+
+	TEST(UnitTest_Utils, format) {
+		auto const time = std::chrono::seconds(7260);
+
+		EXPECT_EQ("01/01/70 02:01", format(time, "%D %R"));
+		EXPECT_EQ("02:01:00 1970-01-01", format(time, "%T %F"));
+	}
+}


### PR DESCRIPTION
### What does this PR do?

The pr adds new song sort options:
- by file time
- by most sung
 
Additionally it stores date and time of performs and display them.

### Closes Issue(s)

#787 and #822 

### Motivation

I am missing those options during game play :-) Additionally storing dates will be used for player achievements later. 

### More

- [x] Needs testing
- [x] Needs cut off for displaying scores after singing cause now 16 scores are stored per song. Before only 3 scores were stored and displayed. (Draw 8 scores/lines)
- [x] Draw score dates.
- [x] Fix bug in saving option_list

### Additional Notes

None