### PR TITLE
Fix: apply the filter to the songs before passing them to the web server

### DIFF
--- a/game/requesthandler.cc
+++ b/game/requesthandler.cc
@@ -100,6 +100,8 @@ void RequestHandler::Get(web::http::http_request request)
         } else if(query == "sort=creator&order=descending") {
             m_songs.sortSpecificChange(10, true);
         }
+        // make sure to apply the filtering
+        m_songs.update();
         web::json::value jsonRoot = SongsToJsonObject();
         request.reply(web::http::status_codes::OK, jsonRoot);
         return;


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/performous/performous/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

Edit: call the `m_songs.update()` function from `requesthandler.cc` before constructing the json and passing the songs to the web server.
~This PR adds a call to `filter_internal()` after the songs are loaded from cache/filesystem.~
~This way, the web server can load the songs after this filtering is done.~
<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

#900 
<!-- List here all the issues closed by this pull request. -->

### Motivation

Being able to use the web server before having to enter the "Perform" screen.
<!-- What inspired you to submit this pull request? -->

### More

- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
