### PR TITLE
Initialize SDL before creating threads to avoid concurrency issues

### DIFF
--- a/game/graphic/window.cc
+++ b/game/graphic/window.cc
@@ -47,7 +47,9 @@ float screenH() { return s_height; }
 Window::Window()
 : screen(nullptr, &SDL_DestroyWindow), glContext(nullptr, &SDL_GL_DeleteContext) {
 	m_system = std::make_unique<SDLSystem>();
+}
 
+void Window::start() {
 	SDL_JoystickEventState(SDL_ENABLE);
 	{ // Setup GL attributes for context creation
 		SDL_SetHintWithPriority("SDL_HINT_VIDEO_HIGHDPI_DISABLED", "0", SDL_HINT_DEFAULT);

--- a/game/graphic/window.hh
+++ b/game/graphic/window.hh
@@ -27,6 +27,7 @@ class Window {
 	Window();
 	~Window();
 
+	void start();
 	void shutdown();
 
 	void render(Game &game, std::function<void (void)> drawFunc);

--- a/game/main.cc
+++ b/game/main.cc
@@ -97,6 +97,8 @@ static void checkEvents(Game& gm, Time eventTime) {
 }
 
 void mainLoop(std::string const& songlist) {
+	Window window{};
+
 	Platform platform;
 	std::clog << "core/notice: Starting the audio subsystem (errors printed on console may be ignored)." << std::endl;
 	std::clog << "core/info: Loading assets." << std::endl;
@@ -107,7 +109,7 @@ void mainLoop(std::string const& songlist) {
 	Songs songs(database, songlist);
 	loadFonts();
 
-	Window window{};
+	window.start();
 	Game gm(window);
 	WebServer server(gm, songs);
 


### PR DESCRIPTION
Fixes #946 