### PR TITLE
Common functions library

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -31,13 +31,13 @@ jobs:
       - name: Checkout Git
         id: checkout_git
         uses: actions/checkout@v3
-        with:
-          path: performous
 
       - name: Build the AppImage
         id: build_appimage
         run: |
-          cd performous
+          # Pull in our common build functions
+          . .github/workflows/build_functions.sh
+
           PACKAGE_VERSION=${{ inputs.package_complete_version }}
           sed -i s/@@VERSION@@/${PACKAGE_VERSION}/ AppImageBuilder.yml
           mkdir build
@@ -47,20 +47,8 @@ jobs:
           cd ..
           appimage-builder --recipe AppImageBuilder.yml --skip-test
 
-          WORK_DIR=$(pwd)
-          PACKAGE_PATH=$(ls ${WORK_DIR}/*.AppImage)
-          PACKAGE_NAME=$(echo ${PACKAGE_PATH} | sed 's/\(Performous\).*$/\1/')
-          PACKAGE_SUFFIX=".AppImage"
-          NEW_PACKAGE_NAME="${PACKAGE_NAME}-${PACKAGE_VERSION}${PACKAGE_SUFFIX}"
-          MASTER_NEW_PACKAGE_NAME="${PACKAGE_NAME}-latest${PACKAGE_SUFFIX}"
-          cp ${PACKAGE_PATH} ${MASTER_NEW_PACKAGE_NAME}
-          mv ${PACKAGE_PATH} ${NEW_PACKAGE_NAME}
-          ARTIFACT_NAME=$( echo ${NEW_PACKAGE_NAME} | rev | cut -d '/' -f1 | rev)
-          MASTER_ARTIFACT_NAME=$( echo ${MASTER_NEW_PACKAGE_NAME} | rev | cut -d '/' -f1 | rev)
-          echo "ARTIFACT_PATH=${NEW_PACKAGE_NAME}" >> ${GITHUB_ENV}
-          echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >> ${GITHUB_ENV}
-          echo "MASTER_ARTIFACT_PATH=${MASTER_NEW_PACKAGE_NAME}" >> ${GITHUB_ENV}
-          echo "MASTER_ARTIFACT_NAME=${MASTER_ARTIFACT_NAME}" >> ${GITHUB_ENV}
+          # Provided by the common build functions
+          package_name "$(pwd)" "*.AppImage" "${PACKAGE_VERSION}"
 
       # Upload artifacts during pull-requests
       - name: Upload artifact

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -8,7 +8,7 @@ on:
         description: 'The output of the complete_version of the "determine_version" job from the build_and_release.yml workflow'
         required: true
         type: string
-      release_upload_url:
+      release_id:
         description: 'The output of the "create_release" job from the build_and_release.yml workflow'
         required: true
         type: string
@@ -70,11 +70,9 @@ jobs:
       - name: Upload artifacts to tagged release
         id: upload_assets
         if: ${{ github.event_name != 'pull_request' && github.ref_type == 'tag' }}
-        uses: actions/upload-release-asset@v1
+        uses: xresloader/upload-to-github-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ inputs.release_upload_url }}
-          asset_path: ${{ env.ARTIFACT_PATH }}
-          asset_name: ${{ env.ARTIFACT_NAME }}
-          asset_content_type: application/octet-stream
+          release_id: ${{ inputs.release_id }}
+          file: ${{ env.ARTIFACT_PATH }}

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -1,10 +1,6 @@
 name: Build AppImage Packages
 
 on:
-  # Run on a schedule to get monthly updates
-  schedule:
-    - cron: "0 0 28 * *"
-
   # Run when called from other workflows
   workflow_call:
     inputs:

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -2,6 +2,10 @@ name: Build and Release Performous
 
 # Controls when the workflow will run
 on:
+  # Run on a schedule to get weekly updates for the Linux containers
+  # and keep the cache fresh for Windows builds. Runs Sundays at midnight.
+  schedule:
+    - cron: "0 0 * * 0"
   # Triggers the workflow on merges to master, release branches,
   # all PRs, and release tags 
   push:

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -69,17 +69,15 @@ jobs:
     # Make sure the output variable for this step is set so it
     # can be consumed by later build steps
     outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
+      release_id: ${{ steps.create_release.outputs.id }}
     steps:
       - name: Create the Main release
         id: create_release
         if: ${{ github.event_name != 'pull_request' && github.ref_type == 'tag' }}
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.ref_name }}
-          release_name: Performous ${{ github.ref_name }}
+          name: Performous ${{ github.ref_name }}
           draft: true
           prerelease: false
 
@@ -89,7 +87,7 @@ jobs:
     uses: ./.github/workflows/linux.yml
     with:
       package_complete_version: ${{ needs.determine_version.outputs.complete_version }}
-      release_upload_url: ${{ needs.create_release.outputs.upload_url }}
+      release_id: ${{ needs.create_release.outputs.release_id }}
     needs:
       - determine_version
       - create_release
@@ -100,7 +98,7 @@ jobs:
     uses: ./.github/workflows/appimage.yml
     with:
       package_complete_version: ${{ needs.determine_version.outputs.complete_version }}
-      release_upload_url: ${{ needs.create_release.outputs.upload_url }}
+      release_id: ${{ needs.create_release.outputs.release_id }}
     needs:
       - determine_version
       - create_release
@@ -111,7 +109,7 @@ jobs:
     uses: ./.github/workflows/macos.yml
     with:
       package_complete_version: ${{ needs.determine_version.outputs.complete_version }}
-      release_upload_url: ${{ needs.create_release.outputs.upload_url }}
+      release_id: ${{ needs.create_release.outputs.release_id }}
     needs:
       - determine_version
       - create_release
@@ -122,7 +120,7 @@ jobs:
     uses: ./.github/workflows/windows.yml
     with:
       package_complete_version: ${{ needs.determine_version.outputs.complete_version }}
-      release_upload_url: ${{ needs.create_release.outputs.upload_url }}
+      release_id: ${{ needs.create_release.outputs.release_id }}
     needs:
       - determine_version
       - create_release

--- a/.github/workflows/build_functions.sh
+++ b/.github/workflows/build_functions.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+##########################################################
+##
+## These functions are meant to be pulled into stages
+## of the various workflows that require common tasks,
+## such as finding the package that was just created.
+## This is meant to reduce the size of the workflow
+## files, and to utilize a single set of shared code
+## among all the workflows, since copying these
+## everywhere is error-prone and tedious.
+##
+## For simplicity, these functions should work on all
+## UNIX(like) platforms without any special treatment
+## needed to detect OS type, lineage, etc.
+## 
+##########################################################
+
+## This function finds the package names produced by the
+## build, renames the artifact as appropriate, and sets
+## the outputs that will be consumed by later actions.
+## The first argument is a path to the working drectory,
+## usually "$(pwd)". The second argument is a
+## bash-compatible regex to search for the package.
+## The third argument is the package version as reported
+## by ${{ inputs.package_complete_version }}.
+## The fourth argument is the OS name, and the fifth
+## argument is the OS version, both are optional.
+function package_name () {
+  WORK_DIR=${1}
+  PACKAGE_REGEX=${2}
+  PACKAGE_OFFICIAL_VERSION=${3}
+  PACKAGE_OS=${4}
+  PACKAGE_OS_VERSION=${5}
+
+  if [ ${PACKAGE_OS} ]; then
+    PACKAGE_OS_NAME="-${PACKAGE_OS}"
+  fi
+  if [ ${PACKAGE_OS_VERSION} ]; then
+    PACKAGE_OS_VERSION_NAME="_${PACKAGE_OS_VERSION}"
+  fi
+  PACKAGE_PATH=$(ls ${WORK_DIR}/${PACKAGE_REGEX})
+  PACKAGE_NAME=$(basename ${PACKAGE_PATH})
+  PACKAGE_SUFFIX=$(echo ${PACKAGE_NAME} | rev | cut -d'.' -f1 | rev)
+  NEW_PACKAGE_NAME="Performous-${PACKAGE_OFFICIAL_VERSION}${PACKAGE_OS_NAME}${PACKAGE_OS_VERSION_NAME}.${PACKAGE_SUFFIX}"
+  NEW_PACKAGE_PATH="/tmp/${NEW_PACKAGE_NAME}"
+  MASTER_NEW_PACKAGE_NAME="Performous-latest${PACKAGE_OS_NAME}${PACKAGE_OS_VERSION_NAME}.${PACKAGE_SUFFIX}"
+  MASTER_NEW_PACKAGE_PATH="/tmp/${MASTER_NEW_PACKAGE_NAME}"
+  cp ${PACKAGE_PATH} ${MASTER_NEW_PACKAGE_PATH}
+  cp ${PACKAGE_PATH} ${NEW_PACKAGE_PATH}
+  ARTIFACT_NAME=$(basename ${NEW_PACKAGE_NAME})
+  MASTER_ARTIFACT_NAME=$(basename ${MASTER_NEW_PACKAGE_NAME})
+  echo "ARTIFACT_PATH=${NEW_PACKAGE_PATH}" >> ${GITHUB_ENV}
+  echo "ARTIFACT_NAME=${NEW_PACKAGE_NAME}" >> ${GITHUB_ENV}
+  echo "MASTER_ARTIFACT_PATH=${MASTER_NEW_PACKAGE_PATH}" >> ${GITHUB_ENV}
+  echo "MASTER_ARTIFACT_NAME=${MASTER_NEW_PACKAGE_NAME}" >> ${GITHUB_ENV}
+}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -131,6 +131,9 @@ jobs:
 
       - name: Build package
         run: |
+          # Pull in our common build functions
+          . .github/workflows/build_functions.sh
+
           # Set the correct version in cmake
           PACKAGE_VERSION=${{ inputs.package_complete_version }}
           EXTRA_CMAKE_ARGS="-DPERFORMOUS_VERSION=${PACKAGE_VERSION}"
@@ -150,24 +153,9 @@ jobs:
           # Run the build inside the docker containers using the
           # build script that was pulled inside during the build
           docker run --rm -v $(pwd):/github_actions_build/ ${{ env.CONTAINER_NAME }} ./build_performous.sh -g -D /github_actions_build/ -E ${EXTRA_CMAKE_ARGS} ${RELEASE_TYPE}
-          # Do some mangling to make a unique name based on the OS
-          # This is needed so we don't overwite in the release each time.
-          # We should probably investigate what cmake can do for package output
-          # to make this cleaner in the future
-          WORK_DIR=$(pwd)
-          PACKAGE_PATH=$(ls ${WORK_DIR}/build/Performous*-Linux.*)
-          PACKAGE_NAME=$(basename ${PACKAGE_PATH})
-          PACKAGE_SUFFIX=$(echo ${PACKAGE_NAME} | sed 's/^.*\(.\{4\}\)/\1/')
-          NEW_PACKAGE_NAME="${WORK_DIR}/Performous-${PACKAGE_VERSION}-${{ matrix.os }}_${{ matrix.version }}${PACKAGE_SUFFIX}"
-          MASTER_NEW_PACKAGE_NAME="${WORK_DIR}/Performous-latest-${{ matrix.os }}_${{ matrix.version }}${PACKAGE_SUFFIX}"
-          cp ${PACKAGE_PATH} ${MASTER_NEW_PACKAGE_NAME}
-          cp ${PACKAGE_PATH} ${NEW_PACKAGE_NAME}
-          ARTIFACT_NAME=$(basename ${NEW_PACKAGE_NAME})
-          MASTER_ARTIFACT_NAME=$(basename ${MASTER_NEW_PACKAGE_NAME})
-          echo "ARTIFACT_PATH=${NEW_PACKAGE_NAME}" >> ${GITHUB_ENV}
-          echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >> ${GITHUB_ENV}
-          echo "MASTER_ARTIFACT_PATH=${MASTER_NEW_PACKAGE_NAME}" >> ${GITHUB_ENV}
-          echo "MASTER_ARTIFACT_NAME=${MASTER_ARTIFACT_NAME}" >> ${GITHUB_ENV}
+
+          # Provided by the common build functions
+          package_name "$(pwd)/build" "Performous*-Linux.*" "${PACKAGE_VERSION}" "${{ matrix.os }}" "${{ matrix.version }}"
 
       - name: Run unit tests
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,7 +8,7 @@ on:
         description: 'The output of the complete_version of the "determine_version" job from the build_and_release.yml workflow'
         required: true
         type: string
-      release_upload_url:
+      release_id:
         description: 'The output of the "create_release" job from the build_and_release.yml workflow'
         required: true
         type: string
@@ -182,14 +182,12 @@ jobs:
       - name: Upload artifacts to tagged release
         id: upload_assets
         if: ${{ github.event_name != 'pull_request' && github.ref_type == 'tag' }}
-        uses: actions/upload-release-asset@v1
+        uses: xresloader/upload-to-github-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ inputs.release_upload_url }}
-          asset_path: ${{ env.ARTIFACT_PATH }}
-          asset_name: ${{ env.ARTIFACT_NAME }}
-          asset_content_type: application/octet-stream
+          release_id: ${{ inputs.release_id }}
+          file: ${{ env.ARTIFACT_PATH }}
 
       - name: Push container
         uses: docker/build-push-action@v3

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,11 +1,7 @@
 name: Build Linux Packages
 
 on:
-  # Run on a schedule to get monthly updates
-  schedule:
-    - cron: "0 0 28 * *"
-
-  # Run when called from other workflows
+  # Run when called from other workflows only
   workflow_call:
     inputs:
       package_complete_version:
@@ -134,11 +130,6 @@ jobs:
           build-args: OS_VERSION=${{ matrix.version }}
 
       - name: Build package
-        # Don't build the packages if triggered by cron because it will not
-        # have the correct inputs required to construct the package names correctly.
-        # The cron schedule is really for making sure the docker containers are
-        # up-to-date anyway.
-        if: ${{ github.event_name != 'schedule' }}
         run: |
           # Set the correct version in cmake
           PACKAGE_VERSION=${{ inputs.package_complete_version }}
@@ -179,7 +170,6 @@ jobs:
           echo "MASTER_ARTIFACT_NAME=${MASTER_ARTIFACT_NAME}" >> ${GITHUB_ENV}
 
       - name: Run unit tests
-        if: ${{ github.event_name != 'schedule' }}
         run: |
           # Run the containers with the script for each testing suite
           docker run --rm -v $(pwd):/github_actions_build/ ${{ env.CONTAINER_NAME }} ./run_tests.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,7 +8,7 @@ on:
         description: 'The output of the complete_version of the "determine_version" job from the build_and_release.yml workflow'
         required: true
         type: string
-      release_upload_url:
+      release_id:
         description: 'The output of the "create_release" job from the build_and_release.yml workflow'
         required: true
         type: string
@@ -102,11 +102,9 @@ jobs:
       - name: Upload artifacts to tagged release
         id: upload_assets
         if: ${{ github.event_name != 'pull_request' && github.ref_type == 'tag' }}
-        uses: actions/upload-release-asset@v1
+        uses: xresloader/upload-to-github-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ inputs.release_upload_url }}
-          asset_path: ${{ env.ARTIFACT_PATH }}
-          asset_name: ${{ env.ARTIFACT_NAME }}
-          asset_content_type: application/octet-stream
+          release_id: ${{ inputs.release_id }}
+          file: ${{ env.ARTIFACT_PATH }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,10 +1,6 @@
 name: Build MacOS Package
 
 on:
-  # Run on a schedule to get monthly updates
-  schedule:
-    - cron: "0 0 28 * *"
-
   # Run when called from other workflows
   workflow_call:
     inputs:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ on:
         description: 'The output of the complete_version of the "determine_version" job from the build_and_release.yml workflow'
         required: true
         type: string
-      release_upload_url:
+      release_id:
         description: 'The output of the "create_release" job from the build_and_release.yml workflow'
         required: true
         type: string
@@ -91,15 +91,13 @@ jobs:
 
       - name: Upload artifacts to tagged release
         id: upload_assets
-        uses: actions/upload-release-asset@v1
         if: ${{ github.event_name != 'pull_request' && github.ref_type == 'tag' }}
+        uses: xresloader/upload-to-github-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ inputs.release_upload_url }}
-          asset_path: ${{ env.ARTIFACT_PATH }}
-          asset_name: ${{ env.ARTIFACT_FILENAME }}
-          asset_content_type: application/octet-stream
+          release_id: ${{ inputs.release_id }}
+          file: ${{ env.ARTIFACT_PATH }}
 
   Windows_MinGW-w64_Packages:
     name: Create Windows installer with MinGW-w64
@@ -207,12 +205,10 @@ jobs:
 
       - name: Upload artifacts to tagged release
         id: upload_assets
-        uses: actions/upload-release-asset@v1
         if: ${{ github.event_name != 'pull_request' && github.ref_type == 'tag' }}
+        uses: xresloader/upload-to-github-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ inputs.release_upload_url }}
-          asset_path: ${{ env.ARTIFACT_PATH }}
-          asset_name: ${{ env.ARTIFACT_FILENAME }}
-          asset_content_type: application/octet-stream
+          release_id: ${{ inputs.release_id }}
+          file: ${{ env.ARTIFACT_PATH }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,10 +1,6 @@
 name: Build Windows Packages
 
 on:
-  # Run on a schedule to get monthly updates
-  schedule:
-    - cron: "0 0 28 * *"
-
   # Run when called from other workflows
   workflow_call:
     inputs:


### PR DESCRIPTION
### What does this PR do?
Move the code that figures out the name and location of the Linux packages and AppImages to a shell script that can be sourced and the function called directly in the workflows. This is to eliminate drift that may occur between common code areas that must be solved in multiple workflows, and makes the workflows simpler and cleanlier. I did the same thing for the Composer repo a few months back: https://github.com/performous/composer/pull/49

Also, the official Github actions we were using to create releases and upload artifacts to them have been deprecated, will no longer be maintained, and the actions runners are starting to complain about them because they use the old `set-output` method and node 12:
https://github.com/actions/create-release/issues/119
https://github.com/actions/upload-release-asset/issues/78

### More
**This should be merged after https://github.com/performous/performous/pull/866.**

Here's a release, created in my repo, that is using the new methods in this PR: https://github.com/ooshlablu/performous/releases/tag/3.4.5
The actions run for that was: https://github.com/ooshlablu/performous/actions/runs/4273227492/jobs/7438991455
Just like the old jobs, releases will be created as drafts and will require a member of the org to publish them before they are officially released. I published the release I linked so others who are not part of my org/repo can view it.