### PR TITLE
Runner on macOS13

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,7 +24,7 @@ jobs:
   # Create the MacOS dmg
   MacOS_Packages:
     name: Create MacOS dmg
-    runs-on: macos-latest
+    runs-on: macos-13
     env:
       MACOS_DEPS: >-
         aubio


### PR DESCRIPTION
### What does this PR do?

* Updates the macos runner to Ventura (13)
<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

Performous 1.3.0 (from release) can't run on certain devices...

### Motivation

<!-- What inspired you to submit this pull request? -->
Trying to get Performous working again on macos

### More

- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
