### PR TITLE
Allow all connections

### DIFF
--- a/game/webserver.cc
+++ b/game/webserver.cc
@@ -1,5 +1,6 @@
 #include "webserver.hh"
 #include "game.hh"
+#include "platform.hh"
 
 #ifdef USE_WEBSERVER
 #include <boost/asio.hpp>
@@ -26,7 +27,14 @@ void WebServer::StartServer(int tried, bool fallbackPortInUse) {
 		addr = "http://127.0.0.1:" + portToUse;
 		std::clog << "webserver/notice: Starting local server on: " << addr <<std::endl;
 	} else {
-		addr = "http://0.0.0.0:" + portToUse;
+		if (Platform::currentOS() == Platform::HostOS::OS_WIN)
+		{
+			addr = "http://*:" + portToUse; // Allow Windows to accept all connections. Needs admin privileges though.
+		}
+		else 
+		{
+			addr = "http://0.0.0.0:" + portToUse;
+		}
 		std::clog << "webserver/notice: Starting public server on: " << addr << std::endl;
 	}
 


### PR DESCRIPTION
### What does this PR do?

While testing 1.3.0-rc1 we found that on windows we cannot accept all connections.
This is a problem within cpprestsdk as we bind wrongly for Windows.

Added an if-statement to check for OS and added the correct binding address.

### Closes Issue(s)

None

### Motivation

All connections for webserver should work just fine on Windows as it also does for Linux/MacOS

### Additional Notes

Windows users still need Admin privileges to run the webserver with All connections.
