### PR TITLE
Use DATADIR as installation path for the desktop file and the icon

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -3,8 +3,8 @@ set(PIXMAP_FILE      "themes/default/icon.svg")
 
 # Install launcher and fonts on system level
 if(UNIX AND NOT APPLE)
-	install(FILES "${APPLICATION_FILE}" DESTINATION "/usr/share/applications/")
-	install(FILES "${PIXMAP_FILE}" DESTINATION "/usr/share/pixmaps/" RENAME "performous.svg")
+	install(FILES "${APPLICATION_FILE}" DESTINATION "${CMAKE_INSTALL_DATADIR}/applications/")
+	install(FILES "${PIXMAP_FILE}" DESTINATION "${CMAKE_INSTALL_DATADIR}/pixmaps/" RENAME "performous.svg")
 endif()
 
 install(DIRECTORY backgrounds config fonts shaders sounds themes xsl DESTINATION ${SHARE_INSTALL})

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -4,7 +4,7 @@ set(PIXMAP_FILE      "themes/default/icon.svg")
 # Install launcher and fonts on system level
 if(UNIX AND NOT APPLE)
 	install(FILES "${APPLICATION_FILE}" DESTINATION "${CMAKE_INSTALL_DATADIR}/applications/")
-	install(FILES "${PIXMAP_FILE}" DESTINATION "${CMAKE_INSTALL_DATADIR}/pixmaps/" RENAME "performous.svg")
+	install(FILES "${PIXMAP_FILE}" DESTINATION "${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/apps/" RENAME "performous.svg")
 endif()
 
 install(DIRECTORY backgrounds config fonts shaders sounds themes xsl DESTINATION ${SHARE_INSTALL})


### PR DESCRIPTION
### What does this PR do?

This uses the DATADIR build-specified directory to install the desktop file and the icon.
It also uses the more standard DATADIR/icons/hicolor/scalable/apps directory instead of DATADIR/pixmaps.

Reference: https://specifications.freedesktop.org/icon-theme-spec/latest/ar01s03.html

### Motivation

Before this PR, the installation paths were hardcoded to `/usr/share`, which does not work well with a Flatpak installation, because everything is in `/app`