### PR TITLE
Fixes UTF8 Paths with UnicodeUtil class

### DIFF
--- a/game/ffmpeg.cc
+++ b/game/ffmpeg.cc
@@ -4,6 +4,7 @@
 #include "config.hh"
 #include "screen_songs.hh"
 #include "util.hh"
+#include "unicode.hh"
 
 #include "aubio/aubio.h"
 #include <memory>
@@ -249,7 +250,7 @@ FFmpeg::FFmpeg(fs::path const& _filename, int mediaType) : m_filename(_filename)
 	av_log_set_level(AV_LOG_ERROR);
 	{
 		AVFormatContext *avfctx = nullptr;
-		auto err = avformat_open_input(&avfctx, m_filename.string().c_str(), nullptr, nullptr);
+		auto err = avformat_open_input(&avfctx, UnicodeUtil::convertToUTF8(m_filename.string()).c_str(), nullptr, nullptr);
 		if (err) throw Error(*this, err);
 		m_formatContext.reset(avfctx);
 	}

--- a/game/song.cc
+++ b/game/song.cc
@@ -15,35 +15,35 @@ extern "C" {
 }
 
 Song::Song(nlohmann::json const& song): dummyVocal(TrackName::VOCAL_LEAD), randomIdx(rand()) {
-	path = getJsonEntry<std::string>(song, "txtFileFolder").value_or("");
-	filename = getJsonEntry<std::string>(song, "txtFile").value_or("");
+	path = UnicodeUtil::convertToUTF8(getJsonEntry<std::string>(song, "txtFileFolder").value_or(""));
+	filename = UnicodeUtil::convertToUTF8(getJsonEntry<std::string>(song, "txtFile").value_or(""));
 	artist = getJsonEntry<std::string>(song, "artist").value_or("");
 	title = getJsonEntry<std::string>(song, "title").value_or("");
 	language = getJsonEntry<std::string>(song, "language").value_or("");
 	edition = getJsonEntry<std::string>(song, "edition").value_or("");
 	creator = getJsonEntry<std::string>(song, "creator").value_or("");
 	genre = getJsonEntry<std::string>(song, "genre").value_or("");
-	cover = getJsonEntry<std::string>(song, "cover").value_or("");
-	background = getJsonEntry<std::string>(song, "background").value_or("");
-	video = getJsonEntry<std::string>(song, "videoFile").value_or("");
-	midifilename = getJsonEntry<std::string>(song, "midiFile").value_or("");
+	cover = UnicodeUtil::convertToUTF8(getJsonEntry<std::string>(song, "cover").value_or(""));
+	background = UnicodeUtil::convertToUTF8(getJsonEntry<std::string>(song, "background").value_or(""));
+	video = UnicodeUtil::convertToUTF8(getJsonEntry<std::string>(song, "videoFile").value_or(""));
+	midifilename = UnicodeUtil::convertToUTF8(getJsonEntry<std::string>(song, "midiFile").value_or(""));
 	videoGap = getJsonEntry<double>(song, "videoGap").value_or(0.0);
 	start = getJsonEntry<double>(song, "start").value_or(0.0);
 	preview_start = getJsonEntry<double>(song, "previewStart").value_or(0.0);
 	m_duration = getJsonEntry<double>(song, "duration").value_or(0.0);
-	music[TrackName::BGMUSIC] = getJsonEntry<std::string>(song, "songFile").value_or("");
-	music[TrackName::VOCAL_LEAD] = getJsonEntry<std::string>(song, "vocals").value_or("");
-	music[TrackName::VOCAL_BACKING] = getJsonEntry<std::string>(song, "vocalsBacking").value_or("");
-	music[TrackName::PREVIEW] = getJsonEntry<std::string>(song, "preview").value_or("");
-	music[TrackName::GUITAR] = getJsonEntry<std::string>(song, "guitar").value_or("");
-	music[TrackName::BASS] = getJsonEntry<std::string>(song, "bass").value_or("");
-	music[TrackName::DRUMS] = getJsonEntry<std::string>(song, "drums").value_or("");
-	music[TrackName::DRUMS_SNARE] = getJsonEntry<std::string>(song, "drumsSnare").value_or("");
-	music[TrackName::DRUMS_CYMBALS] = getJsonEntry<std::string>(song, "drumsCymbals").value_or("");
-	music[TrackName::DRUMS_TOMS] = getJsonEntry<std::string>(song, "drumsToms").value_or("");
-	music[TrackName::KEYBOARD] = getJsonEntry<std::string>(song, "keyboard").value_or("");
-	music[TrackName::GUITAR_COOP] = getJsonEntry<std::string>(song, "guitarCoop").value_or("");
-	music[TrackName::GUITAR_RHYTHM] = getJsonEntry<std::string>(song, "guitarRhythm").value_or("");
+	music[TrackName::BGMUSIC] = UnicodeUtil::convertToUTF8(getJsonEntry<std::string>(song, "songFile").value_or(""));
+	music[TrackName::VOCAL_LEAD] = UnicodeUtil::convertToUTF8(getJsonEntry<std::string>(song, "vocals").value_or(""));
+	music[TrackName::VOCAL_BACKING] = UnicodeUtil::convertToUTF8(getJsonEntry<std::string>(song, "vocalsBacking").value_or(""));
+	music[TrackName::PREVIEW] = UnicodeUtil::convertToUTF8(getJsonEntry<std::string>(song, "preview").value_or(""));
+	music[TrackName::GUITAR] = UnicodeUtil::convertToUTF8(getJsonEntry<std::string>(song, "guitar").value_or(""));
+	music[TrackName::BASS] = UnicodeUtil::convertToUTF8(getJsonEntry<std::string>(song, "bass").value_or(""));
+	music[TrackName::DRUMS] = UnicodeUtil::convertToUTF8(getJsonEntry<std::string>(song, "drums").value_or(""));
+	music[TrackName::DRUMS_SNARE] = UnicodeUtil::convertToUTF8(getJsonEntry<std::string>(song, "drumsSnare").value_or(""));
+	music[TrackName::DRUMS_CYMBALS] = UnicodeUtil::convertToUTF8(getJsonEntry<std::string>(song, "drumsCymbals").value_or(""));
+	music[TrackName::DRUMS_TOMS] = UnicodeUtil::convertToUTF8(getJsonEntry<std::string>(song, "drumsToms").value_or(""));
+	music[TrackName::KEYBOARD] = UnicodeUtil::convertToUTF8(getJsonEntry<std::string>(song, "keyboard").value_or(""));
+	music[TrackName::GUITAR_COOP] = UnicodeUtil::convertToUTF8(getJsonEntry<std::string>(song, "guitarCoop").value_or(""));
+	music[TrackName::GUITAR_RHYTHM] = UnicodeUtil::convertToUTF8(getJsonEntry<std::string>(song, "guitarRhythm").value_or(""));
 	loadStatus = Song::LoadStatus::HEADER;
 
 	for (size_t i = 0; i < getJsonEntry<size_t>(song, "vocalTracks").value_or(0); i++) {
@@ -192,7 +192,7 @@ VocalTrack& Song::getVocalTrack(unsigned idx) {
 double Song::getDurationSeconds() {
 	if(m_duration == 0.0 || m_duration < 1.0) {
 		AVFormatContext *pFormatCtx = avformat_alloc_context();
-		if (avformat_open_input(&pFormatCtx, music["background"].string().c_str(), nullptr, nullptr) == 0) {
+		if (avformat_open_input(&pFormatCtx, UnicodeUtil::convertToUTF8(music["background"].string()).c_str(), nullptr, nullptr) == 0) {
 			avformat_find_stream_info(pFormatCtx, nullptr);
 			m_duration = static_cast<double>(pFormatCtx->duration) / static_cast<double>(AV_TIME_BASE);
 			avformat_close_input(&pFormatCtx);

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -126,7 +126,7 @@ void Songs::LoadCache() {
 	std::vector<std::string> allPaths;
 	for(const auto& songPaths : {getPathsConfig("paths/system-songs"), getPathsConfig("paths/songs")}) {
 		for(const auto& songPath: songPaths) {
-			allPaths.push_back(songPath.string());
+			allPaths.push_back(UnicodeUtil::convertToUTF8(songPath.string()));
 		}
 	}
 
@@ -138,8 +138,8 @@ void Songs::LoadCache() {
 			[songPath](const std::string& userSongItem) {
 				return songPath.find(userSongItem) != std::string::npos;
 			}) != allPaths.end();
-		STAT buffer;
-		if(_STAT(songPath.c_str(), &buffer) == 0 && isSongPathInConfiguredPaths) {
+
+		if(fs::exists(UnicodeUtil::convertToUTF8(songPath)) && isSongPathInConfiguredPaths) {
 			auto realSong = std::make_shared<Song>(song);
 			std::unique_lock<std::shared_mutex> l(m_mutex);
 			m_songs.push_back(std::move(realSong));
@@ -153,10 +153,10 @@ void Songs::CacheSonglist() {
 	for (auto const& song : m_songs) {
 		auto songObject = nlohmann::json::object();
 		if(!song->path.string().empty()) {
-			songObject["txtFileFolder"] = song->path.string();
+			songObject["txtFileFolder"] = UnicodeUtil::convertToUTF8(song->path.string());
 		}
 		if(!song->filename.string().empty()) {
-			songObject["txtFile"] = song->filename.string();
+			songObject["txtFile"] = UnicodeUtil::convertToUTF8(song->filename.string());
 		}
 		if(!song->title.empty()) {
 			songObject["title"] = song->title;
@@ -177,19 +177,19 @@ void Songs::CacheSonglist() {
 			songObject["genre"] = song->genre;
 		}
 		if(!song->cover.string().empty()) {
-			songObject["cover"] = song->cover.string();
+			songObject["cover"] = UnicodeUtil::convertToUTF8(song->cover.string());
 		}
 		if(!song->background.string().empty()) {
-			songObject["background"] = song->background.string();
+			songObject["background"] = UnicodeUtil::convertToUTF8(song->background.string());
 		}
 		if(!song->music[TrackName::BGMUSIC].string().empty()) {
-			songObject["songFile"] = song->music[TrackName::BGMUSIC].string();
+			songObject["songFile"] = UnicodeUtil::convertToUTF8(song->music[TrackName::BGMUSIC].string());
 		}
 		if(!song->midifilename.string().empty()) {
-			songObject["midiFile"] = song->midifilename.string();
+			songObject["midiFile"] = UnicodeUtil::convertToUTF8(song->midifilename.string());
 		}
 		if(!song->video.string().empty()) {
-			songObject["videoFile"] = song->video.string();
+			songObject["videoFile"] = UnicodeUtil::convertToUTF8(song->video.string());
 		}
 		if(!std::isnan(song->start)) {
 			songObject["start"] = song->start;
@@ -201,40 +201,40 @@ void Songs::CacheSonglist() {
 			songObject["previewStart"] = song->preview_start;
 		}
 		if(!song->music[TrackName::VOCAL_LEAD].string().empty()) {
-			songObject["vocals"] = song->music[TrackName::VOCAL_LEAD].string();
+			songObject["vocals"] = UnicodeUtil::convertToUTF8(song->music[TrackName::VOCAL_LEAD].string());
 		}
 		if(!song->music[TrackName::VOCAL_BACKING].string().empty()) {
-			songObject["vocalsBacking"] = song->music[TrackName::VOCAL_BACKING].string();
+			songObject["vocalsBacking"] = UnicodeUtil::convertToUTF8(song->music[TrackName::VOCAL_BACKING].string());
 		}
 		if(!song->music[TrackName::PREVIEW].string().empty()) {
-			songObject["preview"] = song->music[TrackName::PREVIEW].string();
+			songObject["preview"] = UnicodeUtil::convertToUTF8(song->music[TrackName::PREVIEW].string());
 		}
 		if(!song->music[TrackName::GUITAR].string().empty()) {
-			songObject["guitar"] = song->music[TrackName::GUITAR].string();
+			songObject["guitar"] = UnicodeUtil::convertToUTF8(song->music[TrackName::GUITAR].string());
 		}
-		if(!song->music[TrackName::BASS].string().empty()) {
-			songObject["bass"] = song->music[TrackName::BASS].string();
+		if (!song->music[TrackName::BASS].string().empty()) {
+			songObject["bass"] = UnicodeUtil::convertToUTF8(song->music[TrackName::BASS].string());
 		}
-		if(!song->music[TrackName::DRUMS].string().empty()) {
-			songObject["drums"] = song->music[TrackName::DRUMS].string();
+		if (!song->music[TrackName::DRUMS].string().empty()) {
+			songObject["drums"] = UnicodeUtil::convertToUTF8(song->music[TrackName::DRUMS].string());
 		}
-		if(!song->music[TrackName::DRUMS_SNARE].string().empty()) {
-			songObject["drumsSnare"] = song->music[TrackName::DRUMS_SNARE].string();
+		if (!song->music[TrackName::DRUMS_SNARE].string().empty()) {
+			songObject["drumsSnare"] = UnicodeUtil::convertToUTF8(song->music[TrackName::DRUMS_SNARE].string());
 		}
-		if(!song->music[TrackName::DRUMS_CYMBALS].string().empty()) {
-			songObject["drumsCymbals"] = song->music[TrackName::DRUMS_CYMBALS].string();
+		if (!song->music[TrackName::DRUMS_CYMBALS].string().empty()) {
+			songObject["drumsCymbals"] = UnicodeUtil::convertToUTF8(song->music[TrackName::DRUMS_CYMBALS].string());
 		}
-		if(!song->music[TrackName::DRUMS_TOMS].string().empty()) {
-			songObject["drumsToms"] = song->music[TrackName::DRUMS_TOMS].string();
+		if (!song->music[TrackName::DRUMS_TOMS].string().empty()) {
+			songObject["drumsToms"] = UnicodeUtil::convertToUTF8(song->music[TrackName::DRUMS_TOMS].string());
 		}
-		if(!song->music[TrackName::KEYBOARD].string().empty()) {
-			songObject["keyboard"] = song->music[TrackName::KEYBOARD].string();
+		if (!song->music[TrackName::KEYBOARD].string().empty()) {
+			songObject["keyboard"] = UnicodeUtil::convertToUTF8(song->music[TrackName::KEYBOARD].string());
 		}
-		if(!song->music[TrackName::GUITAR_COOP].string().empty()) {
-			songObject["guitarCoop"] = song->music[TrackName::GUITAR_COOP].string();
+		if (!song->music[TrackName::GUITAR_COOP].string().empty()) {
+			songObject["guitarCoop"] = UnicodeUtil::convertToUTF8(song->music[TrackName::GUITAR_COOP].string());
 		}
-		if(!song->music[TrackName::GUITAR_RHYTHM].string().empty()) {
-			songObject["guitarRhythm"] = song->music[TrackName::GUITAR_RHYTHM].string();
+		if (!song->music[TrackName::GUITAR_RHYTHM].string().empty()) {
+			songObject["guitarRhythm"] = UnicodeUtil::convertToUTF8(song->music[TrackName::GUITAR_RHYTHM].string());
 		}
 
 		double duration = song->getDurationSeconds();
@@ -275,7 +275,7 @@ void Songs::reload_internal(fs::path const& parent) {
 				{
 					std::shared_lock<std::shared_mutex> l(m_mutex);
 					auto it = std::find_if(m_songs.begin(), m_songs.end(), [p](std::shared_ptr<Song> n) {
-						return n->filename == p;
+						return n->filename == UnicodeUtil::convertToUTF8(p.string());
 					});
 					auto const alreadyInCache =  it != m_songs.end();
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/performous/performous/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

This PR fixes an issue on windows that crashes Performous when importing songs with characters like `ö` and `’` while not having the beta utf8 support enabled in settings.

Without this change the `Song::getDurationSeconds` function crashes on `avformat_open_input` while supplying a path as mentioned above.
<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

#893 
<!-- List here all the issues closed by this pull request. -->

### Motivation

Running Performous on windows while not having to enable utf8 support.
<!-- What inspired you to submit this pull request? -->

### More

- [ ] Added/updated documentation

### Additional Notes

Tested on Win11 with the beta utf8 support disabled.
<!-- Anything else we should know when reviewing? -->
