### PR TITLE
Add Fedora 39

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -106,6 +106,8 @@ jobs:
             version: 37
           - os: fedora
             version: 38
+          - os: fedora
+            version: 39
     steps:
       - name: Container name
         run: |

--- a/README.md
+++ b/README.md
@@ -26,4 +26,5 @@ For compiling instructions, see docs/Compiling.txt or visit the wiki page: https
 - [Linux - Fedora 36](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-fedora_36.rpm.zip)
 - [Linux - Fedora 37](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-fedora_37.rpm.zip)
 - [Linux - Fedora 38](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-fedora_38.rpm.zip)
+- [Linux - Fedora 39](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest-fedora_39.rpm.zip)
 - [Linux - AppImage](https://nightly.link/performous/performous/workflows/build_and_release/master/Performous-latest.AppImage.zip)


### PR DESCRIPTION
### What does this PR do?

Adds Fedora 39 packages

### Closes Issue(s)

None

### Motivation

Fedora 39 was released on Nov. 7th