### PR TITLE
Do not show webserver if its not compiled in

### DIFF
--- a/game/screen_intro.cc
+++ b/game/screen_intro.cc
@@ -182,6 +182,12 @@ void ScreenIntro::populateMenu() {
 			MenuOptions opts;
 			// Process items that belong to that submenu
 			for (auto const& item: submenu.items) {
+#ifdef USE_WEBSERVER
+#else
+				if (item.find("game/webserver") != std::string::npos) {
+					continue;
+				}
+#endif
 				ConfigItem& c = config[item];
 				opts.emplace_back(MenuOption(c.getShortDesc(), c.getLongDesc()));
 				opts.back().changer(c);


### PR DESCRIPTION
### What does this PR do?

Do not show the webserver entries if the game is compiled without `USE_WEBSERVER`
<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

<!-- List here all the issues closed by this pull request. -->
Closes #517 

### Motivation

<!-- What inspired you to submit this pull request? -->
This fixes some confusion as previously you could enable to use the webserver in game but nothing did happen.

### More

- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
