### PR TITLE
Change from NEVER to AUTO for ced, aubio and json in cmake

### DIFF
--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -121,9 +121,10 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(deps REQUIRED IMPORTED_TARGET glib-2.0 gio-2.0 gobject-2.0)
 
 set(SELF_BUILT_GIT_BASE "https://github.com/performous" CACHE STRING "base path of the git trees used for self built dependencies")
-set(SELF_BUILT_AUBIO "NEVER" CACHE STRING "rule to allow self build of Aubio dependency library [NEVER*|AUTO|ALWAYS]")
-set(SELF_BUILT_CED "NEVER" CACHE STRING "rule to allow self build of Ced dependency library [NEVER*|AUTO|ALWAYS]")
-set(SELF_BUILT_JSON "NEVER" CACHE STRING "rule to allow self build of Json dependency library [NEVER*|AUTO|ALWAYS]")
+set(SELF_BUILT_AUBIO "AUTO" CACHE STRING "rule to allow self build of Aubio dependency library [NEVER|AUTO*|ALWAYS]")
+set(SELF_BUILT_JSON "AUTO" CACHE STRING "rule to allow self build of Json dependency library [NEVER|AUTO*|ALWAYS]")
+# This is AUTO cause CED is not available on ubuntu
+set(SELF_BUILT_CED "AUTO" CACHE STRING "rule to allow self build of Ced dependency library [NEVER|AUTO*|ALWAYS]")
 
 set(Aubio_REQUIRED_VERSION "0.4.9")
 


### PR DESCRIPTION
### What does this PR do?

The default value NEVER is changed to AUTO for the libraries ced, aubio and json in cmake. NEVER has the meaning, that the library is never build with performous. Therefore a system version of the library is required. If those are not available cmake failes.

Changing the default to AUTO is the better choice, cause in this case cmake will look for a system library and if none is available it will be build with performous.

### Closes Issue(s)

None.

### Motivation

It is a pain for a developer if cmake doesn't work out of the box. The new default values will make it much easier to build performous from sources.

