### PR TITLE
Add Appstream metadata

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,10 +1,12 @@
 set(APPLICATION_FILE "performous.desktop")
 set(PIXMAP_FILE      "themes/default/icon.svg")
+set(METAINFO_FILE      "performous.metainfo.xml")
 
 # Install launcher and fonts on system level
 if(UNIX AND NOT APPLE)
 	install(FILES "${APPLICATION_FILE}" DESTINATION "/usr/share/applications/")
 	install(FILES "${PIXMAP_FILE}" DESTINATION "/usr/share/pixmaps/" RENAME "performous.svg")
+    install(FILES "${METAINFO_FILE}" DESTINATION "${CMAKE_INSTALL_DATADIR}/metainfo/")
 endif()
 
 install(DIRECTORY backgrounds config fonts shaders sounds themes xsl DESTINATION ${SHARE_INSTALL})

--- a/data/performous.metainfo.xml
+++ b/data/performous.metainfo.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.performous.Performous</id>
+  <metadata_license>CC0</metadata_license>
+  <project_license>GPL-2.0-or-later</project_license>
+  <name>Performous</name>
+  <summary>Music and rhythm / party game</summary>
+  <description>
+    <p>
+      A karaoke, band and dancing game where one or more players perform a
+      song and the game scores their performances.
+    </p>
+    <p>
+      Supports songs in UltraStar, Frets on Fire and StepMania formats.
+      Microphones and instruments from SingStar, Guitar Hero and Rock Band
+      as well as some dance pads are auto-detected.
+    </p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image type="source" width="1536" height="96">http://performous.org/imgs/showcase.jpg</image>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://performous.org</url>
+  <content_rating type="oars-1.1" />
+  <launchable type="desktop-id">performous.desktop</launchable>
+  <releases>
+    <release version="1.2.0" date="2022-03-27">
+      <artifacts>
+        <artifact type="source">
+          <location>https://github.com/performous/performous/archive/refs/tags/1.2.0.tar.gz</location>
+          <checksum type="sha256">c88438bb3b9400a2254a99284375157534ae38befc48ba27254bc3b9e7ef50ef</checksum>
+        </artifact>
+      </artifacts>
+    </release>
+  </releases>
+</component>


### PR DESCRIPTION
### What does this PR do?

This PR adds the [Appstream](https://www.freedesktop.org/software/appstream/docs/) metadata file.

### Motivation

An Appstream metadata file is required to show up in gnome-software, or to be listed as a GUI application in Flatpak.

### Additional Notes

Reference: https://www.freedesktop.org/software/appstream/docs/

I've added the only screenshot I found on performous.org, but it's a carroussel, I'd perfer to add other higher-resolution screenshots if there are any.