### PR TITLE
Showing error for songs that do not contain audio.

### DIFF
--- a/data/themes/default/www/css/style.css
+++ b/data/themes/default/www/css/style.css
@@ -27,10 +27,6 @@
     width:14px;
 }
 
-.fixed-pixel-glyphicon {
-    width: 31px;
-}
-
 td {
     max-width: 0;
     overflow: hidden;

--- a/data/themes/default/www/database.html
+++ b/data/themes/default/www/database.html
@@ -18,6 +18,7 @@
 					<th class="hidden-xs"><a id="sort-by-language" href="#" data-sort-ascending="true">language<span class="glyphicon glyphicon-menu-down"></span></a></th>
 					<th class="hidden-xs hidden-sm"><a id="sort-by-edition" href="#" data-sort-ascending="true">edition<span class="glyphicon glyphicon-menu-down"></span></a></th>
 					<th class="hidden-xs hidden-sm hidden-md"><a id="sort-by-creator" href="#" data-sort-ascending="true">creator<span class="glyphicon glyphicon-menu-down"></span></a></th>
+					<th class="hidden-xs hidden-sm hidden-md">has_error</th>
 					<th></th>
 				</tr>
 			</table>

--- a/data/themes/default/www/js/playlist.js
+++ b/data/themes/default/www/js/playlist.js
@@ -1,4 +1,4 @@
-/*
+﻿/*
     Scripts related to the playlist tab.
     Most of these are click events on the playlist tab.
 */
@@ -23,8 +23,9 @@ $("#refresh-playlist").click(function () {
             $.each(database, function (iterator, songObject) {
                 totalTime += songObject.Duration + timeout;
                 var position = String(iterator + 1).padStart(2, '0') + ".";
-                $("#playlist-songs").append("<a id=\"playlist-songs-" + iterator + "\" href=\"#\" class=\"list-group-item\" data-toggle=\"modal\" data-target=\"#dynamic-modal\">" + position + " " + songObject.Artist + " - " + songObject.Title + " - " + secondsToDate(totalTime) + "<span class=\"glyphicon glyphicon-info-sign\"></span></a>");
-                $("#playlist-songs-sortable").append("<a id=\"playlist-songs-sortable-" + iterator + "\" href=\"#\" class=\"list-group-item\" data-toggle=\"modal\" data-target=\"#dynamic-modal\">" + position + " " + songObject.Artist + " - " + songObject.Title + " - " + secondsToDate(totalTime) + "<span class=\"glyphicon glyphicon-info-sign\"></span></a>");
+                var errorMeta = songObject.HasError ? "⚠️" : "";
+                $("#playlist-songs").append("<a id=\"playlist-songs-" + iterator + "\" href=\"#\" class=\"list-group-item\" data-toggle=\"modal\" data-target=\"#dynamic-modal\">" + errorMeta + position + " " + songObject.Artist + " - " + songObject.Title + " - " + secondsToDate(totalTime) + "<span class=\"glyphicon glyphicon-info-sign\"></span></a>");
+                $("#playlist-songs-sortable").append("<a id=\"playlist-songs-sortable-" + iterator + "\" href=\"#\" class=\"list-group-item\" data-toggle=\"modal\" data-target=\"#dynamic-modal\">" + errorMeta + position + " " + songObject.Artist + " - " + songObject.Title + " - " + secondsToDate(totalTime) + "<span class=\"glyphicon glyphicon-info-sign\"></span></a>");
                 songObject.Position = iterator;
                 songObject.PositionStr = position;
                 $("#playlist-songs-" + iterator).data("modal-songObject", JSON.stringify(songObject));

--- a/data/themes/default/www/js/search.js
+++ b/data/themes/default/www/js/search.js
@@ -1,4 +1,4 @@
-/*
+﻿/*
     Scripts related to the search tab.
     Most of these are click events on the search tab.
 */
@@ -53,7 +53,8 @@ $("#search-database").click(function (e, callback) {
                 var songMeta = "";
                 songMeta += songObject.Language.length > 0 ? " | " + songObject.Language : "";
                 songMeta += songObject.Edition.length > 0 ? " | " + songObject.Edition : "";
-                $("#searched-songs").append("<a href=\"#\" id=\"searched-songs-" + iterator + "\" class=\"list-group-item\" >" + songObject.Artist + " - " + songObject.Title + songMeta + "<span class=\"glyphicon glyphicon-plus\"></span></a>");
+                var errorMeta = songObject.HasError ? "⚠️" : "";
+                $("#searched-songs").append("<a href=\"#\" id=\"searched-songs-" + iterator + "\" class=\"list-group-item\" >" + errorMeta + songObject.Artist + " - " + songObject.Title + songMeta + "<span class=\"glyphicon glyphicon-plus\"></span></a>");
                 $("#searched-songs-"+iterator).data("songObject", JSON.stringify(songObject));
             });
 
@@ -84,7 +85,8 @@ $("#search-database").click(function (e, callback) {
                 var songMeta = "";
                 songMeta += songObject.Language.length > 0 ? " | " + songObject.Language : "";
                 songMeta += songObject.Edition.length > 0 ? " | " + songObject.Edition : "";
-                $("#searched-songs").append("<a href=\"#\" id=\"searched-songs-" + iterator + "\" class=\"list-group-item\" >" + songObject.Artist + " - " + songObject.Title + songMeta + "<span class=\"glyphicon glyphicon-plus\"></span></a>");
+                var errorMeta = songObject.HasError ? "⚠️" : "";
+                $("#searched-songs").append("<a href=\"#\" id=\"searched-songs-" + iterator + "\" class=\"list-group-item\" >" + errorMeta + songObject.Artist + " - " + songObject.Title + songMeta + "<span class=\"glyphicon glyphicon-plus\"></span></a>");
                 $("#searched-songs-"+iterator).data("songObject", JSON.stringify(songObject));
             });
 

--- a/data/themes/default/www/js/table.js
+++ b/data/themes/default/www/js/table.js
@@ -1,4 +1,4 @@
-/*
+﻿/*
     Helper functions for tables.
 */
 "use strict";
@@ -24,6 +24,8 @@ function buildTable(database) {
         r[++j] = database[key].Edition;
         r[++j] = "</td><td class='hidden-xs hidden-sm hidden-md'>";
         r[++j] = database[key].Creator;
+        r[++j] = "</td><td class='hidden-xs hidden-sm hidden-md'>";
+        r[++j] = database[key].HasError ? "⚠️" : "";
         r[++j] = "</td><td class='text-right text-nowrap fixed-pixel-glyphicon'>";
         r[++j] = "<span class='glyphicon glyphicon-plus'></span>";
         r[++j] = "</td></tr>";

--- a/game/requesthandler.cc
+++ b/game/requesthandler.cc
@@ -6,15 +6,15 @@
 
 #ifdef USE_WEBSERVER
 RequestHandler::RequestHandler(Game& game, Songs& songs)
-    : m_game(game), m_songs(songs) {
+	: m_game(game), m_songs(songs) {
 }
 
 RequestHandler::RequestHandler(Game& game, std::string url, Songs& songs)
-    : m_listener(utility::conversions::to_string_t(url)), m_game(game), m_songs(songs) {
-    m_listener.support(web::http::methods::GET, std::bind(&RequestHandler::Get, this, std::placeholders::_1));
-    m_listener.support(web::http::methods::PUT, std::bind(&RequestHandler::Put, this, std::placeholders::_1));
-    m_listener.support(web::http::methods::POST, std::bind(&RequestHandler::Post, this, std::placeholders::_1));
-    m_listener.support(web::http::methods::DEL, std::bind(&RequestHandler::Delete, this, std::placeholders::_1));
+	: m_listener(utility::conversions::to_string_t(url)), m_game(game), m_songs(songs) {
+	m_listener.support(web::http::methods::GET, std::bind(&RequestHandler::Get, this, std::placeholders::_1));
+	m_listener.support(web::http::methods::PUT, std::bind(&RequestHandler::Put, this, std::placeholders::_1));
+	m_listener.support(web::http::methods::POST, std::bind(&RequestHandler::Post, this, std::placeholders::_1));
+	m_listener.support(web::http::methods::DEL, std::bind(&RequestHandler::Delete, this, std::placeholders::_1));
 
 }
 
@@ -27,114 +27,114 @@ void RequestHandler::Error(pplx::task<void>& t) {
 }
 
 void RequestHandler::HandleFile(web::http::http_request request, std::string filePath) {
-    auto path = filePath != "" ? utility::conversions::to_utf8string(utility::conversions::to_string_t(filePath)) : utility::conversions::to_utf8string(request.relative_uri().path());
-    auto fileName = path.substr(path.find_last_of("/\\") + 1);
+	auto path = filePath != "" ? utility::conversions::to_utf8string(utility::conversions::to_string_t(filePath)) : utility::conversions::to_utf8string(request.relative_uri().path());
+	auto fileName = path.substr(path.find_last_of("/\\") + 1);
 
 	std::string fileToSend = findFile(fileName).string();
 
-    concurrency::streams::fstream::open_istream(utility::conversions::to_string_t(fileToSend), std::ios::in).then([=](concurrency::streams::istream is) {
-        std::string content_type = "";
-        if(path.find(".html") != std::string::npos) {
-            content_type = "text/html";
-        } else if(path.find(".js") != std::string::npos) {
-            content_type = "text/javascript";
-        } else if (path.find(".css") != std::string::npos) {
-            content_type = "text/css";
-        } else if (path.find(".png") != std::string::npos) {
-            content_type = "image/png";
-        } else if (path.find(".gif") != std::string::npos) {
-            content_type = "image/gif";
-        } else if (path.find(".ico") != std::string::npos) {
-            content_type = "image/x-icon";
-        }
+	concurrency::streams::fstream::open_istream(utility::conversions::to_string_t(fileToSend), std::ios::in).then([=](concurrency::streams::istream is) {
+		std::string content_type = "";
+		if(path.find(".html") != std::string::npos) {
+			content_type = "text/html";
+		} else if(path.find(".js") != std::string::npos) {
+			content_type = "text/javascript";
+		} else if (path.find(".css") != std::string::npos) {
+			content_type = "text/css";
+		} else if (path.find(".png") != std::string::npos) {
+			content_type = "image/png";
+		} else if (path.find(".gif") != std::string::npos) {
+			content_type = "image/gif";
+		} else if (path.find(".ico") != std::string::npos) {
+			content_type = "image/x-icon";
+		}
 
-        request.reply(web::http::status_codes::OK, is, utility::conversions::to_string_t(content_type)).then([](pplx::task<void> t) {
-            try {
-                t.get();
-            } catch(...){
-                //
-            }
-        });
+		request.reply(web::http::status_codes::OK, is, utility::conversions::to_string_t(content_type)).then([](pplx::task<void> t) {
+			try {
+				t.get();
+			} catch(...){
+				//
+			}
+		});
 
-    }).then([=](pplx::task<void>t) {
-        try {
-            t.get();
-        } catch(...) {
-            request.reply(web::http::status_codes::InternalError,utility::conversions::to_string_t("INTERNAL ERROR "));
-        }
-    });
+	}).then([=](pplx::task<void>t) {
+		try {
+			t.get();
+		} catch(...) {
+			request.reply(web::http::status_codes::InternalError,utility::conversions::to_string_t("INTERNAL ERROR "));
+		}
+	});
 }
 
 void RequestHandler::Get(web::http::http_request request)
 {
-    std::string content_type = "text/html";
-    auto uri = request.relative_uri().path();
-    auto query = utility::conversions::to_utf8string(request.relative_uri().query());
-    if(query != "") {
-        uri += utility::conversions::to_string_t("?") + request.relative_uri().query();
-    }
-    std::clog << "requesthandler/debug: path is: " << utility::conversions::to_utf8string(uri) << std::endl;
-    auto path = utility::conversions::to_utf8string(request.relative_uri().path());
-    if (path == "/") {
-        HandleFile(request, findFile("index.html").string());
-    } else if (path == "/api/getDataBase.json") { //get database
-        m_songs.setFilter("");
-        if(query == "sort=artist&order=ascending") {
-            m_songs.sortSpecificChange(2);
-        } else if(query == "sort=artist&order=descending") {
-            m_songs.sortSpecificChange(2, true);
-        } else if(query == "sort=title&order=ascending") {
-            m_songs.sortSpecificChange(1);
-        } else if(query == "sort=title&order=descending") {
-            m_songs.sortSpecificChange(1, true);
-        } else if(query == "sort=language&order=ascending") {
-            m_songs.sortSpecificChange(6);
-        } else if(query == "sort=language&order=descending") {
-            m_songs.sortSpecificChange(6, true);
-        } else if(query == "sort=edition&order=ascending") {
-            m_songs.sortSpecificChange(3);
-        } else if(query == "sort=edition&order=descending") {
-            m_songs.sortSpecificChange(3, true);
-        } else if(query == "sort=creator&order=ascending") {
-            m_songs.sortSpecificChange(10);
-        } else if(query == "sort=creator&order=descending") {
-            m_songs.sortSpecificChange(10, true);
-        }
-        // make sure to apply the filtering
-        m_songs.update();
-        web::json::value jsonRoot = SongsToJsonObject();
-        request.reply(web::http::status_codes::OK, jsonRoot);
-        return;
-    }  else if(path == "/api/language") {
-        auto localeMap = GenerateLocaleDict();
-        web::json::value jsonRoot = web::json::value::object();
-            for (auto const &kv : localeMap) {
-                std::string key = kv.first;
-                //Hack to get an easy key value pair within the json object.
-                if(key == "Web interface by Niek Nooijens and Arjan Speiard, for full credits regarding Performous see /docs/Authors.txt"){
-                    key = "Credits";
-                }
-                std::replace(key.begin(), key.end(), ' ','_');
-                key = UnicodeUtil::toLower(key);
-                jsonRoot[utility::conversions::to_string_t(key)] = web::json::value(utility::conversions::to_string_t(kv.second));
-            }
-        request.reply(web::http::status_codes::OK, jsonRoot);
-        return;
-    } else if(path == "/api/getCurrentPlaylist.json") {
-        web::json::value jsonRoot = web::json::value::array();
-        unsigned i = 0;
-        for (auto const& song : m_game.getCurrentPlayList().getList()) {
-            web::json::value songObject = web::json::value::object();
-            songObject[utility::conversions::to_string_t("Title")] = web::json::value::string(utility::conversions::to_string_t(song->title));
-            songObject[utility::conversions::to_string_t("Artist")] = web::json::value::string(utility::conversions::to_string_t(song->artist));
-            songObject[utility::conversions::to_string_t("Edition")] = web::json::value::string(utility::conversions::to_string_t(song->edition));
-            songObject[utility::conversions::to_string_t("Language")] = web::json::value::string(utility::conversions::to_string_t(song->language));
-            songObject[utility::conversions::to_string_t("Creator")] = web::json::value::string(utility::conversions::to_string_t(song->creator));
-            songObject[utility::conversions::to_string_t("Duration")] = web::json::value(song->getDurationSeconds());
-            songObject[utility::conversions::to_string_t("HasError")] = web::json::value::boolean(song->loadStatus == Song::LoadStatus::ERROR);
-            jsonRoot[i] = songObject;
-            i++;
-        }
+	std::string content_type = "text/html";
+	auto uri = request.relative_uri().path();
+	auto query = utility::conversions::to_utf8string(request.relative_uri().query());
+	if(query != "") {
+		uri += utility::conversions::to_string_t("?") + request.relative_uri().query();
+	}
+	std::clog << "requesthandler/debug: path is: " << utility::conversions::to_utf8string(uri) << std::endl;
+	auto path = utility::conversions::to_utf8string(request.relative_uri().path());
+	if (path == "/") {
+		HandleFile(request, findFile("index.html").string());
+	} else if (path == "/api/getDataBase.json") { //get database
+		m_songs.setFilter("");
+		if(query == "sort=artist&order=ascending") {
+			m_songs.sortSpecificChange(2);
+		} else if(query == "sort=artist&order=descending") {
+			m_songs.sortSpecificChange(2, true);
+		} else if(query == "sort=title&order=ascending") {
+			m_songs.sortSpecificChange(1);
+		} else if(query == "sort=title&order=descending") {
+			m_songs.sortSpecificChange(1, true);
+		} else if(query == "sort=language&order=ascending") {
+			m_songs.sortSpecificChange(6);
+		} else if(query == "sort=language&order=descending") {
+			m_songs.sortSpecificChange(6, true);
+		} else if(query == "sort=edition&order=ascending") {
+			m_songs.sortSpecificChange(3);
+		} else if(query == "sort=edition&order=descending") {
+			m_songs.sortSpecificChange(3, true);
+		} else if(query == "sort=creator&order=ascending") {
+			m_songs.sortSpecificChange(10);
+		} else if(query == "sort=creator&order=descending") {
+			m_songs.sortSpecificChange(10, true);
+		}
+		// make sure to apply the filtering
+		m_songs.update();
+		web::json::value jsonRoot = SongsToJsonObject();
+		request.reply(web::http::status_codes::OK, jsonRoot);
+		return;
+	}  else if(path == "/api/language") {
+		auto localeMap = GenerateLocaleDict();
+		web::json::value jsonRoot = web::json::value::object();
+			for (auto const &kv : localeMap) {
+				std::string key = kv.first;
+				//Hack to get an easy key value pair within the json object.
+				if(key == "Web interface by Niek Nooijens and Arjan Speiard, for full credits regarding Performous see /docs/Authors.txt"){
+					key = "Credits";
+				}
+				std::replace(key.begin(), key.end(), ' ','_');
+				key = UnicodeUtil::toLower(key);
+				jsonRoot[utility::conversions::to_string_t(key)] = web::json::value(utility::conversions::to_string_t(kv.second));
+			}
+		request.reply(web::http::status_codes::OK, jsonRoot);
+		return;
+	} else if(path == "/api/getCurrentPlaylist.json") {
+		web::json::value jsonRoot = web::json::value::array();
+		unsigned i = 0;
+		for (auto const& song : m_game.getCurrentPlayList().getList()) {
+			web::json::value songObject = web::json::value::object();
+			songObject[utility::conversions::to_string_t("Title")] = web::json::value::string(utility::conversions::to_string_t(song->title));
+			songObject[utility::conversions::to_string_t("Artist")] = web::json::value::string(utility::conversions::to_string_t(song->artist));
+			songObject[utility::conversions::to_string_t("Edition")] = web::json::value::string(utility::conversions::to_string_t(song->edition));
+			songObject[utility::conversions::to_string_t("Language")] = web::json::value::string(utility::conversions::to_string_t(song->language));
+			songObject[utility::conversions::to_string_t("Creator")] = web::json::value::string(utility::conversions::to_string_t(song->creator));
+			songObject[utility::conversions::to_string_t("Duration")] = web::json::value(song->getDurationSeconds());
+			songObject[utility::conversions::to_string_t("HasError")] = web::json::value::boolean(song->loadStatus == Song::LoadStatus::ERROR);
+			jsonRoot[i] = songObject;
+			i++;
+		}
 
 		request.reply(web::http::status_codes::OK, jsonRoot);
 		return;
@@ -148,14 +148,14 @@ void RequestHandler::Get(web::http::http_request request)
 
 void RequestHandler::Post(web::http::http_request request)
 {
-    auto uri = request.relative_uri().path();
-    auto query = utility::conversions::to_utf8string(request.relative_uri().query());
-    if(query != "") {
-        uri += utility::conversions::to_string_t("?") + request.relative_uri().query();
-    }
-    std::clog << "requesthandler/debug: path is: " << utility::conversions::to_utf8string(uri) << std::endl;
+	auto uri = request.relative_uri().path();
+	auto query = utility::conversions::to_utf8string(request.relative_uri().query());
+	if(query != "") {
+		uri += utility::conversions::to_string_t("?") + request.relative_uri().query();
+	}
+	std::clog << "requesthandler/debug: path is: " << utility::conversions::to_utf8string(uri) << std::endl;
 
-    auto path = utility::conversions::to_utf8string(request.relative_uri().path());
+	auto path = utility::conversions::to_utf8string(request.relative_uri().path());
 
 	web::json::value jsonPostBody = ExtractJsonFromRequest(request);
 
@@ -164,98 +164,97 @@ void RequestHandler::Post(web::http::http_request request)
 		return;
 	}
 
-    if (path == "/api/add") {
-        m_songs.setFilter("");
-        std::shared_ptr<Song> songPointer = GetSongFromJSON(jsonPostBody);
-        if(!songPointer) {
-            auto artist = utility::conversions::to_utf8string(jsonPostBody[utility::conversions::to_string_t("Artist")].as_string());
-            auto title = utility::conversions::to_utf8string(jsonPostBody[utility::conversions::to_string_t("Title")].as_string());
-            request.reply(web::http::status_codes::NotFound, "Song \"" + artist + " - " + title + "\" was not found.");
-            return;
-        }
-        else if (songPointer->loadStatus == Song::LoadStatus::ERROR)
-        {
-	    auto artist = utility::conversions::to_utf8string(jsonPostBody[utility::conversions::to_string_t("Artist")].as_string());
-            auto title = utility::conversions::to_utf8string(jsonPostBody[utility::conversions::to_string_t("Title")].as_string());
-            request.reply(web::http::status_codes::NotFound, "Song \"" + artist + " - " + title + "\" Song load status is error. Please check what's wrong with it.");
-            return;
-        }
-        else {
-            std::clog << "requesthandler/debug: Adding " << songPointer->artist << " - " << songPointer->title << " to the playlist " << std::endl;
-            m_game.getCurrentPlayList().addSong(songPointer);
-            ScreenPlaylist* m_pp = dynamic_cast<ScreenPlaylist*>(m_game.getScreen("Playlist"));
-            m_pp->triggerSongListUpdate();
+	if (path == "/api/add") {
+		m_songs.setFilter("");
+		std::shared_ptr<Song> songPointer = GetSongFromJSON(jsonPostBody);
+		if(!songPointer) {
+			auto artist = utility::conversions::to_utf8string(jsonPostBody[utility::conversions::to_string_t("Artist")].as_string());
+			auto title = utility::conversions::to_utf8string(jsonPostBody[utility::conversions::to_string_t("Title")].as_string());
+			request.reply(web::http::status_codes::NotFound, "Song \"" + artist + " - " + title + "\" was not found.");
+			return;
+		}
+		else if (songPointer->loadStatus == Song::LoadStatus::ERROR) {
+			auto artist = utility::conversions::to_utf8string(jsonPostBody[utility::conversions::to_string_t("Artist")].as_string());
+			auto title = utility::conversions::to_utf8string(jsonPostBody[utility::conversions::to_string_t("Title")].as_string());
+			request.reply(web::http::status_codes::NotFound, "Song \"" + artist + " - " + title + "\" Song load status is error. Please check what's wrong with it.");
+			return;
+		}
+		else {
+			std::clog << "requesthandler/debug: Adding " << songPointer->artist << " - " << songPointer->title << " to the playlist " << std::endl;
+			m_game.getCurrentPlayList().addSong(songPointer);
+			ScreenPlaylist* m_pp = dynamic_cast<ScreenPlaylist*>(m_game.getScreen("Playlist"));
+			m_pp->triggerSongListUpdate();
 
-            request.reply(web::http::status_codes::OK, "success");
-            return;
-        }
-    } else if(path == "/api/remove") {
-        if(m_game.getCurrentPlayList().isEmpty()) {
-            request.reply(web::http::status_codes::BadRequest, "Playlist is empty.");
-            return;
-        }
-        try {
-            unsigned songIdToDelete = jsonPostBody[utility::conversions::to_string_t("songId")].as_number().to_uint32();
-            m_game.getCurrentPlayList().removeSong(songIdToDelete);
-            ScreenPlaylist* m_pp = dynamic_cast<ScreenPlaylist*>(m_game.getScreen("Playlist"));
-            m_pp->triggerSongListUpdate();
+			request.reply(web::http::status_codes::OK, "success");
+			return;
+		}
+	} else if(path == "/api/remove") {
+		if(m_game.getCurrentPlayList().isEmpty()) {
+			request.reply(web::http::status_codes::BadRequest, "Playlist is empty.");
+			return;
+		}
+		try {
+			unsigned songIdToDelete = jsonPostBody[utility::conversions::to_string_t("songId")].as_number().to_uint32();
+			m_game.getCurrentPlayList().removeSong(songIdToDelete);
+			ScreenPlaylist* m_pp = dynamic_cast<ScreenPlaylist*>(m_game.getScreen("Playlist"));
+			m_pp->triggerSongListUpdate();
 
-            request.reply(web::http::status_codes::OK, "success");
-            return;
-        } catch(web::json::json_exception const & e) {
-            std::string str = std::string("JSON Exception: ") + e.what();
-            request.reply(web::http::status_codes::BadRequest, str);
-            return;
-        }
-    } else if(path == "/api/setposition") {
-        if(m_game.getCurrentPlayList().isEmpty()) {
-            request.reply(web::http::status_codes::BadRequest, "Playlist is empty.");
-            return;
-        }
-        try {
-            unsigned songIdToMove = jsonPostBody[utility::conversions::to_string_t("songId")].as_number().to_uint32();
-            unsigned positionToMoveTo = jsonPostBody[utility::conversions::to_string_t("position")].as_number().to_uint32();
-            unsigned sizeOfPlaylist = static_cast<unsigned>(m_game.getCurrentPlayList().getList().size());
-            if (songIdToMove > sizeOfPlaylist - 1) {
-                request.reply(web::http::status_codes::BadRequest, "Not gonna move the unknown song you've provided \"" + std::to_string(songIdToMove + 1) + "\". Please make a valid request.");
-                return;
-            }
-            if (positionToMoveTo <= sizeOfPlaylist - 1) {
-                m_game.getCurrentPlayList().move(songIdToMove, positionToMoveTo);
-                ScreenPlaylist* m_pp = dynamic_cast<ScreenPlaylist*>(m_game.getScreen("Playlist"));
-                m_pp->triggerSongListUpdate();
-                request.reply(web::http::status_codes::OK, "success");
-                return;
-            }
-            else {
-                request.reply(web::http::status_codes::BadRequest, "Not gonna move the song to \"" + std::to_string(positionToMoveTo + 1) + "\" since the list ain't that long. Please make a valid request.");
-                return;
-            }
-        } catch(web::json::json_exception const & e) {
-            std::string str = std::string("JSON Exception: ") + e.what();
-            request.reply(web::http::status_codes::BadRequest, str);
-            return;
-        }
-    } else if(path == "/api/search") {
-        auto query = utility::conversions::to_utf8string(jsonPostBody[utility::conversions::to_string_t("query")].as_string());
-        m_songs.setFilter(query);
-        web::json::value jsonRoot = web::json::value::array();
-        for(size_t i = 0; i < m_songs.size(); i++) {
-            web::json::value songObject = web::json::value::object();
-            songObject[utility::conversions::to_string_t("Title")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->title));
-            songObject[utility::conversions::to_string_t("Artist")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->artist));
-            songObject[utility::conversions::to_string_t("Edition")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->edition));
-            songObject[utility::conversions::to_string_t("Language")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->language));
-            songObject[utility::conversions::to_string_t("Creator")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->creator));
-            songObject[utility::conversions::to_string_t("HasError")] = web::json::value::boolean(m_songs[i]->loadStatus == Song::LoadStatus::ERROR);
-            jsonRoot[i] = songObject;
-        }
-        request.reply(web::http::status_codes::OK, jsonRoot);
-        return;
-    } else {
-        request.reply(web::http::status_codes::NotFound, "The path \""+ path +"\" was not found.");
-        return;
-    }
+			request.reply(web::http::status_codes::OK, "success");
+			return;
+		} catch(web::json::json_exception const & e) {
+			std::string str = std::string("JSON Exception: ") + e.what();
+			request.reply(web::http::status_codes::BadRequest, str);
+			return;
+		}
+	} else if(path == "/api/setposition") {
+		if(m_game.getCurrentPlayList().isEmpty()) {
+			request.reply(web::http::status_codes::BadRequest, "Playlist is empty.");
+			return;
+		}
+		try {
+			unsigned songIdToMove = jsonPostBody[utility::conversions::to_string_t("songId")].as_number().to_uint32();
+			unsigned positionToMoveTo = jsonPostBody[utility::conversions::to_string_t("position")].as_number().to_uint32();
+			unsigned sizeOfPlaylist = static_cast<unsigned>(m_game.getCurrentPlayList().getList().size());
+			if (songIdToMove > sizeOfPlaylist - 1) {
+				request.reply(web::http::status_codes::BadRequest, "Not gonna move the unknown song you've provided \"" + std::to_string(songIdToMove + 1) + "\". Please make a valid request.");
+				return;
+			}
+			if (positionToMoveTo <= sizeOfPlaylist - 1) {
+				m_game.getCurrentPlayList().move(songIdToMove, positionToMoveTo);
+				ScreenPlaylist* m_pp = dynamic_cast<ScreenPlaylist*>(m_game.getScreen("Playlist"));
+				m_pp->triggerSongListUpdate();
+				request.reply(web::http::status_codes::OK, "success");
+				return;
+			}
+			else {
+				request.reply(web::http::status_codes::BadRequest, "Not gonna move the song to \"" + std::to_string(positionToMoveTo + 1) + "\" since the list ain't that long. Please make a valid request.");
+				return;
+			}
+		} catch(web::json::json_exception const & e) {
+			std::string str = std::string("JSON Exception: ") + e.what();
+			request.reply(web::http::status_codes::BadRequest, str);
+			return;
+		}
+	} else if(path == "/api/search") {
+		auto query = utility::conversions::to_utf8string(jsonPostBody[utility::conversions::to_string_t("query")].as_string());
+		m_songs.setFilter(query);
+		web::json::value jsonRoot = web::json::value::array();
+		for(size_t i = 0; i < m_songs.size(); i++) {
+			web::json::value songObject = web::json::value::object();
+			songObject[utility::conversions::to_string_t("Title")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->title));
+			songObject[utility::conversions::to_string_t("Artist")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->artist));
+			songObject[utility::conversions::to_string_t("Edition")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->edition));
+			songObject[utility::conversions::to_string_t("Language")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->language));
+			songObject[utility::conversions::to_string_t("Creator")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->creator));
+			songObject[utility::conversions::to_string_t("HasError")] = web::json::value::boolean(m_songs[i]->loadStatus == Song::LoadStatus::ERROR);
+			jsonRoot[i] = songObject;
+		}
+		request.reply(web::http::status_codes::OK, jsonRoot);
+		return;
+	} else {
+		request.reply(web::http::status_codes::NotFound, "The path \""+ path +"\" was not found.");
+		return;
+	}
 }
 
 void RequestHandler::Delete(web::http::http_request request)
@@ -287,18 +286,18 @@ web::json::value RequestHandler::ExtractJsonFromRequest(web::http::http_request 
 
 
 web::json::value RequestHandler::SongsToJsonObject() {
-    web::json::value jsonRoot = web::json::value::array();
-    for (size_t i=0; i< m_songs.size(); i++) {
-        web::json::value songObject = web::json::value::object();
-        songObject[utility::conversions::to_string_t("Title")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->title));
-        songObject[utility::conversions::to_string_t("Artist")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->artist));
-        songObject[utility::conversions::to_string_t("Edition")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->edition));
-        songObject[utility::conversions::to_string_t("Language")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->language));
-        songObject[utility::conversions::to_string_t("Creator")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->creator));
-        songObject[utility::conversions::to_string_t("name")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->artist + " " + m_songs[i]->title));
-        songObject[utility::conversions::to_string_t("HasError")] = web::json::value::boolean(m_songs[i]->loadStatus == Song::LoadStatus::ERROR);
-        jsonRoot[i] = songObject;
-    }
+	web::json::value jsonRoot = web::json::value::array();
+	for (size_t i=0; i< m_songs.size(); i++) {
+		web::json::value songObject = web::json::value::object();
+		songObject[utility::conversions::to_string_t("Title")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->title));
+		songObject[utility::conversions::to_string_t("Artist")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->artist));
+		songObject[utility::conversions::to_string_t("Edition")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->edition));
+		songObject[utility::conversions::to_string_t("Language")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->language));
+		songObject[utility::conversions::to_string_t("Creator")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->creator));
+		songObject[utility::conversions::to_string_t("name")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->artist + " " + m_songs[i]->title));
+		songObject[utility::conversions::to_string_t("HasError")] = web::json::value::boolean(m_songs[i]->loadStatus == Song::LoadStatus::ERROR);
+		jsonRoot[i] = songObject;
+	}
 
 	return jsonRoot;
 }
@@ -306,16 +305,16 @@ web::json::value RequestHandler::SongsToJsonObject() {
 std::shared_ptr<Song> RequestHandler::GetSongFromJSON(web::json::value jsonDoc) {
 	m_songs.setFilter("");
 
-    for(size_t i = 0; i< m_songs.size(); i++) {
-        if(m_songs[i]->title == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Title")].as_string()) &&
-           m_songs[i]->artist == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Artist")].as_string()) &&
-           m_songs[i]->edition == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Edition")].as_string()) &&
-           m_songs[i]->language == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Language")].as_string()) &&
-           m_songs[i]->creator == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Creator")].as_string()) ) {
-            std::clog << "webserver/info: Found requested song." << std::endl;
-            return m_songs[i];
-        }
-    }
+	for(size_t i = 0; i< m_songs.size(); i++) {
+		if(m_songs[i]->title == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Title")].as_string()) &&
+		   m_songs[i]->artist == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Artist")].as_string()) &&
+		   m_songs[i]->edition == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Edition")].as_string()) &&
+		   m_songs[i]->language == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Language")].as_string()) &&
+		   m_songs[i]->creator == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Creator")].as_string()) ) {
+			std::clog << "webserver/info: Found requested song." << std::endl;
+			return m_songs[i];
+		}
+	}
 
 	std::clog << "webserver/info: Couldn't find requested song." << std::endl;
 	return std::shared_ptr<Song>();
@@ -372,7 +371,7 @@ std::vector<std::string> RequestHandler::GetTranslationKeys() {
 		translate_noop("Successfully added song to the playlist."),
 		translate_noop("Failed adding song to the playlist!"),
 		translate_noop("No songs found with current filter."),
-        translate_noop("Has error")
+		translate_noop("Has error")
 	};
 
 	return tranlationKeys;

--- a/game/requesthandler.cc
+++ b/game/requesthandler.cc
@@ -168,12 +168,16 @@ void RequestHandler::Post(web::http::http_request request)
         m_songs.setFilter("");
         std::shared_ptr<Song> songPointer = GetSongFromJSON(jsonPostBody);
         if(!songPointer) {
-            request.reply(web::http::status_codes::NotFound, "Song \"" + utility::conversions::to_utf8string(jsonPostBody[utility::conversions::to_string_t("Artist")].as_string()) + " - " + utility::conversions::to_utf8string(jsonPostBody[utility::conversions::to_string_t("Title")].as_string()) + "\" was not found.");
+            auto artist = utility::conversions::to_utf8string(jsonPostBody[utility::conversions::to_string_t("Artist")].as_string());
+            auto title = utility::conversions::to_utf8string(jsonPostBody[utility::conversions::to_string_t("Title")].as_string());
+            request.reply(web::http::status_codes::NotFound, "Song \"" + artist + " - " + title + "\" was not found.");
             return;
         }
         else if (songPointer->loadStatus == Song::LoadStatus::ERROR)
         {
-            request.reply(web::http::status_codes::NotFound, "Song \"" + utility::conversions::to_utf8string(jsonPostBody[utility::conversions::to_string_t("Artist")].as_string()) + " - " + utility::conversions::to_utf8string(jsonPostBody[utility::conversions::to_string_t("Title")].as_string()) + "\" Song load status is error. Please check what's wrong with it.");
+	    auto artist = utility::conversions::to_utf8string(jsonPostBody[utility::conversions::to_string_t("Artist")].as_string());
+            auto title = utility::conversions::to_utf8string(jsonPostBody[utility::conversions::to_string_t("Title")].as_string());
+            request.reply(web::http::status_codes::NotFound, "Song \"" + artist + " - " + title + "\" Song load status is error. Please check what's wrong with it.");
             return;
         }
         else {

--- a/game/screen_songs.cc
+++ b/game/screen_songs.cc
@@ -218,9 +218,16 @@ void ScreenSongs::update() {
 
 bool ScreenSongs::addSong() {
 	auto& pl = getGame().getCurrentPlayList();
-	bool empty = pl.getList().empty();
-	pl.addSong(m_songs.currentPtr());
-	return empty;
+	auto song = m_songs.currentPtr();
+	if (song->loadStatus != Song::LoadStatus::ERROR) {
+		pl.addSong(song);
+	}
+	else {
+		getGame().dialog(_("Song load status is error. Please check what's wrong with it."));
+	}
+	auto size = pl.getList().size();
+
+	return size == 1;
 }
 
 void ScreenSongs::sing() {

--- a/game/song.cc
+++ b/game/song.cc
@@ -44,7 +44,8 @@ Song::Song(nlohmann::json const& song): dummyVocal(TrackName::VOCAL_LEAD), rando
 	music[TrackName::KEYBOARD] = getJsonEntry<std::string>(song, "keyboard").value_or("");
 	music[TrackName::GUITAR_COOP] = getJsonEntry<std::string>(song, "guitarCoop").value_or("");
 	music[TrackName::GUITAR_RHYTHM] = getJsonEntry<std::string>(song, "guitarRhythm").value_or("");
-	loadStatus = Song::LoadStatus::HEADER;
+	loadStatus = static_cast<Song::LoadStatus>(getJsonEntry<int>(song, "loadStatus").value_or(1));
+	//loadStatus = Song::LoadStatus::HEADER;
 
 	for (size_t i = 0; i < getJsonEntry<size_t>(song, "vocalTracks").value_or(0); i++) {
 		std::string track = "DummyTrack" + std::to_string(i);
@@ -192,7 +193,7 @@ VocalTrack& Song::getVocalTrack(unsigned idx) {
 double Song::getDurationSeconds() {
 	if(m_duration == 0.0 || m_duration < 1.0) {
 		AVFormatContext *pFormatCtx = avformat_alloc_context();
-		if (avformat_open_input(&pFormatCtx, music["background"].string().c_str(), nullptr, nullptr) == 0) {
+		if (avformat_open_input(&pFormatCtx, music[TrackName::BGMUSIC].string().c_str(), nullptr, nullptr) == 0) {
 			avformat_find_stream_info(pFormatCtx, nullptr);
 			m_duration = static_cast<double>(pFormatCtx->duration) / static_cast<double>(AV_TIME_BASE);
 			avformat_close_input(&pFormatCtx);

--- a/game/song.hh
+++ b/game/song.hh
@@ -39,7 +39,7 @@ class Song {
 	friend class SongParser;
 public:
 	/// Is the song parsed from the file yet?
-	enum class LoadStatus { NONE, HEADER, FULL } loadStatus = LoadStatus::NONE;
+	enum class LoadStatus { NONE = 0, HEADER = 1, FULL = 2, ERROR = -1 } loadStatus = LoadStatus::NONE;
 	/// status of song
 	enum class Status { NORMAL, INSTRUMENTAL_BREAK, FINISHED };
 	VocalTracks vocalTracks; ///< notes for the sing part

--- a/game/songparser-txt.cc
+++ b/game/songparser-txt.cc
@@ -23,6 +23,11 @@ void SongParser::txtParseHeader() {
 	s.insertVocalTrack(TrackName::VOCAL_LEAD, VocalTrack(TrackName::VOCAL_LEAD)); // Dummy note to indicate there is a track
 	while (getline(line) && txtParseField(line)) {}
 	if (s.title.empty() || s.artist.empty()) throw std::runtime_error("Required header fields missing");
+	if (!fs::exists(s.music[TrackName::BGMUSIC]))
+	{
+		s.loadStatus = Song::LoadStatus::ERROR;
+		std::clog << "songparser/error: Required MP3 '" << s.music[TrackName::BGMUSIC].string() << "' file isn't available." << std::endl;
+	}
 	if (m_bpm != 0.0f) addBPM(0, m_bpm);
 }
 
@@ -121,8 +126,8 @@ bool SongParser::txtParseField(std::string const& line) {
 	else if (key == "GENRE") m_song.genre = value.substr(value.find_first_not_of(" "));
 	else if (key == "CREATOR") m_song.creator = value.substr(value.find_first_not_of(" "));
 	else if (key == "COVER") m_song.cover = absolute(value, m_song.path);
-	else if (key == "MP3") m_song.music["background"] = absolute(value, m_song.path);
-	else if (key == "VOCALS") m_song.music["vocals"] = absolute(value, m_song.path);
+	else if (key == "MP3") m_song.music[TrackName::BGMUSIC] = absolute(value, m_song.path);
+	else if (key == "VOCALS") m_song.music[TrackName::VOCAL_LEAD] = absolute(value, m_song.path);
 	else if (key == "VIDEO") m_song.video = absolute(value, m_song.path);
 	else if (key == "BACKGROUND") m_song.background = absolute(value, m_song.path);
 	else if (key == "START") assign(m_song.start, value);

--- a/game/songparser.cc
+++ b/game/songparser.cc
@@ -112,8 +112,10 @@ SongParser::SongParser(Song& s): m_song(s) {
 		}
 		guessFiles();
 		if (!m_song.midifilename.empty()) {midParseHeader(); }
-
-		s.loadStatus = Song::LoadStatus::HEADER;
+		if(s.loadStatus != Song::LoadStatus::ERROR)
+		{
+			s.loadStatus = Song::LoadStatus::HEADER;
+		}
 	} catch (SongParserException&) {
 		throw;
 	} catch (std::runtime_error& e) {

--- a/game/songparser.cc
+++ b/game/songparser.cc
@@ -112,8 +112,7 @@ SongParser::SongParser(Song& s): m_song(s) {
 		}
 		guessFiles();
 		if (!m_song.midifilename.empty()) {midParseHeader(); }
-		if(s.loadStatus != Song::LoadStatus::ERROR)
-		{
+		if(s.loadStatus != Song::LoadStatus::ERROR) {
 			s.loadStatus = Song::LoadStatus::HEADER;
 		}
 	} catch (SongParserException&) {

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -253,6 +253,7 @@ void Songs::CacheSonglist() {
 		songObject["drumTracks"] = song->hasDrums();
 		songObject["danceTracks"] = song->hasDance();
 		songObject["guitarTracks"] = song->hasGuitars();
+		songObject["loadStatus"] = static_cast<int>(song->loadStatus);
 		if(songObject != nlohmann::json::object()) {
 			jsonRoot.push_back(songObject);
 		}


### PR DESCRIPTION
### What does this PR do?

The awesome project of https://github.com/bohning/usdb_syncer creates txt files without mandatoring the mp3 file to be there.
These files get loaded within performous but the songs won't work since there's no audio. For the keen eye, if you enabled autoplay with a certain timeout. You could identify this by seeing the offset of the timeout (in my case 10 seconds) as the duration for the song when added to the queue. This is not really a good way to tell the user it's a faulty song.

This feature tries to solve that issue.

From the webserver point you get to see:
Searching for a song:
![image](https://github.com/performous/performous/assets/3918517/4338bcd8-ad23-407e-96b2-a75d4a55b913)

Adding a faulty song:
![image](https://github.com/performous/performous/assets/3918517/6020f7bf-0ff1-498a-ae26-4f7346371049)

Database view:
![image](https://github.com/performous/performous/assets/3918517/d42f8fb3-ce0d-4673-80a1-57b21f41bc83)

From within performous you'll get a message that the song couldn't be opened:
![image](https://github.com/performous/performous/assets/3918517/a18da362-5066-4b55-900a-086596c6a777)

### Closes Issue(s)

# Closes #127

### Motivation

Telling the enduser to be able to play the song, but it can't be played is not nice. So we shouldn't do this.
This tells the user something is up with the song, please check later.

### More

- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
When you fixed the song one should bust the cache entirely.
Tried to make it auto-bust but we have a thing called "guessFiles" which is fucking this up. Can be done at a later time when we refactor this.