### PR TITLE
Cmake minimum version required bump

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14.5)
+cmake_minimum_required(VERSION 3.15)
 project(Performous CXX C)
 
 set(CMAKE_VERBOSE_MAKEFILE TRUE CACHE BOOL "Produce verbose makefile" FORCE)
@@ -110,7 +110,7 @@ add_subdirectory(data)
 
 add_subdirectory(game)
 
-target_compile_options(performous PRIVATE -Wall $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wextra> $<$<CXX_COMPILER_ID:gcc>:-fcx-limited-range> $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wconversion>)
+target_compile_options(performous PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/W4> $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall> $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wextra> $<$<CXX_COMPILER_ID:gcc>:-fcx-limited-range> $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wconversion>)
 
 
 add_subdirectory(docs)

--- a/cmake/Modules/FindFilesystem.cmake
+++ b/cmake/Modules/FindFilesystem.cmake
@@ -102,7 +102,7 @@ if(TARGET std::filesystem)
     return()
 endif()
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.15)
 
 include(CMakePushCheckState)
 include(CheckIncludeFileCXX)

--- a/cmake/Modules/LibFetchMacros.cmake
+++ b/cmake/Modules/LibFetchMacros.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.15)
 include(FetchContent)
 
 # Simple function to abstract fetching a dependency from Git.

--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14.5)
+cmake_minimum_required(VERSION 3.15)
 
 file(GLOB SOURCE_FILES
 	"*.cc"

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14.5)
+cmake_minimum_required(VERSION 3.15)
 
 # It should be possible to switch to CMake's GETTEXT_CREATE_TRANSLATIONS
 # if we either drop the LOCALE_DIR or that function gets a customised

--- a/osx-utils/CMakeLists.txt
+++ b/osx-utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14.5)
+cmake_minimum_required(VERSION 3.15)
 
 set(PERFORMOUS_SEMVER "" CACHE STRING "Version in semver format")
 set(PERFORMOUS_LOG_LEVEL "" CACHE STRING "Log level to set in launcher script")


### PR DESCRIPTION
### What does this PR do?

* Bumped cmake version required to 3.15 in all files.
* Sets /w4 error level for msvc instead of /wall. Usually /w4 is good enough, `/wall` has issues with stl of mickeysoft

Documentation for cmake says so: https://discourse.cmake.org/t/how-to-set-warning-level-correctly-in-modern-cmake/1103

### Closes Issue(s)

None

### Motivation

Wanting to enable treat warnings as errors on Windows.
Still some warnings to fix on windows before we can enable it again.

### Notes

Hopefully i didn't break any cmake code. I purposely didn't update any syntax that can be done when we clean up cmake code in its entirety
