### PR TITLE
Debian 12 released today

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -96,6 +96,8 @@ jobs:
             version: 10
           - os: debian
             version: 11
+          - os: debian
+            version: 12
           - os: fedora
             version: 35
           - os: fedora

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Latest builds
 - [Linux - Ubuntu 22.04](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-ubuntu_22.04.deb.zip)
 - [Linux - Debian 10](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-debian_10.deb.zip)
 - [Linux - Debian 11](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-debian_11.deb.zip)
+- [Linux - Debian 12](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-debian_12.deb.zip)
 - [Linux - Fedora 35](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-fedora_35.rpm.zip)
 - [Linux - Fedora 36](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-fedora_36.rpm.zip)
 - [Linux - Fedora 37](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-fedora_37.rpm.zip)


### PR DESCRIPTION
### What does this PR do?

Adds packages for Debian 12.

### Closes Issue(s)

None

### Motivation

Debian 12 was officially released a few days ago, and the docker container for it went live earlier today.