### PR TITLE
Feature/commenttag

### DIFF
--- a/data/themes/default/www/js/playlist-song-modal-body.js
+++ b/data/themes/default/www/js/playlist-song-modal-body.js
@@ -136,6 +136,50 @@ $(function () {
     }
 
     /*
+        If our song contains a source show it.
+        Else hide the complete div.
+    */
+    if (songObject.Source.length > 1) {
+        $("#playlist-song-modal-body #modal-source-div").show();
+        $("#playlist-song-modal-body #modal-source-value").text(songObject.Source);
+    } else {
+        $("#playlist-song-modal-body #modal-source-div").hide();
+    }
+
+    /*
+        If our song contains an app show it.
+        Else hide the complete div.
+    */
+    if (songObject.App.length > 1) {
+        $("#playlist-song-modal-body #modal-app-div").show();
+        $("#playlist-song-modal-body #modal-app-value").text(songObject.App);
+    } else {
+        $("#playlist-song-modal-body #modal-app-div").hide();
+    }
+
+    /*
+        If our song contains an appversion show it.
+        Else hide the complete div.
+    */
+    if (songObject.AppVersion.length > 1) {
+        $("#playlist-song-modal-body #modal-appversion-div").show();
+        $("#playlist-song-modal-body #modal-appversion-value").text(songObject.AppVersion);
+    } else {
+        $("#playlist-song-modal-body #modal-appversion-div").hide();
+    }
+
+    /*
+        If our song contains a comment show it.
+        Else hide the complete div.
+    */
+    if (songObject.Comment.length > 1) {
+        $("#playlist-song-modal-body #modal-comment-div").show();
+        $("#playlist-song-modal-body #modal-comment-value").text(songObject.Comment);
+    } else {
+        $("#playlist-song-modal-body #modal-comment-div").hide();
+    }
+
+    /*
         Click event handlers to either change a position of the song or remove the song.
     */
     $("#playlist-song-modal-body #modal-move-song-up").click(function () {

--- a/data/themes/default/www/js/playlist.js
+++ b/data/themes/default/www/js/playlist.js
@@ -22,9 +22,16 @@ $("#refresh-playlist").click(function () {
 
             $.each(database, function (iterator, songObject) {
                 totalTime += songObject.Duration + timeout;
-                var position = String(iterator + 1).padStart(2, '0') + ".";
-                $("#playlist-songs").append("<a id=\"playlist-songs-" + iterator + "\" href=\"#\" class=\"list-group-item\" data-toggle=\"modal\" data-target=\"#dynamic-modal\">" + position + " " + songObject.Artist + " - " + songObject.Title + " - " + secondsToDate(totalTime) + "<span class=\"glyphicon glyphicon-info-sign\"></span></a>");
-                $("#playlist-songs-sortable").append("<a id=\"playlist-songs-sortable-" + iterator + "\" href=\"#\" class=\"list-group-item\" data-toggle=\"modal\" data-target=\"#dynamic-modal\">" + position + " " + songObject.Artist + " - " + songObject.Title + " - " + secondsToDate(totalTime) + "<span class=\"glyphicon glyphicon-info-sign\"></span></a>");
+                var songMeta = "";
+                songMeta += songObject.Language.length > 0 ? " | " + songObject.Language : "";
+                songMeta += songObject.Edition.length > 0 ? " | " + songObject.Edition : "";
+                songMeta += songObject.Source.length > 0 ? " | " + songObject.Source : "";
+                songMeta += songObject.App.length > 0 ? " | " + songObject.App : "";
+                songMeta += songObject.AppVersion.length > 0 ? " | " + songObject.AppVersion : "";
+                songMeta += songObject.Comment.length > 0 ? " | " + songObject.Comment : "";
+				var position = String(iterator + 1).padStart(2, '0') + ".";
+                $("#playlist-songs").append("<a id=\"playlist-songs-" + iterator + "\" href=\"#\" class=\"list-group-item\" data-toggle=\"modal\" data-target=\"#dynamic-modal\">" + position + " " + songObject.Artist + " - " + songObject.Title + songMeta + " - " + secondsToDate(totalTime) + "<span class=\"glyphicon glyphicon-info-sign\"></span></a>");
+                $("#playlist-songs-sortable").append("<a id=\"playlist-songs-sortable-" + iterator + "\" href=\"#\" class=\"list-group-item\" data-toggle=\"modal\" data-target=\"#dynamic-modal\">" + position + " " + songObject.Artist + " - " + songObject.Title + songMeta + " - " + secondsToDate(totalTime) + "<span class=\"glyphicon glyphicon-info-sign\"></span></a>");
                 songObject.Position = iterator;
                 songObject.PositionStr = position;
                 $("#playlist-songs-" + iterator).data("modal-songObject", JSON.stringify(songObject));

--- a/data/themes/default/www/js/search.js
+++ b/data/themes/default/www/js/search.js
@@ -53,6 +53,10 @@ $("#search-database").click(function (e, callback) {
                 var songMeta = "";
                 songMeta += songObject.Language.length > 0 ? " | " + songObject.Language : "";
                 songMeta += songObject.Edition.length > 0 ? " | " + songObject.Edition : "";
+                songMeta += songObject.Source.length > 0 ? " | " + songObject.Source : "";
+                songMeta += songObject.App.length > 0 ? " | " + songObject.App : "";
+                songMeta += songObject.AppVersion.length > 0 ? " | " + songObject.AppVersion : "";
+                songMeta += songObject.Comment.length > 0 ? " | " + songObject.Comment : "";
                 $("#searched-songs").append("<a href=\"#\" id=\"searched-songs-" + iterator + "\" class=\"list-group-item\" >" + songObject.Artist + " - " + songObject.Title + songMeta + "<span class=\"glyphicon glyphicon-plus\"></span></a>");
                 $("#searched-songs-"+iterator).data("songObject", JSON.stringify(songObject));
             });
@@ -84,6 +88,10 @@ $("#search-database").click(function (e, callback) {
                 var songMeta = "";
                 songMeta += songObject.Language.length > 0 ? " | " + songObject.Language : "";
                 songMeta += songObject.Edition.length > 0 ? " | " + songObject.Edition : "";
+                songMeta += songObject.Source.length > 0 ? " | " + songObject.Source : "";
+                songMeta += songObject.App.length > 0 ? " | " + songObject.App : "";
+                songMeta += songObject.AppVersion.length > 0 ? " | " + songObject.AppVersion : "";
+                songMeta += songObject.Comment.length > 0 ? " | " + songObject.Comment : "";
                 $("#searched-songs").append("<a href=\"#\" id=\"searched-songs-" + iterator + "\" class=\"list-group-item\" >" + songObject.Artist + " - " + songObject.Title + songMeta + "<span class=\"glyphicon glyphicon-plus\"></span></a>");
                 $("#searched-songs-"+iterator).data("songObject", JSON.stringify(songObject));
             });

--- a/data/themes/default/www/playlist-song-modal-body.html
+++ b/data/themes/default/www/playlist-song-modal-body.html
@@ -14,6 +14,22 @@
 			<label class="control-label" for="modal-creator-value">creator</label>
 			<span id="modal-creator-value" class="show"></span>
 		</div>
+		<div id="modal-source-div" class="col-sm-4">
+			<label class="control-label" for="modal-source-value">source</label>
+			<span id="modal-source-value" class="show"></span>
+		</div>
+		<div id="modal-app-div" class="col-sm-4">
+			<label class="control-label" for="modal-app-value">app</label>
+			<span id="modal-app-value" class="show"></span>
+		</div>
+		<div id="modal-appversion-div" class="col-sm-4">
+			<label class="control-label" for="modal-appversion-value">app version</label>
+			<span id="modal-appversion-value" class="show"></span>
+		</div>
+		<div id="modal-comment-div" class="col-sm-4">
+			<label class="control-label" for="modal-comment-value">comment</label>
+			<span id="modal-comment-value" class="show"></span>
+		</div>
 	</div>
 	<!-- Simple buttons to move the song one position up or down. -->
 	<div class="form-group row col-sm-12">

--- a/game/requesthandler.cc
+++ b/game/requesthandler.cc
@@ -131,6 +131,10 @@ void RequestHandler::Get(web::http::http_request request)
             songObject[utility::conversions::to_string_t("Language")] = web::json::value::string(utility::conversions::to_string_t(song->language));
             songObject[utility::conversions::to_string_t("Creator")] = web::json::value::string(utility::conversions::to_string_t(song->creator));
             songObject[utility::conversions::to_string_t("Duration")] = web::json::value(song->getDurationSeconds());
+            songObject[utility::conversions::to_string_t("Source")] = web::json::value(utility::conversions::to_string_t(song->source));
+            songObject[utility::conversions::to_string_t("App")] = web::json::value(utility::conversions::to_string_t(song->app));
+            songObject[utility::conversions::to_string_t("AppVersion")] = web::json::value(utility::conversions::to_string_t(song->appVersion));
+            songObject[utility::conversions::to_string_t("Comment")] = web::json::value(utility::conversions::to_string_t(song->comment));
             jsonRoot[i] = songObject;
             i++;
         }
@@ -236,6 +240,10 @@ void RequestHandler::Post(web::http::http_request request)
             songObject[utility::conversions::to_string_t("Edition")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->edition));
             songObject[utility::conversions::to_string_t("Language")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->language));
             songObject[utility::conversions::to_string_t("Creator")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->creator));
+            songObject[utility::conversions::to_string_t("Source")] = web::json::value(utility::conversions::to_string_t(m_songs[i]->source));
+            songObject[utility::conversions::to_string_t("App")] = web::json::value(utility::conversions::to_string_t(m_songs[i]->app));
+            songObject[utility::conversions::to_string_t("AppVersion")] = web::json::value(utility::conversions::to_string_t(m_songs[i]->appVersion));
+            songObject[utility::conversions::to_string_t("Comment")] = web::json::value(utility::conversions::to_string_t(m_songs[i]->comment));
             jsonRoot[i] = songObject;
         }
         request.reply(web::http::status_codes::OK, jsonRoot);
@@ -284,6 +292,10 @@ web::json::value RequestHandler::SongsToJsonObject() {
         songObject[utility::conversions::to_string_t("Language")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->language));
         songObject[utility::conversions::to_string_t("Creator")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->creator));
         songObject[utility::conversions::to_string_t("name")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->artist + " " + m_songs[i]->title));
+        songObject[utility::conversions::to_string_t("Source")] = web::json::value(utility::conversions::to_string_t(m_songs[i]->source));
+        songObject[utility::conversions::to_string_t("App")] = web::json::value(utility::conversions::to_string_t(m_songs[i]->app));
+        songObject[utility::conversions::to_string_t("AppVersion")] = web::json::value(utility::conversions::to_string_t(m_songs[i]->appVersion));
+        songObject[utility::conversions::to_string_t("Comment")] = web::json::value(utility::conversions::to_string_t(m_songs[i]->comment));
         jsonRoot[i] = songObject;
     }
 
@@ -298,7 +310,11 @@ std::shared_ptr<Song> RequestHandler::GetSongFromJSON(web::json::value jsonDoc) 
            m_songs[i]->artist == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Artist")].as_string()) &&
            m_songs[i]->edition == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Edition")].as_string()) &&
            m_songs[i]->language == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Language")].as_string()) &&
-           m_songs[i]->creator == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Creator")].as_string()) ) {
+           m_songs[i]->creator == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Creator")].as_string()) &&
+           m_songs[i]->source == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Source")].as_string()) &&
+           m_songs[i]->app == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("App")].as_string()) &&
+           m_songs[i]->appVersion == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("AppVersion")].as_string()) &&
+            m_songs[i]->comment == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Comment")].as_string())) {
             std::clog << "webserver/info: Found requested song." << std::endl;
             return m_songs[i];
         }

--- a/game/song.cc
+++ b/game/song.cc
@@ -22,6 +22,10 @@ Song::Song(nlohmann::json const& song): dummyVocal(TrackName::VOCAL_LEAD), rando
 	language = getJsonEntry<std::string>(song, "language").value_or("");
 	edition = getJsonEntry<std::string>(song, "edition").value_or("");
 	creator = getJsonEntry<std::string>(song, "creator").value_or("");
+	source = getJsonEntry<std::string>(song, "source").value_or("");
+	app = getJsonEntry<std::string>(song, "app").value_or("");
+	appVersion = getJsonEntry<std::string>(song, "appVersion").value_or("");
+	comment = getJsonEntry<std::string>(song, "comment").value_or("");
 	genre = getJsonEntry<std::string>(song, "genre").value_or("");
 	cover = getJsonEntry<std::string>(song, "cover").value_or("");
 	background = getJsonEntry<std::string>(song, "background").value_or("");

--- a/game/song.hh
+++ b/game/song.hh
@@ -65,6 +65,10 @@ public:
 	std::string text; ///< songtext
 	std::string creator; ///< creator
 	std::string language; ///< language
+	std::string source; ///< source of the mapped file.
+	std::string app; ///< Application used to create the mapped file.
+	std::string appVersion; ///< Version of the application used to create the mapped file.
+	std::string comment; ///< comment of the mapped file.
 	using MusicFiles = std::map<std::string, fs::path>;
 	MusicFiles music; ///< music files (background, guitar, rhythm/bass, drums, vocals)
 	fs::path cover; ///< cd cover

--- a/game/songparser-txt.cc
+++ b/game/songparser-txt.cc
@@ -129,6 +129,10 @@ bool SongParser::txtParseField(std::string const& line) {
 	else if (key == "VIDEOGAP") assign(m_song.videoGap, value);
 	else if (key == "PREVIEWSTART") assign(m_song.preview_start, value);
 	else if (key == "LANGUAGE") m_song.language = value.substr(value.find_first_not_of(" "));
+	else if (key == "SOURCE") m_song.source = value.substr(value.find_first_not_of(" "));
+	else if (key == "APP") m_song.app = value.substr(value.find_first_not_of(" "));
+	else if (key == "APP_VERSION") m_song.appVersion = value.substr(value.find_first_not_of(" "));
+	else if (key == "COMMENT") m_song.comment = value.substr(value.find_first_not_of(" "));
 	return true;
 }
 

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -173,6 +173,18 @@ void Songs::CacheSonglist() {
 		if(!song->creator.empty()) {
 			songObject["creator"] = song->creator;
 		}
+		if (!song->source.empty()) {
+			songObject["source"] = song->source;
+		}
+		if (!song->app.empty()) {
+			songObject["app"] = song->app;
+		}
+		if (!song->appVersion.empty()) {
+			songObject["appVersion"] = song->appVersion;
+		}
+		if (!song->comment.empty()) {
+			songObject["comment"] = song->comment;
+		}
 		if(!song->genre.empty()) {
 			songObject["genre"] = song->genre;
 		}


### PR DESCRIPTION
### What does this PR do?

Trying to introduce new (hopefully) standardized fields.
This helps in distinguishing where the mapped file came from and which program made it at which version.
Aside from this `#COMMENT` is sometimes used which is now also supported

### Closes Issue(s)

None

### Motivation

I'm trying to get a couple new standardized fields into the ultrastar format.
This allows hosting websites to add their name to song files whilst creator tools like composer add their specific version and appname.

This way everyone knows where the txt came from and which program is used to create it.

Since the varying sources of which you can download songs from differ in quality this is a nicely added bonus to see where it came from.

Might be a niche for just me, but if everyone opts in it'd make for a way better system and maybe even a newly introduced system which combines all the sources out there.... (that's my endgoal)

### Testing

You can test this by adding the following tags:
```
#SOURCE:USDB
#APP:Composer
#APPVERSION:1.0.0
#COMMENT:Some comment
```

All tags are opt in. But if everyone plays by the rules every txt will have these fields eventually

The tags are shown within the webserver-ui: Playlist and search screen.
All extra tags are seperated by the `|` symbol. And the popup if you click a song also mentions the tags + content if they're there.

### Meanwhile...
Meanwhile i'm trying to convince other karaoke creators and downloadable websites to implement this for every song txt they have. But currently everyone is against it....
