### PR TITLE
Move the cron trigger to the correct workflow and set it to run weekly

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -1,10 +1,6 @@
 name: Build AppImage Packages
 
 on:
-  # Run on a schedule to get monthly updates
-  schedule:
-    - cron: "0 0 28 * *"
-
   # Run when called from other workflows
   workflow_call:
     inputs:

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -2,6 +2,10 @@ name: Build and Release Performous
 
 # Controls when the workflow will run
 on:
+  # Run on a schedule to get weekly updates for the Linux containers
+  # and keep the cache fresh for Windows builds. Runs Sundays at midnight.
+  schedule:
+    - cron: "0 0 * * 0"
   # Triggers the workflow on merges to master, release branches,
   # all PRs, and release tags 
   push:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,11 +1,7 @@
 name: Build Linux Packages
 
 on:
-  # Run on a schedule to get monthly updates
-  schedule:
-    - cron: "0 0 28 * *"
-
-  # Run when called from other workflows
+  # Run when called from other workflows only
   workflow_call:
     inputs:
       package_complete_version:
@@ -134,11 +130,6 @@ jobs:
           build-args: OS_VERSION=${{ matrix.version }}
 
       - name: Build package
-        # Don't build the packages if triggered by cron because it will not
-        # have the correct inputs required to construct the package names correctly.
-        # The cron schedule is really for making sure the docker containers are
-        # up-to-date anyway.
-        if: ${{ github.event_name != 'schedule' }}
         run: |
           # Set the correct version in cmake
           PACKAGE_VERSION=${{ inputs.package_complete_version }}
@@ -179,7 +170,6 @@ jobs:
           echo "MASTER_ARTIFACT_NAME=${MASTER_ARTIFACT_NAME}" >> ${GITHUB_ENV}
 
       - name: Run unit tests
-        if: ${{ github.event_name != 'schedule' }}
         run: |
           # Run the containers with the script for each testing suite
           docker run --rm -v $(pwd):/github_actions_build/ ${{ env.CONTAINER_NAME }} ./run_tests.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,10 +1,6 @@
 name: Build MacOS Package
 
 on:
-  # Run on a schedule to get monthly updates
-  schedule:
-    - cron: "0 0 28 * *"
-
   # Run when called from other workflows
   workflow_call:
     inputs:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,10 +1,6 @@
 name: Build Windows Packages
 
 on:
-  # Run on a schedule to get monthly updates
-  schedule:
-    - cron: "0 0 28 * *"
-
   # Run when called from other workflows
   workflow_call:
     inputs:


### PR DESCRIPTION
### What does this PR do?

Move the cron trigger to the correct workflow and set it to run weekly.

### Motivation
The old way the `cron` trigger was firing would miss the steps required to name the artifacts and, therefore, the builds would fail. The `cron` trigger was bumped up to a weekly frequency to make sure that we have a functioning cache for `vcpkg` builds.