### PR TITLE
Split video_driver into one file per class and fix crash 

### DIFF
--- a/game/3dobject.cc
+++ b/game/3dobject.cc
@@ -5,6 +5,7 @@
 #include <sstream>
 
 #include "texture.hh"
+#include "graphic/transform.hh"
 
 // TODO: test & fix faces that doesn't have texcoords in the file
 // TODO: group handling for loader

--- a/game/dancegraph.cc
+++ b/game/dancegraph.cc
@@ -1,6 +1,7 @@
 #include "dancegraph.hh"
 #include "song.hh"
 #include "i18n.hh"
+#include "graphic/view_trans.hh"
 
 #include <stdexcept>
 #include <algorithm>

--- a/game/fbo.hh
+++ b/game/fbo.hh
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "texture.hh"
-#include "video_driver.hh"
+#include "graphic/window.hh"
 
 /// Frame Buffer Object class
 class FBO {

--- a/game/game.cc
+++ b/game/game.cc
@@ -5,6 +5,7 @@
 #include "configuration.hh"
 #include "glutil.hh"
 #include "util.hh"
+#include "graphic/color_trans.hh"
 
 #include <thread>
 #include <stdexcept>

--- a/game/game.hh
+++ b/game/game.hh
@@ -5,7 +5,7 @@
 
 #include "animvalue.hh"
 #include "opengl_text.hh"
-#include "video_driver.hh"
+#include "graphic/window.hh"
 #include "dialog.hh"
 #include "playlist.hh"
 #include "fbo.hh"

--- a/game/glshader.cc
+++ b/game/glshader.cc
@@ -1,7 +1,8 @@
 #include "glshader.hh"
 
 #include "glutil.hh"
-#include "video_driver.hh"
+#include "graphic/video_driver.hh"
+#include "graphic/window.hh"
 #include <algorithm>
 #include <ios>
 #include <fstream>

--- a/game/glutil.cc
+++ b/game/glutil.cc
@@ -1,5 +1,6 @@
 #include "glutil.hh"
-#include "video_driver.hh"
+#include "graphic/video_driver.hh"
+#include "graphic/window.hh"
 
 namespace glutil {
 

--- a/game/graphic/color_trans.cc
+++ b/game/graphic/color_trans.cc
@@ -1,0 +1,23 @@
+#include "color_trans.hh"
+
+#include "color.hh"
+#include "window.hh"
+#include "video_driver.hh"
+
+ColorTrans::ColorTrans(Window& window, glmath::mat4 const& mat)
+: m_window(window), m_old(Global::color) {
+	Global::color = Global::color * mat;
+	window.updateColor();
+}
+
+ColorTrans::ColorTrans(Window& window, Color const& c)
+ : m_window(window), m_old(Global::color) {
+	using namespace glmath;
+	Global::color = Global::color * diagonal(c.linear());
+	window.updateColor();
+}
+
+ColorTrans::~ColorTrans() {
+	Global::color = m_old;
+	m_window.updateColor();
+}

--- a/game/graphic/color_trans.hh
+++ b/game/graphic/color_trans.hh
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "glmath.hh"
+
+struct Color;
+class Window;
+
+struct ColorTrans {
+	ColorTrans(Window&, Color const& c);
+	ColorTrans(Window&, glmath::mat4 const& mat);
+	~ColorTrans();
+
+  private:
+	Window& m_window;
+	glmath::mat4 m_old;
+};

--- a/game/graphic/lyrics_color_trans.cc
+++ b/game/graphic/lyrics_color_trans.cc
@@ -1,0 +1,14 @@
+#include "lyrics_color_trans.hh"
+
+#include "window.hh"
+
+LyricColorTrans::LyricColorTrans(Window& window, Color const& fill, Color const& stroke, Color const& newFill, Color const& newStroke)
+ : m_window(window) {
+	oldFill = fill.linear();
+	oldStroke = stroke.linear();
+	window.updateLyricHighlight(fill.linear(), stroke.linear(), newFill.linear(), newStroke.linear());
+}
+
+LyricColorTrans::~LyricColorTrans() {
+	m_window.updateLyricHighlight(oldFill, oldStroke);
+}

--- a/game/graphic/lyrics_color_trans.hh
+++ b/game/graphic/lyrics_color_trans.hh
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "glmath.hh"
+
+struct Color;
+class Window;
+
+struct LyricColorTrans {
+	LyricColorTrans(Window&, Color const& fill, Color const& stroke, Color const& newFill, Color const& newStroke);
+	~LyricColorTrans();
+
+  private:
+	Window& m_window;
+	glmath::vec4 oldFill;
+	glmath::vec4 oldStroke;
+};

--- a/game/graphic/shader_manager.cc
+++ b/game/graphic/shader_manager.cc
@@ -1,0 +1,32 @@
+#include "shader_manager.hh"
+
+ShaderManager::ShaderManager(std::shared_ptr<SDL_Window> sdlWindow)
+: m_sdlWindow(sdlWindow) {
+}
+
+ShaderManager::~ShaderManager() {
+	// Careful, Shaders depends on SDL_Window, thus m_shaders need to be
+	// destroyed before screen (and thus be creater after)
+	resetShaders();
+	releaseSDL();
+}
+
+Shader& ShaderManager::createOrGet(std::string const& name) {
+	auto it = m_shaders.find(name);
+
+	if (it != m_shaders.end()) {
+		return *it->second;
+	}
+
+	auto kv = std::make_pair(name, std::make_unique<Shader>(name));
+
+	return *m_shaders.insert(std::move(kv)).first->second;
+}
+
+void ShaderManager::resetShaders() {
+	m_shaders.clear();
+}
+
+void ShaderManager::releaseSDL() {
+	m_sdlWindow.reset();
+}

--- a/game/graphic/shader_manager.cc
+++ b/game/graphic/shader_manager.cc
@@ -1,16 +1,5 @@
 #include "shader_manager.hh"
 
-ShaderManager::ShaderManager(std::shared_ptr<SDL_Window> sdlWindow)
-: m_sdlWindow(sdlWindow) {
-}
-
-ShaderManager::~ShaderManager() {
-	// Careful, Shaders depends on SDL_Window, thus m_shaders need to be
-	// destroyed before screen (and thus be creater after)
-	resetShaders();
-	releaseSDL();
-}
-
 Shader& ShaderManager::createOrGet(std::string const& name) {
 	auto it = m_shaders.find(name);
 
@@ -25,8 +14,4 @@ Shader& ShaderManager::createOrGet(std::string const& name) {
 
 void ShaderManager::resetShaders() {
 	m_shaders.clear();
-}
-
-void ShaderManager::releaseSDL() {
-	m_sdlWindow.reset();
 }

--- a/game/graphic/shader_manager.hh
+++ b/game/graphic/shader_manager.hh
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "glshader.hh"
+
+#include <map>
+#include <memory>
+#include <string>
+
+struct SDL_Window;
+
+class ShaderManager {
+  public:
+	ShaderManager(std::shared_ptr<SDL_Window>);
+	~ShaderManager();
+
+	/// Construct a new shader or return an existing one by name
+	Shader& createOrGet(std::string const& name);
+	void resetShaders();
+
+  private:
+	void releaseSDL();
+
+  private:
+	using ShaderMap = std::map<std::string, std::unique_ptr<Shader>>;
+	ShaderMap m_shaders; ///< Shader programs by name
+	std::shared_ptr<SDL_Window> m_sdlWindow;
+};

--- a/game/graphic/shader_manager.hh
+++ b/game/graphic/shader_manager.hh
@@ -6,22 +6,15 @@
 #include <memory>
 #include <string>
 
-struct SDL_Window;
+class Window;
 
 class ShaderManager {
   public:
-	ShaderManager(std::shared_ptr<SDL_Window>);
-	~ShaderManager();
-
 	/// Construct a new shader or return an existing one by name
 	Shader& createOrGet(std::string const& name);
 	void resetShaders();
 
   private:
-	void releaseSDL();
-
-  private:
 	using ShaderMap = std::map<std::string, std::unique_ptr<Shader>>;
 	ShaderMap m_shaders; ///< Shader programs by name
-	std::shared_ptr<SDL_Window> m_sdlWindow;
 };

--- a/game/graphic/transform.cc
+++ b/game/graphic/transform.cc
@@ -1,0 +1,15 @@
+#include "transform.hh"
+
+#include "window.hh"
+#include "video_driver.hh"
+
+Transform::Transform(Window& window, glmath::mat4 const& m)
+ : m_window(window), m_old(Global::modelview) {
+	Global::modelview = Global::modelview * m;
+	window.updateTransforms();
+}
+
+Transform::~Transform() {
+	Global::modelview = m_old;
+	m_window.updateTransforms();
+}

--- a/game/graphic/transform.hh
+++ b/game/graphic/transform.hh
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "glmath.hh"
+
+class Window;
+
+/// Apply a transform to current modelview stack
+class Transform {
+  public:
+	Transform(Window&, glmath::mat4 const& m);
+	~Transform();
+
+  private:
+	Window& m_window;
+	glmath::mat4 m_old;
+};

--- a/game/graphic/video_driver.cc
+++ b/game/graphic/video_driver.cc
@@ -28,7 +28,7 @@ float getSeparation() {
 }
 
 glmath::mat4 farTransform() {
-	float z = Constant::far_ - 0.1f;  // Very near the far plane but just a bit closer to avoid accidental clipping
+	float z = Constant::far - 0.1f;  // Very near the far plane but just a bit closer to avoid accidental clipping
 	float s = z / Constant::z0;  // Scale the image so that it looks the same size
 	s *= 1.0f + 2.0f * getSeparation(); // A bit more for stereo3d (avoid black borders)
 	using namespace glmath;

--- a/game/graphic/video_driver.cc
+++ b/game/graphic/video_driver.cc
@@ -1,0 +1,36 @@
+#include "video_driver.hh"
+
+#include "chrono.hh"
+#include "config.hh"
+#include "controllers.hh"
+#include "fs.hh"
+#include "glmath.hh"
+#include "image.hh"
+#include "platform.hh"
+#include "screen.hh"
+#include "game.hh"
+#include "util.hh"
+#include "fs.hh"
+#include <SDL.h>
+#include <SDL_hints.h>
+#include <SDL_rect.h>
+#include <SDL_video.h>
+#include <cstdint>
+
+namespace Global {
+	glmath::mat4 projection = glmath::mat4(1.0f);
+	glmath::mat4 modelview = glmath::mat4(1.0f);
+	glmath::mat4 color = glmath::mat4(1.0f);
+}
+
+float getSeparation() {
+	return config["graphic/stereo3d"].b() ? 0.001f * config["graphic/stereo3dseparation"].f() : 0.0f;
+}
+
+glmath::mat4 farTransform() {
+	float z = Constant::far_ - 0.1f;  // Very near the far plane but just a bit closer to avoid accidental clipping
+	float s = z / Constant::z0;  // Scale the image so that it looks the same size
+	s *= 1.0f + 2.0f * getSeparation(); // A bit more for stereo3d (avoid black borders)
+	using namespace glmath;
+	return translate(vec3(0.0f, 0.0f, -z + Constant::z0)) * scale(s); // Very near the farplane
+}

--- a/game/graphic/video_driver.hh
+++ b/game/graphic/video_driver.hh
@@ -16,8 +16,8 @@ namespace Global {
 namespace Constant {
 	const float targetWidth = 1366.0f; // One of the most common desktop resolutions in use today.
 	// stump: under MSVC, near and far are #defined to nothing for compatibility with ancient code, hence the underscores.
-	const float far_ = 110.0f; // How far away can things be seen
-	const float near_ = 0.1f; // This determines the near clipping distance (must be > 0)
+	const float far = 110.0f; // How far away can things be seen
+	const float near = 0.1f; // This determines the near clipping distance (must be > 0)
 	const float z0 = 1.5f; // This determines FOV: the value is your distance from the monitor (the unit being the width of the Performous window)
 }
 

--- a/game/graphic/video_driver.hh
+++ b/game/graphic/video_driver.hh
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "glmath.hh"
+
+float getSeparation();
+
+/// Performs a GL transform for displaying background image at far distance
+glmath::mat4 farTransform();
+
+namespace Global {
+	extern glmath::mat4 projection;
+	extern glmath::mat4 modelview;
+	extern glmath::mat4 color;
+}
+
+namespace Constant {
+	const float targetWidth = 1366.0f; // One of the most common desktop resolutions in use today.
+	// stump: under MSVC, near and far are #defined to nothing for compatibility with ancient code, hence the underscores.
+	const float far_ = 110.0f; // How far away can things be seen
+	const float near_ = 0.1f; // This determines the near clipping distance (must be > 0)
+	const float z0 = 1.5f; // This determines FOV: the value is your distance from the monitor (the unit being the width of the Performous window)
+}
+
+

--- a/game/graphic/view_trans.cc
+++ b/game/graphic/view_trans.cc
@@ -8,7 +8,7 @@ ViewTrans::ViewTrans(Window& window, float offsetX, float offsetY, float frac)
 	// Setup the projection matrix for 2D translates
 	using namespace glmath;
 	float h = virtH();
-	const float f = Constant::near_ / Constant::z0;  // z0 to nearplane conversion factor
+	const float f = Constant::near / Constant::z0;  // z0 to nearplane conversion factor
 	// Corners of the screen at z0
 	float x1 = -0.5f, x2 = 0.5f;
 	float y1 = 0.5f * h, y2 = -0.5f * h;
@@ -17,7 +17,7 @@ ViewTrans::ViewTrans(Window& window, float offsetX, float offsetY, float frac)
 	x1 -= persX; x2 -= persX;
 	y1 -= persY; y2 -= persY;
 	// Perspective projection + the rest of the offset in eye (world) space
-	Global::projection = glm::frustum(f * x1, f * x2, f * y1, f * y2, Constant::near_, Constant::far_)
+	Global::projection = glm::frustum(f * x1, f * x2, f * y1, f * y2, Constant::near, Constant::far)
 	  * translate(vec3(offsetX - persX, offsetY - persY, -Constant::z0));
 	window.updateTransforms();
 }

--- a/game/graphic/view_trans.cc
+++ b/game/graphic/view_trans.cc
@@ -1,0 +1,34 @@
+#include "view_trans.hh"
+
+#include "video_driver.hh"
+#include "window.hh"
+
+ViewTrans::ViewTrans(Window& window, float offsetX, float offsetY, float frac)
+: m_window(window), m_old(Global::projection) {
+	// Setup the projection matrix for 2D translates
+	using namespace glmath;
+	float h = virtH();
+	const float f = Constant::near_ / Constant::z0;  // z0 to nearplane conversion factor
+	// Corners of the screen at z0
+	float x1 = -0.5f, x2 = 0.5f;
+	float y1 = 0.5f * h, y2 = -0.5f * h;
+	// Move the perspective point by frac of offset (i.e. move the image)
+	float persX = frac * offsetX, persY = frac * offsetY;
+	x1 -= persX; x2 -= persX;
+	y1 -= persY; y2 -= persY;
+	// Perspective projection + the rest of the offset in eye (world) space
+	Global::projection = glm::frustum(f * x1, f * x2, f * y1, f * y2, Constant::near_, Constant::far_)
+	  * translate(vec3(offsetX - persX, offsetY - persY, -Constant::z0));
+	window.updateTransforms();
+}
+
+ViewTrans::ViewTrans(Window& window, glmath::mat4 const& m)
+: m_window(window), m_old(Global::projection) {
+	Global::projection = Global::projection * m;
+	m_window.updateTransforms();
+}
+
+ViewTrans::~ViewTrans() {
+	Global::projection = m_old;
+	m_window.updateTransforms();
+}

--- a/game/graphic/view_trans.hh
+++ b/game/graphic/view_trans.hh
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "glmath.hh"
+
+class Window;
+
+class ViewTrans {
+  public:
+	/// Apply a translation on top of current viewport translation
+	ViewTrans(Window&, glmath::mat4 const& m);
+	/// Apply a subviewport with different perspective projection
+	ViewTrans(Window&, float offsetX = 0.0f, float offsetY = 0.0f, float frac = 1.0f);
+	~ViewTrans();
+
+ private:
+	Window& m_window;
+	glmath::mat4 m_old;
+};

--- a/game/graphic/window.cc
+++ b/game/graphic/window.cc
@@ -64,8 +64,12 @@ Window::Window()
 		GLattrSetter attr_d(SDL_GL_DEPTH_SIZE, 24);
 		GLattrSetter attr_db(SDL_GL_DOUBLEBUFFER, 1);
 		Uint32 flags = SDL_WINDOW_HIDDEN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_OPENGL;
-		if (config["graphic/highdpi"].b()) { flags |= SDL_WINDOW_ALLOW_HIGHDPI; }
-		else { SDL_SetHintWithPriority("SDL_HINT_VIDEO_HIGHDPI_DISABLED", "1", SDL_HINT_OVERRIDE); }
+		if (config["graphic/highdpi"].b()) {
+			flags |= SDL_WINDOW_ALLOW_HIGHDPI;
+		}
+		else {
+			SDL_SetHintWithPriority("SDL_HINT_VIDEO_HIGHDPI_DISABLED", "1", SDL_HINT_OVERRIDE);
+		}
 		int width = config["graphic/window_width"].i();
 		int height = config["graphic/window_height"].i();
 		int windowPosX = config["graphic/window_pos_x"].i();
@@ -102,31 +106,37 @@ Window::Window()
 		}
 		SDL_Point winOrigin {windowPosX, windowPosY};
 		if (SDL_PointInRect(&winOrigin, &totalSize) == SDL_FALSE) {
-			if (winOrigin.x < totalSize.x) { winOrigin.x = totalSize.x; }
-			else if (winOrigin.x > totalSize.w) { winOrigin.x = (totalSize.w - width); }
-			if (winOrigin.y < totalSize.y) { winOrigin.y = totalSize.y; }
-			else if (winOrigin.y > totalSize.h) { winOrigin.y = (totalSize.h - height); }
+			if (winOrigin.x < totalSize.x) {
+				winOrigin.x = totalSize.x;
+			}
+			else if (winOrigin.x > totalSize.w) {
+				winOrigin.x = (totalSize.w - width);
+			}
+			if (winOrigin.y < totalSize.y) {
+				winOrigin.y = totalSize.y;
+			}
+			else if (winOrigin.y > totalSize.h) {
+				winOrigin.y = (totalSize.h - height);
+			}
 			std::clog << "video/info: Saved window position outside of current display set-up; resetting to " << winOrigin.x << "," << winOrigin.y << std::endl;
 		}
 		SDL_Point winEnd {(winOrigin.x + width), (winOrigin.y + height)};
 		if (SDL_PointInRect(&winEnd, &totalSize) == SDL_FALSE) {
 			if (winEnd.x > totalSize.w) {
-			width = totalSize.w;
-			winOrigin.x = (totalSize.w - width);
+				width = totalSize.w;
+				winOrigin.x = (totalSize.w - width);
 			}
 			if (winEnd.y > totalSize.h) {
-			height = totalSize.h;
-			winOrigin.y = (totalSize.y - height);
+				height = totalSize.h;
+				winOrigin.y = (totalSize.y - height);
 			}
 			std::clog << "video/info: Saved window size outside of current display set-up; resetting to " << width << "x" << height << std::endl;
 		}
 
-		if (winOrigin.x == 0)
-		{
+		if (winOrigin.x == 0) {
 			winOrigin.x = SDL_WINDOWPOS_UNDEFINED;
 		}
-		if (winOrigin.y == 0)
-		{
+		if (winOrigin.y == 0) {
 			winOrigin.y = SDL_WINDOWPOS_UNDEFINED;
 		}
 
@@ -159,15 +169,15 @@ void Window::createShaders() {
 	// but not GL_ARB_viewport_array, so we just check for the extension here.
 	if (config["graphic/stereo3d"].b()) {
 		if (epoxy_has_gl_extension("GL_ARB_viewport_array")) {
-		// Compile geometry shaders when stereo is requested
-		shader("color").compileFile(findFile("shaders/stereo3d.geom"));
-		shader("texture").compileFile(findFile("shaders/stereo3d.geom"));
-		shader("3dobject").compileFile(findFile("shaders/stereo3d.geom"));
-		shader("dancenote").compileFile(findFile("shaders/stereo3d.geom"));
+			// Compile geometry shaders when stereo is requested
+			shader("color").compileFile(findFile("shaders/stereo3d.geom"));
+			shader("texture").compileFile(findFile("shaders/stereo3d.geom"));
+			shader("3dobject").compileFile(findFile("shaders/stereo3d.geom"));
+			shader("dancenote").compileFile(findFile("shaders/stereo3d.geom"));
 		}
 		else {
-		std::clog << "video/warning: Stereo3D was enabled but the 'GL_ARB_viewport_array' extension is unsupported; will now disable Stereo3D." << std::endl;
-		config["graphic/stereo3d"].b() = false;
+			std::clog << "video/warning: Stereo3D was enabled but the 'GL_ARB_viewport_array' extension is unsupported; will now disable Stereo3D." << std::endl;
+			config["graphic/stereo3d"].b() = false;
 		}
 	}
 
@@ -236,11 +246,11 @@ void Window::blank() {
 }
 
 void Window::updateStereo(float sepFactor) {
-		try {
-			m_stereoUniforms.sepFactor = sepFactor;
-			m_stereoUniforms.z0 = (Constant::z0 - 2.0f * Constant::near_);
-			glBufferSubData(GL_UNIFORM_BUFFER, m_stereoUniforms.offset(), m_stereoUniforms.size(), &m_stereoUniforms);
-		} catch(...) {}  // Not fatal if 3d shader is missing
+	try {
+		m_stereoUniforms.sepFactor = sepFactor;
+		m_stereoUniforms.z0 = (Constant::z0 - 2.0f * Constant::near);
+		glBufferSubData(GL_UNIFORM_BUFFER, m_stereoUniforms.offset(), m_stereoUniforms.size(), &m_stereoUniforms);
+	} catch(...) {}  // Not fatal if 3d shader is missing
 }
 
 void Window::updateColor() {
@@ -296,7 +306,11 @@ void Window::render(Game &game, std::function<void (void)> drawFunc) {
 	updateStereo(stereo ? getSeparation() : 0.0f);
 	glerror.check("setup");
 	// Can we do direct to framebuffer rendering (no FBO)?
-	if (!stereo || type == 2) { view(stereo); drawFunc(); return; }
+	if (!stereo || type == 2) {
+		view(stereo);
+		drawFunc();
+		return;
+	}
 	// Render both eyes to FBO (full resolution top/bottom for anaglyph)
 
 	glerror.check("FBO");
@@ -402,14 +416,16 @@ void Window::event(Uint8 const& eventID, Sint32 const& data1, Sint32 const& data
 		case SDL_WINDOWEVENT_MAXIMIZED:
 			if (Platform::currentOS() == Platform::HostOS::OS_MAC) {
 				config["graphic/fullscreen"].b() = true;
-				}
+			}
 			else { m_needResize = true; }
 			break;
 		case SDL_WINDOWEVENT_RESTORED:
 			if (Platform::currentOS() == Platform::HostOS::OS_MAC) {
 				config["graphic/fullscreen"].b() = false;
-				}
-			else { m_needResize = true; }
+			}
+			else {
+				m_needResize = true;
+			}
 			break;
 		case SDL_WINDOWEVENT_SHOWN:
 			[[fallthrough]];
@@ -429,7 +445,9 @@ void Window::setWindowPosition(const Sint32& x, const Sint32& y)
 }
 
 FBO& Window::getFBO() {
-	if (!m_fbo) m_fbo = std::make_unique<FBO>(*this, s_width, (2 * s_height));
+	if (!m_fbo) {
+		m_fbo = std::make_unique<FBO>(*this, s_width, (2 * s_height));
+	}
 	return *m_fbo;
 }
 
@@ -472,7 +490,9 @@ void Window::resize() {
 	if (std::stoi(SDL_GetHint("SDL_HINT_VIDEO_HIGHDPI_DISABLED")) == 1) {
 		SDL_GetWindowSize(screen.get(), &nativeW, &nativeH);
 	}
-	else { SDL_GL_GetDrawableSize(screen.get(), &nativeW, &nativeH); }
+	else {
+		SDL_GL_GetDrawableSize(screen.get(), &nativeW, &nativeH);
+	}
 	s_width = static_cast<float>(nativeW);
 	s_height = static_cast<float>(nativeH);
 	// Enforce aspect ratio limits
@@ -481,7 +501,9 @@ void Window::resize() {
 	std::clog << "video/info: Window size " << w << "x" << h;
 	if (w != nativeW) std::clog << " (HiDPI " << nativeW << "x" << nativeH << ")";
 	std::clog << ", rendering in " << s_width << "x" << s_height << std::endl;
-	if (m_fbo) { m_fbo->resize(s_width, 2 * s_height); }
+	if (m_fbo) {
+		m_fbo->resize(s_width, 2 * s_height);
+	}
 }
 
 void Window::screenshot() {
@@ -491,7 +513,9 @@ void Window::screenshot() {
 	if (std::stoi(SDL_GetHint("SDL_HINT_VIDEO_HIGHDPI_DISABLED")) == 1) {
 		SDL_GetWindowSize(screen.get(), &nativeW, &nativeH);
 	}
-	else { SDL_GL_GetDrawableSize(screen.get(), &nativeW, &nativeH); }
+	else {
+		SDL_GL_GetDrawableSize(screen.get(), &nativeW, &nativeH);
+	}
 	img.width = static_cast<unsigned>(nativeW);
 	img.height = static_cast<unsigned>(nativeH);
 	unsigned stride = (img.width * 3 + 3) & ~3u;  // Rows are aligned to 4 byte boundaries
@@ -511,5 +535,3 @@ void Window::screenshot() {
 	writePNG(filename.string(), img, stride);
 	std::clog << "video/info: Screenshot taken: " << filename << " (" << img.width << "x" << img.height << ")" << std::endl;
 }
-
-

--- a/game/graphic/window.cc
+++ b/game/graphic/window.cc
@@ -297,7 +297,7 @@ void Window::render(Game &game, std::function<void (void)> drawFunc) {
 	auto& window = game.getWindow();
 	ViewTrans trans(*this);  // Default frustum
 	bool stereo = config["graphic/stereo3d"].b();
-	unsigned type = config["graphic/stereo3dtype"].ui();
+	auto const type = static_cast<Stereo3dType>(config["graphic/stereo3dtype"].ui());
 
 	static bool warn3d = false;
 	if (!stereo) warn3d = false;
@@ -311,13 +311,13 @@ void Window::render(Game &game, std::function<void (void)> drawFunc) {
 	}
 
 	// Over/under only available in fullscreen
-	if (stereo && type == 2 && !m_fullscreen) stereo = false;
+	if (stereo && type == Stereo3dType::OverUnder && !m_fullscreen) stereo = false;
 
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	updateStereo(stereo ? getSeparation() : 0.0f);
 	glerror.check("setup");
 	// Can we do direct to framebuffer rendering (no FBO)?
-	if (!stereo || type == 2) {
+	if (!stereo || type == Stereo3dType::OverUnder) {
 		view(stereo);
 		drawFunc();
 		return;
@@ -347,10 +347,10 @@ void Window::render(Game &game, std::function<void (void)> drawFunc) {
 			float col = (1.0f + 2.0f * saturation) / 3.0f;
 			float gry = 0.5f * (1.0f - col);
 			bool out[3] = {};  // Which colors to output
-			if (type == 0 && num == 0) { out[0] = true; }  // Red
-			if (type == 0 && num == 1) { out[1] = out[2] = true; }  // Cyan
-			if (type == 1 && num == 0) { out[1] = true; }  // Green
-			if (type == 1 && num == 1) { out[0] = out[2] = true; }  // Magenta
+			if (type == Stereo3dType::RedCyan && num == 0) { out[0] = true; }  // Red
+			if (type == Stereo3dType::RedCyan && num == 1) { out[1] = out[2] = true; }  // Cyan
+			if (type == Stereo3dType::GreenMagenta && num == 0) { out[1] = true; }  // Green
+			if (type == Stereo3dType::GreenMagenta && num == 1) { out[0] = out[2] = true; }  // Magenta
 			for (int i = 0; i < 3; ++i) {
 				for (int j = 0; j < 3; ++j) {
 					float val = 0.0f;

--- a/game/graphic/window.hh
+++ b/game/graphic/window.hh
@@ -18,7 +18,7 @@ static inline float virtH() { return float(screenH()) / screenW(); }
 
 /// handles the window
 class Window {
-public:
+  public:
 	Window();
 	~Window();
 	void render(Game &game, std::function<void (void)> drawFunc);
@@ -41,6 +41,8 @@ public:
 	GLuint const& VAO() const { return Window::m_vao; }
 	/// Return reference to Vertex Buffer Object.
 	GLuint const& VBO() const { return Window::m_vbo; }
+	FBO& getFBO();
+
 	/// Store value of GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT.
 	static GLint bufferOffsetAlignment;
 
@@ -58,17 +60,19 @@ public:
 	void updateLyricHighlight(glmath::vec4 const& fill, glmath::vec4 const& stroke, glmath::vec4 const& newFill, glmath::vec4 const& newStroke);
 	void updateLyricHighlight(glmath::vec4 const& fill, glmath::vec4 const& stroke);
 	void updateTransforms();
-private:
-	const GLuint vertPos = 0;
-	const GLuint vertTexCoord = 1;
-	const GLuint vertNormal = 2;
-	const GLuint vertColor = 3;
+
+  private:
 	void setWindowPosition(const Sint32& x, const Sint32& y);
 	void setFullscreen();
 	/// Setup everything for drawing a view.
 	/// @param num 0 = no stereo, 1 = left eye, 2 = right eye
 	void view(unsigned num);
 	void updateStereo(float separation);
+
+	const GLuint vertPos = 0;
+	const GLuint vertTexCoord = 1;
+	const GLuint vertNormal = 2;
+	const GLuint vertColor = 3;
 	bool m_fullscreen = false;
 	bool m_needResize = true;
 	static GLuint m_ubo;
@@ -86,6 +90,4 @@ private:
 	// Careful, Shaders depends on SDL_Window, thus m_shaders need to be
 	// destroyed before screen (and thus be creater after)
 	ShaderMap m_shaders; ///< Shader programs by name
-	public:
-	FBO& getFBO();
 };

--- a/game/graphic/window.hh
+++ b/game/graphic/window.hh
@@ -21,6 +21,8 @@ static inline float virtH() { return float(screenH()) / screenW(); }
 
 /// handles the window
 class Window {
+	enum class Stereo3dType {RedCyan, GreenMagenta, OverUnder};
+
   public:
 	Window();
 	~Window();

--- a/game/graphic/window.hh
+++ b/game/graphic/window.hh
@@ -21,7 +21,7 @@ static inline float virtH() { return float(screenH()) / screenW(); }
 
 /// handles the window
 class Window {
-	enum class Stereo3dType {RedCyan, GreenMagenta, OverUnder};
+	enum class Stereo3dType {RedCyan = 0, GreenMagenta = 1, OverUnder = 2};
 
   public:
 	Window();

--- a/game/graphic/window.hh
+++ b/game/graphic/window.hh
@@ -1,69 +1,20 @@
 #pragma once
 
+#include <functional>
+#include <map>
+#include <SDL_events.h>
 #include "glmath.hh"
 #include "glshader.hh"
 #include "glutil.hh"
-#include <map>
-#include <functional>
-#include <SDL_events.h>
-
-float screenW();
-float screenH();
-const float targetWidth = 1366.0f; // One of the most common desktop resolutions in use today.
-static inline float virtH() { return float(screenH()) / screenW(); }
 
 struct SDL_Surface;
 struct SDL_Window;
 class FBO;
-class Window;
-
-struct ColorTrans {
-	ColorTrans(Window&, Color const& c);
-	ColorTrans(Window&, glmath::mat4 const& mat);
-	~ColorTrans();
-
-  private:
-	Window& m_window;
-	glmath::mat4 m_old;
-};
-
-struct LyricColorTrans {
-	LyricColorTrans(Window&, Color const& fill, Color const& stroke, Color const& newFill, Color const& newStroke);
-	~LyricColorTrans();
-
-  private:
-	Window& m_window;
-	glmath::vec4 oldFill;
-	glmath::vec4 oldStroke;
-};
-
-class ViewTrans {
-  public:
-	/// Apply a translation on top of current viewport translation
-	ViewTrans(Window&, glmath::mat4 const& m);
-	/// Apply a subviewport with different perspective projection
-	ViewTrans(Window&, float offsetX = 0.0f, float offsetY = 0.0f, float frac = 1.0f);
-	~ViewTrans();
-
- private:
-	Window& m_window;
-	glmath::mat4 m_old;
-};
-
-/// Apply a transform to current modelview stack
-class Transform {
-  public:
-	Transform(Window&, glmath::mat4 const& m);
-	~Transform();
-
-  private:
-	Window& m_window;
-	glmath::mat4 m_old;
-};
-
-/// Performs a GL transform for displaying background image at far distance
-glmath::mat4 farTransform();
 class Game;
+
+float screenW();
+float screenH();
+static inline float virtH() { return float(screenH()) / screenW(); }
 
 /// handles the window
 class Window {
@@ -138,4 +89,3 @@ private:
 	public:
 	FBO& getFBO();
 };
-

--- a/game/graphic/window.hh
+++ b/game/graphic/window.hh
@@ -1,7 +1,10 @@
 #pragma once
 
+#include "shader_manager.hh"
+
 #include <functional>
 #include <map>
+#include <memory>
 #include <SDL_events.h>
 #include "glmath.hh"
 #include "glshader.hh"
@@ -47,15 +50,10 @@ class Window {
 	static GLint bufferOffsetAlignment;
 
 	/// Construct a new shader or return an existing one by name
-	Shader& shader(std::string const& name) {
-		ShaderMap::iterator it = m_shaders.find(name);
-		if (it != m_shaders.end()) return *it->second;
-		std::pair<std::string, std::unique_ptr<Shader>> kv = std::make_pair(name, std::make_unique<Shader>(name));
-		return *m_shaders.insert(std::move(kv)).first->second;
-	}
+	Shader& shader(std::string const& name);
 	/// Compiles and links all shaders.
 	void createShaders();
-	void resetShaders() { m_shaders.clear(); createShaders(); };
+	void resetShaders();
 	void updateColor();
 	void updateLyricHighlight(glmath::vec4 const& fill, glmath::vec4 const& stroke, glmath::vec4 const& newFill, glmath::vec4 const& newStroke);
 	void updateLyricHighlight(glmath::vec4 const& fill, glmath::vec4 const& stroke);
@@ -84,10 +82,7 @@ class Window {
 	std::unique_ptr<FBO> m_fbo;
 	int m_windowX = 0;
 	int m_windowY = 0;
-	std::unique_ptr<SDL_Window, void (*)(SDL_Window*)> screen;
+	std::shared_ptr<SDL_Window> screen;
 	std::unique_ptr<std::remove_pointer_t<SDL_GLContext> /* SDL_GLContext is a void* */, void (*)(SDL_GLContext)> glContext;
-	using ShaderMap = std::map<std::string, std::unique_ptr<Shader>>;
-	// Careful, Shaders depends on SDL_Window, thus m_shaders need to be
-	// destroyed before screen (and thus be creater after)
-	ShaderMap m_shaders; ///< Shader programs by name
+	std::unique_ptr<ShaderManager> m_shaderManager;
 };

--- a/game/graphic/window.hh
+++ b/game/graphic/window.hh
@@ -24,6 +24,9 @@ class Window {
   public:
 	Window();
 	~Window();
+
+	void shutdown();
+
 	void render(Game &game, std::function<void (void)> drawFunc);
 	/// clears window
 	void blank();
@@ -67,6 +70,11 @@ class Window {
 	void view(unsigned num);
 	void updateStereo(float separation);
 
+	struct SDLSystem {
+		SDLSystem();
+		~SDLSystem();
+	};
+
 	const GLuint vertPos = 0;
 	const GLuint vertTexCoord = 1;
 	const GLuint vertNormal = 2;
@@ -82,7 +90,13 @@ class Window {
 	std::unique_ptr<FBO> m_fbo;
 	int m_windowX = 0;
 	int m_windowY = 0;
-	std::shared_ptr<SDL_Window> screen;
+
+	// Careful, Shaders depends on SDL_Window, thus m_shaders need to be
+	// destroyed before screen (and thus be creater after)
+	// Keep the sequence of following members
+
+	std::unique_ptr<SDLSystem> m_system;
+	std::unique_ptr<SDL_Window, void (*)(SDL_Window*)> screen;
 	std::unique_ptr<std::remove_pointer_t<SDL_GLContext> /* SDL_GLContext is a void* */, void (*)(SDL_GLContext)> glContext;
 	std::unique_ptr<ShaderManager> m_shaderManager;
 };

--- a/game/guitargraph.cc
+++ b/game/guitargraph.cc
@@ -60,11 +60,11 @@ void GuitarGraph::initGuitar() {
 	// Copy all tracks of guitar types (not DRUMS and not KEYBOARD) to m_instrumentTracks
 	for (auto const& elem: m_song.instrumentTracks) {
 		std::string index = elem.first;
-		if (index != TrackName::DRUMS
-			&& index != TrackName::DRUMS_SNARE
-			&& index != TrackName::DRUMS_CYMBALS
-			&& index != TrackName::DRUMS_TOMS
-			&& index != TrackName::KEYBOARD)  {
+		if (index != TrackName::DRUMS &&
+			index != TrackName::DRUMS_SNARE &&
+			index != TrackName::DRUMS_CYMBALS &&
+			index != TrackName::DRUMS_TOMS &&
+			index != TrackName::KEYBOARD)  {
 				m_instrumentTracks[index] = &elem.second;
 			}
 	}
@@ -83,10 +83,10 @@ void GuitarGraph::initDrums() {
 	// Copy all tracks of drum type to m_instrumentTracks
 	for (auto const& elem: m_song.instrumentTracks) {
 		std::string index = elem.first;
-		if (index == TrackName::DRUMS
-			|| index == TrackName::DRUMS_SNARE
-			|| index == TrackName::DRUMS_CYMBALS
-			|| index == TrackName::DRUMS_TOMS ) {
+		if (index == TrackName::DRUMS ||
+			index == TrackName::DRUMS_SNARE ||
+			index == TrackName::DRUMS_CYMBALS ||
+			index == TrackName::DRUMS_TOMS ) {
 				m_instrumentTracks[index] = &elem.second;
 			}
 	}

--- a/game/guitargraph.cc
+++ b/game/guitargraph.cc
@@ -2,6 +2,7 @@
 #include "fs.hh"
 #include "song.hh"
 #include "i18n.hh"
+#include "graphic/view_trans.hh"
 
 #include <cmath>
 #include <cstdlib>
@@ -59,10 +60,10 @@ void GuitarGraph::initGuitar() {
 	// Copy all tracks of guitar types (not DRUMS and not KEYBOARD) to m_instrumentTracks
 	for (auto const& elem: m_song.instrumentTracks) {
 		std::string index = elem.first;
-		if (index != TrackName::DRUMS 
-			&& index != TrackName::DRUMS_SNARE 
-			&& index != TrackName::DRUMS_CYMBALS 
-			&& index != TrackName::DRUMS_TOMS 
+		if (index != TrackName::DRUMS
+			&& index != TrackName::DRUMS_SNARE
+			&& index != TrackName::DRUMS_CYMBALS
+			&& index != TrackName::DRUMS_TOMS
 			&& index != TrackName::KEYBOARD)  {
 				m_instrumentTracks[index] = &elem.second;
 			}
@@ -82,9 +83,9 @@ void GuitarGraph::initDrums() {
 	// Copy all tracks of drum type to m_instrumentTracks
 	for (auto const& elem: m_song.instrumentTracks) {
 		std::string index = elem.first;
-		if (index == TrackName::DRUMS 
-			|| index == TrackName::DRUMS_SNARE 
-			|| index == TrackName::DRUMS_CYMBALS 
+		if (index == TrackName::DRUMS
+			|| index == TrackName::DRUMS_SNARE
+			|| index == TrackName::DRUMS_CYMBALS
 			|| index == TrackName::DRUMS_TOMS ) {
 				m_instrumentTracks[index] = &elem.second;
 			}

--- a/game/instrumentgraph.cc
+++ b/game/instrumentgraph.cc
@@ -2,6 +2,7 @@
 #include "i18n.hh"
 #include "glutil.hh"
 #include "theme.hh"
+#include "graphic/view_trans.hh"
 
 namespace {
 	const double join_delay = 3.0; // Time after join menu before playing when joining mid-game

--- a/game/instrumentgraph.hh
+++ b/game/instrumentgraph.hh
@@ -14,6 +14,8 @@
 #include "screen.hh"
 #include "fs.hh"
 #include "util.hh"
+#include "graphic/color_trans.hh"
+#include "graphic/transform.hh"
 
 #include <cstdint>
 

--- a/game/layout_singer.cc
+++ b/game/layout_singer.cc
@@ -4,6 +4,7 @@
 #include "fs.hh"
 #include "song.hh"
 #include "database.hh"
+#include "graphic/color_trans.hh"
 
 #include <list>
 #include <fmt/format.h>

--- a/game/layout_singer.hh
+++ b/game/layout_singer.hh
@@ -4,6 +4,7 @@
 #include "opengl_text.hh"
 #include "notegraph.hh"
 #include "configuration.hh"
+#include "graphic/color_trans.hh"
 
 #include <deque>
 

--- a/game/main.cc
+++ b/game/main.cc
@@ -12,7 +12,7 @@
 #include "profiler.hh"
 #include "screen.hh"
 #include "songs.hh"
-#include "video_driver.hh"
+#include "graphic/window.hh"
 #include "webcam.hh"
 #include "webserver.hh"
 
@@ -255,7 +255,7 @@ void outputOptionalFeatureStatus();
 
 static void fatalError(const std::string &msg) {
 	auto errMsg = msg + "\nIf you think this is a bug in Performous, please report it at \n"
-	                    "  https://github.com/performous/performous/issues";
+						"  https://github.com/performous/performous/issues";
 	auto title = "FATAL ERROR";
 	SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, title, errMsg.c_str(), nullptr);
 	std::cerr << title << ": " << msg << std::endl;

--- a/game/notegraph.cc
+++ b/game/notegraph.cc
@@ -4,6 +4,8 @@
 #include "database.hh"
 #include "engine.hh"
 #include "player.hh"
+#include "graphic/color_trans.hh"
+#include "graphic/transform.hh"
 
 Dimensions dimensions; // Make a public member variable
 

--- a/game/opengl_text.cc
+++ b/game/opengl_text.cc
@@ -8,6 +8,8 @@
 #include <sstream>
 #include "fs.hh"
 #include "graphic/text_renderer.hh"
+#include "graphic/lyrics_color_trans.hh"
+#include "graphic/video_driver.hh"
 #include "fontconfig/fontconfig.h"
 #include <pango/pangocairo.h>
 
@@ -193,7 +195,7 @@ void SvgTxtTheme::draw(Window& window, std::vector<TZoomText>& _text, bool lyric
 	}
 
 	float texture_ar = text_x / text_y;
-	m_texture_width = std::min(0.96f, text_x / targetWidth); // targetWidth is defined in video_driver.cc, it's the base rendering width, used to project the svg onto a gltexture. currently we're targeting 1366x768 as base resolution.
+	m_texture_width = std::min(0.96f, text_x / Constant::targetWidth); // targetWidth is defined in video_driver.cc, it's the base rendering width, used to project the svg onto a gltexture. currently we're targeting 1366x768 as base resolution.
 	float position_x = dimensions.x1();
 
 	if (m_align == Align::CENTER) position_x -= 0.5f * m_texture_width;

--- a/game/screen_audiodevices.cc
+++ b/game/screen_audiodevices.cc
@@ -7,6 +7,7 @@
 #include "theme.hh"
 #include "i18n.hh"
 #include "game.hh"
+#include "graphic/color_trans.hh"
 
 namespace {
 	static const int unassigned_id = -1;  // mic.dev value for unassigned

--- a/game/screen_intro.cc
+++ b/game/screen_intro.cc
@@ -184,13 +184,13 @@ void ScreenIntro::populateMenu() {
 			for (auto const& item: submenu.items) {
 				ConfigItem& c = config[item];
 				opts.emplace_back(MenuOption(c.getShortDesc(), c.getLongDesc()));
-								opts.back().changer(c);
+				opts.back().changer(c);
 			}
 			configmain.emplace_back(MenuOption(submenu.shortDesc, submenu.longDesc, imgConfig));
-						configmain.back().submenu(std::move(opts));
+			configmain.back().submenu(std::move(opts));
 		} else {
 			configmain.emplace_back(MenuOption(submenu.shortDesc, submenu.longDesc, imgConfig));
-						configmain.back().screen(submenu.name);
+			configmain.back().screen(submenu.name);
 		}
 	}
 	m_menu.add(MenuOption(translate_noop("Configure"), translate_noop("Configure audio and game options."), imgConfig)).submenu(std::move(configmain));

--- a/game/screen_intro.cc
+++ b/game/screen_intro.cc
@@ -9,6 +9,7 @@
 #include "theme.hh"
 #include "menu.hh"
 #include "game.hh"
+#include "graphic/color_trans.hh"
 
 #include <SDL_timer.h>
 
@@ -183,13 +184,13 @@ void ScreenIntro::populateMenu() {
 			for (auto const& item: submenu.items) {
 				ConfigItem& c = config[item];
 				opts.emplace_back(MenuOption(c.getShortDesc(), c.getLongDesc()));
-                                opts.back().changer(c);
+								opts.back().changer(c);
 			}
 			configmain.emplace_back(MenuOption(submenu.shortDesc, submenu.longDesc, imgConfig));
-                        configmain.back().submenu(std::move(opts));
+						configmain.back().submenu(std::move(opts));
 		} else {
 			configmain.emplace_back(MenuOption(submenu.shortDesc, submenu.longDesc, imgConfig));
-                        configmain.back().screen(submenu.name);
+						configmain.back().screen(submenu.name);
 		}
 	}
 	m_menu.add(MenuOption(translate_noop("Configure"), translate_noop("Configure audio and game options."), imgConfig)).submenu(std::move(configmain));

--- a/game/screen_paths.cc
+++ b/game/screen_paths.cc
@@ -7,6 +7,7 @@
 #include "audio.hh"
 #include "i18n.hh"
 #include "game.hh"
+#include "graphic/color_trans.hh"
 
 ScreenPaths::ScreenPaths(Game &game, std::string const& name, Audio& audio, Songs& songs)
 : Screen(game, name), m_audio(audio), m_songs(songs) {

--- a/game/screen_sing.cc
+++ b/game/screen_sing.cc
@@ -19,6 +19,7 @@
 #include "webcam.hh"
 #include "screen_songs.hh"
 #include "notegraphscalerfactory.hh"
+#include "graphic/video_driver.hh"
 
 #include <fmt/format.h>
 #include <iostream>

--- a/game/screen_songs.cc
+++ b/game/screen_songs.cc
@@ -12,6 +12,7 @@
 #include "theme.hh"
 #include "util.hh"
 #include "playlist.hh"
+#include "graphic/video_driver.hh"
 
 #include "aubio/aubio.h"
 #include <iostream>

--- a/game/texture.cc
+++ b/game/texture.cc
@@ -1,7 +1,7 @@
 #include "texture.hh"
 
 #include "configuration.hh"
-#include "video_driver.hh"
+#include "graphic/video_driver.hh"
 #include "screen.hh"
 #include "svg.hh"
 #include "game.hh"

--- a/game/texture.hh
+++ b/game/texture.hh
@@ -2,7 +2,7 @@
 
 #include "glutil.hh"
 #include "image.hh"
-#include "video_driver.hh"
+#include "graphic/window.hh"
 
 #include <cairo.h>
 

--- a/game/video.cc
+++ b/game/video.cc
@@ -2,6 +2,8 @@
 
 #include "ffmpeg.hh"
 #include "util.hh"
+#include "graphic/color_trans.hh"
+
 #include <cmath>
 
 bool Video::tryPop(Bitmap& f, double timestamp) {

--- a/game/webcam.cc
+++ b/game/webcam.cc
@@ -2,6 +2,8 @@
 
 #include "chrono.hh"
 #include "fs.hh"
+#include "graphic/transform.hh"
+
 #include <cstdint>
 #include <iostream>
 #include <stdexcept>


### PR DESCRIPTION
### What does this PR do?

Two things:
1. It contains a refectoring for video_driver.hh/cc. There are multiple classes inside the files which are splitted into one file per class.
2. Fix a crash that appears while destructing `Window` where shaders must be destructed before the gl context is gone. Cause actually that is not obvious and only mentioned in a comment, goal is to force the right destruction sequence by code.

### Closes Issue(s)

No issue opened for the bug/crash.

### Motivation

Fix a bug and avoid inserting the bug accidentally in future-

### More

- [x] Moving classes to own files
- [x] Fix bug by restructuring code
- [x] Code review
- [x] Testing

