### PR TITLE
Windows CICD - Updated vcpkg revision to fix recent 404's

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -42,7 +42,7 @@ jobs:
           triplet: x64-windows-release
           extra-args: '--clean-after-build --overlay-triplets="${{ github.workspace }}\performous\cmake\triplets"'
           cache-key: win64-vcpkg
-          revision: 69efe9cc2df0015f0bb2d37d55acde4a75c9a25b
+          revision: 63366443439398a62afc9a63b34b9a3ba63b1cae
           api-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run cmake to configure the project and build it


### PR DESCRIPTION
### What does this PR do?

https://github.com/microsoft/vcpkg/issues/31446#issuecomment-1574196903 mentions that the latest version should be working again

### Closes Issue(s)

None

### Motivation

* Nightly build fails
