### PR TITLE
Changed LogLevel to be always debug unless we're on release mode

### DIFF
--- a/game/main.cc
+++ b/game/main.cc
@@ -272,7 +272,11 @@ int main(int argc, char** argv) try {
 	namespace po = boost::program_options;
 	po::options_description opt1("Generic options");
 	std::string songlist;
+
 	std::string loglevel;
+#ifndef NDEBUG
+	loglevel = "debug";
+#endif
 	opt1.add_options()
 	  ("help,h", "you are viewing it")
 	  ("log,l", po::value<std::string>(&loglevel), "subsystem name or minimum level to log")


### PR DESCRIPTION
### What does this PR do?

Changes the loglevel to be always Debug unless `CMAKE_BUILD_TYPE=Release` is passed as build-flag.

<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

<!-- List here all the issues closed by this pull request. -->
None

### Motivation

<!-- What inspired you to submit this pull request? -->
When debugging you want as much info as needed. This prevented it as on `Debug` or `RelWithDebInfo` we didn't log on debug level per default.

### More

- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
