### PR TITLE
Fixed song sorting from within the web server

### DIFF
--- a/game/requesthandler.cc
+++ b/game/requesthandler.cc
@@ -95,6 +95,10 @@ void RequestHandler::Get(web::http::http_request request)
             m_songs.sortSpecificChange(3);
         } else if(query == "sort=edition&order=descending") {
             m_songs.sortSpecificChange(3, true);
+        } else if(query == "sort=creator&order=ascending") {
+            m_songs.sortSpecificChange(10);
+        } else if(query == "sort=creator&order=descending") {
+            m_songs.sortSpecificChange(10, true);
         }
         web::json::value jsonRoot = SongsToJsonObject();
         request.reply(web::http::status_codes::OK, jsonRoot);

--- a/game/songorder/creator_song_order.cc
+++ b/game/songorder/creator_song_order.cc
@@ -1,0 +1,18 @@
+#include "creator_song_order.hh"
+
+#include "configuration.hh"
+#include "unicode.hh"
+
+std::string CreatorSongOrder::getDescription() const {
+	return _("sorted by creator");
+}
+
+void CreatorSongOrder::prepare(SongCollection const&, Database const&) {
+	UnicodeUtil::m_sortCollator->setStrength(config["game/case-sorting"].b() ? icu::Collator::TERTIARY : icu::Collator::SECONDARY);
+}
+
+bool CreatorSongOrder::operator()(Song const& a, Song const& b) const {
+	return a.creator < b.creator;
+}
+
+

--- a/game/songorder/creator_song_order.hh
+++ b/game/songorder/creator_song_order.hh
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "songorder.hh"
+
+struct CreatorSongOrder : public SongOrder {
+	std::string getDescription() const override;
+
+	void prepare(SongCollection const&, Database const&) override;
+
+	bool operator()(Song const& a, Song const& b) const override;
+};
+

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -11,6 +11,7 @@
 #include "song.hh"
 
 #include "songorder/artist_song_order.hh"
+#include "songorder/creator_song_order.hh"
 #include "songorder/edition_song_order.hh"
 #include "songorder/file_time_song_order.hh"
 #include "songorder/genre_song_order.hh"
@@ -44,6 +45,7 @@ namespace {
 		songs.addSongOrder(std::make_shared<ScoreSongOrder>());
 		songs.addSongOrder(std::make_shared<MostSungSongOrder>());
 		songs.addSongOrder(std::make_shared<FileTimeSongOrder>());
+		songs.addSongOrder(std::make_shared<CreatorSongOrder>());
 	}
 }
 
@@ -528,7 +530,11 @@ void Songs::sort_internal(bool descending) {
 	order.prepare(m_filtered, m_database);
 
 	std::stable_sort(m_filtered.begin(), m_filtered.end(),
-		[&](SongPtr const& a, SongPtr const& b) { return order(*a, *b) ? !descending : descending; });
+		[&](SongPtr const& a, SongPtr const& b) { return order(*a, *b); });
+
+	if (descending) {
+		std::reverse(m_filtered.begin(), m_filtered.end());
+	}
 }
 
 std::shared_ptr<Song> Songs::currentPtr() const try {

--- a/game/utils/cycle.hh
+++ b/game/utils/cycle.hh
@@ -11,6 +11,7 @@ class Cycle {
 	Cycle& backward();
 
 	operator Type() const;
+	Cycle& operator=(Type value);
 
 	Type getMin() const;
 	Type getMax() const;
@@ -55,6 +56,11 @@ Cycle<Type>& Cycle<Type>::set(Type value) {
 	m_value = value;
 
 	return *this;
+}
+
+template<class Type>
+Cycle<Type>& Cycle<Type>::operator=(Type value) {
+	return set(value);
 }
 
 template<class Type>

--- a/testing/cycletest.cc
+++ b/testing/cycletest.cc
@@ -50,6 +50,17 @@ TEST(UnitTest_Cycle, set_bounds) {
 	EXPECT_THROW(Cycle<unsigned short>(1, 2, 1).set(3), std::logic_error);
 }
 
+TEST(UnitTest_Cycle, operator_equals) {
+	EXPECT_EQ(2, Cycle<unsigned short>(0, 2, 0) = 2);
+	EXPECT_EQ(0, Cycle<unsigned short>(1, 2, 0) = 0);
+	EXPECT_EQ(1, Cycle<unsigned short>(2, 2, 0) = 1);
+}
+
+TEST(UnitTest_Cycle, operator_equals_bounds) {
+	EXPECT_THROW(Cycle<unsigned short>(1, 2, 1) = 0, std::logic_error);
+	EXPECT_THROW(Cycle<unsigned short>(1, 2, 1) = 3, std::logic_error);
+}
+
 TEST(UnitTest_Cycle, forward) {
 	EXPECT_EQ(1, Cycle<unsigned short>(0, 2, 0).forward());
 	EXPECT_EQ(2, Cycle<unsigned short>(0, 2, 0).forward().forward());


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/performous/performous/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

Fixed the sorting of songs on artist/title/language/edition/creator.
Added sorting class of the 'creator' field of songs.
Added `operator=(Type value)` to the Cycle class:
* Otherwise the constructor is used which creates a new Cycle instance with `Cycle(value, 1, 0)` default max/min values
* This fails the checks resulting in an `throw std::logic_error(..)` and a HTTP 500 returned to the web server
<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

#903 
<!-- List here all the issues closed by this pull request. -->

### Motivation

Wanting to sort the songs in the web server.
<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
