### PR TITLE
Move the AppImage builder to Ubuntu 22.04

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -17,7 +17,7 @@ jobs:
   # Create the AppImage
   AppImage:
     name: Create the AppImage
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install the AppImage bundler and Performous deps
         id: fetch_deps
@@ -26,7 +26,7 @@ jobs:
           chmod +x appimage-builder-x86_64.AppImage
           sudo mv appimage-builder-x86_64.AppImage /usr/local/bin/appimage-builder
           sudo apt update
-          sudo apt-get install -y --no-install-recommends git cmake build-essential gettext help2man libopenblas-dev libfftw3-dev libicu-dev libepoxy-dev libsdl2-dev libfreetype6-dev libpango1.0-dev librsvg2-dev libxml++2.6-dev libavcodec-dev libavformat-dev libswscale-dev libjpeg-dev portaudio19-dev libglm-dev libboost-filesystem-dev libboost-iostreams-dev libboost-locale-dev libboost-system-dev libboost-program-options-dev libssl-dev libcpprest-dev libgtest-dev libgmock-dev google-mock libportmidi-dev libopencv-dev libaubio-dev nlohmann-json3-dev libfmt-dev
+          sudo apt-get install -y --no-install-recommends git cmake build-essential gettext help2man libopenblas-dev libfftw3-dev libicu-dev libepoxy-dev libsdl2-dev libfreetype6-dev libpango1.0-dev librsvg2-dev libxml++2.6-dev libavcodec-dev libavformat-dev libswscale-dev libjpeg-dev portaudio19-dev libglm-dev libboost-filesystem-dev libboost-iostreams-dev libboost-locale-dev libboost-system-dev libboost-program-options-dev libssl-dev libcpprest-dev libgtest-dev libgmock-dev google-mock libportmidi-dev libopencv-dev libaubio-dev nlohmann-json3-dev libfmt-dev libfuse2
 
       - name: Checkout Git
         id: checkout_git

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -13,30 +13,31 @@ AppDir:
     arch: amd64
     allow_unauthenticated: true
     sources:
-      - sourceline: deb http://archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse
-      - sourceline: deb http://archive.ubuntu.com/ubuntu/ focal-updates main restricted universe multiverse
+      - sourceline: deb http://archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse
+      - sourceline: deb http://archive.ubuntu.com/ubuntu/ jammy-updates main restricted universe multiverse
     include:
       ## All of these dependencies can be found by downloading the Performous
-      ## package for Ubuntu 20.04 and doing a dpkg -I on it
+      ## package for Ubuntu 22.04 and doing a dpkg -I on it
       - libaubio5
       - libavcodec58
       - libavformat58
       - libavutil56
-      - libboost-iostreams1.71.0
-      - libboost-locale1.71.0
-      - libboost-program-options1.71.0
+      - libboost-iostreams1.74.0
+      - libboost-locale1.74.0
+      - libboost-program-options1.74.0
       - libc6
       - libcairo2
       - libcpprest2.10
       - libepoxy0
+      - libfmt8
       - libfontconfig1
       - libgcc-s1
       - libglib2.0-0
       - libglibmm-2.4-1v5
-      - libicu66
+      - libicu70
       - libjpeg8
-      - libopencv-core4.2
-      - libopencv-videoio4.2
+      - libopencv-core4.5d
+      - libopencv-videoio4.5d
       - libpango-1.0-0
       - libpangocairo-1.0-0
       - libpng16-16
@@ -44,7 +45,7 @@ AppDir:
       - libportmidi0
       - librsvg2-2
       - libsdl2-2.0-0
-      - libssl1.1
+      - libssl3
       - libstdc++6
       - libswresample3
       - libswscale5


### PR DESCRIPTION
### What does this PR do?

Move the AppImage builder to Ubuntu 22.04

### Motivation
An issue popped up in `user_support` on Discord that a user was not able to run the AppImage on a newer version of Suse. Running it would crash with the following error:
```
libstdc++.so.6: version 'GLIBCXX_3.4.29' not found
```
Ubuntu 22.04 is using a newer version of the various `libc6` components, so I suspected bumping the runner version up would fix the issue.

### Additional Notes

`libfuse2` was added to the dependencies installed on the builder because it is required to run AppImages for now and 22.04 does not come with it installed by default.

We do still have some workarounds for Arch and Fedora, so those should be tested with the AppImage as well.
