### PR TITLE
Remove Playlist SetPosition

### DIFF
--- a/game/playlist.cc
+++ b/game/playlist.cc
@@ -47,21 +47,6 @@ void PlayList::swap(unsigned index1, unsigned index2) {
 	m_list[index1] = m_list[index2];
 	m_list[index2] = song1;
 }
-void PlayList::setPosition(unsigned index1, unsigned index2) {
-	if(index1 != index2) {	
-		unsigned diff = index1 - index2;
-		if(diff > 0) {
-			// Going to Top
-			swap(index1, index1 - 1u);
-			setPosition(index1 - 1u, index2);
-		} else {
-			// Going to Bottom
-			swap(index1, index1 + 1u);
-			setPosition(index1 + 1u, index2);
-		} 
-	}
-}
-
 
 std::shared_ptr<Song> PlayList::getSong(unsigned index) {
 	std::lock_guard<std::mutex> l(m_mutex);

--- a/game/playlist.hh
+++ b/game/playlist.hh
@@ -33,7 +33,6 @@ public:
 	void removeSong(unsigned index);
 	/// swaps two songs
 	void swap (unsigned index1, unsigned index2);
-	void setPosition (unsigned index1, unsigned index2);
 	/// gets a specific song and removes it from the queue
 	std::shared_ptr<Song> getSong(unsigned index);
 	/// this is for the webserver, to avoid crashing when adding the current playing song

--- a/game/requesthandler.cc
+++ b/game/requesthandler.cc
@@ -204,7 +204,7 @@ void RequestHandler::Post(web::http::http_request request)
                 return;
             }
             if (positionToMoveTo <= sizeOfPlaylist - 1) {
-                m_game.getCurrentPlayList().setPosition(songIdToMove, positionToMoveTo);
+                m_game.getCurrentPlayList().swap(songIdToMove, positionToMoveTo);
                 ScreenPlaylist* m_pp = dynamic_cast<ScreenPlaylist*>(m_game.getScreen("Playlist"));
                 m_pp->triggerSongListUpdate();
                 request.reply(web::http::status_codes::OK, "success");


### PR DESCRIPTION
### What does this PR do?

* Removes the SetPosition function which was only called from requesthandler.
* Changes requesthandler to use the swap method on Playlist.

Less code, better maintainability

### Closes Issue(s)

#886 

### Motivation

I want to be able to use the up/down/set-position functionality in webserver.
