### PR TITLE
set the locale to UTF-8 on windows during startup of Performous

### DIFF
--- a/game/main.cc
+++ b/game/main.cc
@@ -262,15 +262,8 @@ static void fatalError(const std::string &msg) {
 	std::clog << "core/error: " << errMsg << std::endl;
 }
 
-void setupPreconditions() {
-#ifdef WIN32
-	// set the locale to UTF-8 on windows
-	setlocale(LC_ALL, ".UTF8");
-#endif
-}
-
 int main(int argc, char** argv) try {
-	setupPreconditions();
+	Platform::setupPlatform();
 	std::srand(static_cast<unsigned>(std::time(nullptr)));
 	// Parse commandline options
 	std::vector<std::string> devices;

--- a/game/main.cc
+++ b/game/main.cc
@@ -262,7 +262,15 @@ static void fatalError(const std::string &msg) {
 	std::clog << "core/error: " << errMsg << std::endl;
 }
 
+void setupPreconditions() {
+#ifdef WIN32
+	// set the locale to UTF-8 on windows
+	setlocale(LC_ALL, ".UTF8");
+#endif
+}
+
 int main(int argc, char** argv) try {
+	setupPreconditions();
 	std::srand(static_cast<unsigned>(std::time(nullptr)));
 	// Parse commandline options
 	std::vector<std::string> devices;

--- a/game/platform.cc
+++ b/game/platform.cc
@@ -21,6 +21,13 @@ Platform::Platform() {
 	#endif
 }
 
+void Platform::setupPlatform() {
+#if (BOOST_OS_WINDOWS)
+	// set the locale to UTF-8 on windows
+	setlocale(LC_ALL, ".UTF8");
+#endif
+}
+
 const std::array<const char*,6> Platform::platformNames = {{ "Windows", "Linux", "MacOS", "BSD", "Solaris", "Unix" }}; // Relevant for debug only.
 
 int Platform::defaultBackEnd() {

--- a/game/platform.hh
+++ b/game/platform.hh
@@ -27,6 +27,7 @@ Platform();
 static HostOS currentOS();
 static std::uint16_t shortcutModifier(bool eitherSide = true);
 static int defaultBackEnd();
+static void setupPlatform();
 
 private:
 static const std::array<const char*,6> platformNames;


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/performous/performous/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

This PR sets the locale on windows machines to UTF-8 during the startup of Performous.

Background of the issue:
_This PR fixes an issue on windows that crashes Performous when importing songs with characters like ö and ’ while not having the beta utf8 support enabled in settings._
_Without this change the Song::getDurationSeconds function crashes on avformat_open_input while supplying a path as mentioned above._

### Closes Issue(s) / PR's

Closes #893 
Closes #892 
Closes #902 

### Motivation

Running Performous on windows while not having to enable utf8 support.

### More

- [ ] Added/updated documentation

### Additional Notes

Tested on Win11 with the beta utf8 support disabled.

Related PRs fixing the same issue:
- https://github.com/performous/performous/pull/892
- https://github.com/performous/performous/pull/908
