### PR TITLE
Draft: Performous+ Theme - adjust lyrics highlight color, stroke opacity and width

### DIFF
--- a/data/themes/performous+ (Black)/sing_lyricscurrent.svg
+++ b/data/themes/performous+ (Black)/sing_lyricscurrent.svg
@@ -63,10 +63,10 @@
   <text
      xml:space="preserve"
      id="text3481"
-     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:41.3177681px;line-height:125%;font-family:FreeSans;-inkscape-font-specification:'FreeSans Bold';text-align:center;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.58823529"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:41.3177681px;line-height:125%;font-family:FreeSans;-inkscape-font-specification:'FreeSans Bold';text-align:center;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      y="519.05145"
      x="410.00458"><tspan
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:41.3177681px;font-family:FreeSans;-inkscape-font-specification:'FreeSans Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.8;stroke-opacity:0.58823529;stroke-miterlimit:4;stroke-dasharray:none"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:41.3177681px;font-family:FreeSans;-inkscape-font-specification:'FreeSans Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1.5;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
        id="tspan2921"
        y="519.05145"
        x="410.00458">lyrics</tspan></text>

--- a/data/themes/performous+ (Black)/sing_lyricshighlight.svg
+++ b/data/themes/performous+ (Black)/sing_lyricshighlight.svg
@@ -65,12 +65,12 @@
     <text
        x="400"
        y="527.52618"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:36.74266561px;line-height:0%;font-family:FreeSans;text-align:center;writing-mode:lr;text-anchor:middle;display:inline;opacity:1;fill:#00ade5;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.47058824;-inkscape-font-specification:'FreeSans, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:36.74266561px;line-height:0%;font-family:FreeSans;text-align:center;writing-mode:lr;text-anchor:middle;display:inline;opacity:1;fill:#ffd100ff;fill-opacity:1;stroke:#000000;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-font-specification:'FreeSans, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal"
        id="text10203"
        xml:space="preserve"><tspan
          x="400"
          y="527.52618"
          id="tspan10205"
-         style="font-size:36.74266561px;text-align:center;text-anchor:middle;fill:#00ade5;fill-opacity:1;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none;-inkscape-font-specification:'FreeSans, Bold';font-family:FreeSans;font-weight:bold;font-style:normal;font-stretch:normal;font-variant:normal;writing-mode:lr;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;stroke:#000000;stroke-opacity:0.47058824">lyrics</tspan></text>
+         style="font-size:36.74266561px;text-align:center;text-anchor:middle;fill:#ffd100ff;fill-opacity:1;stroke-width:1.5;stroke-miterlimit:4;stroke-dasharray:none;-inkscape-font-specification:'FreeSans, Bold';font-family:FreeSans;font-weight:bold;font-style:normal;font-stretch:normal;font-variant:normal;writing-mode:lr;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;stroke:#000000;stroke-opacity:1">lyrics</tspan></text>
   </g>
 </svg>

--- a/data/themes/performous+ (Black)/sing_lyricsnext.svg
+++ b/data/themes/performous+ (Black)/sing_lyricsnext.svg
@@ -65,13 +65,13 @@
     <text
        x="421.95126"
        y="567.68427"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:45.70231628px;line-height:0%;font-family:FreeSans;-inkscape-font-specification:'FreeSans Bold';text-align:center;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#d3d3d3;fill-opacity:1;stroke:#000000;stroke-width:1.52341032;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.58823529"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:45.70231628px;line-height:0%;font-family:FreeSans;-inkscape-font-specification:'FreeSans Bold';text-align:center;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#d3d3d3;fill-opacity:1;stroke:#000000;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="text6611"
        xml:space="preserve"
        transform="scale(0.99957298,1.0004272)"><tspan
          x="421.95126"
          y="567.68427"
          id="tspan6613"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:45.70231628px;font-family:FreeSans;-inkscape-font-specification:'FreeSans Bold';text-align:center;text-anchor:middle;fill:#d3d3d3;fill-opacity:1;stroke:#000000;stroke-width:1.52341032;stroke-opacity:0.58823529">lyrics</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:45.70231628px;font-family:FreeSans;-inkscape-font-specification:'FreeSans Bold';text-align:center;text-anchor:middle;fill:#d3d3d3;fill-opacity:1;stroke:#000000;stroke-width:1.5;stroke-opacity:1">lyrics</tspan></text>
   </g>
 </svg>

--- a/data/themes/performous+ (Colors)/sing_lyricscurrent.svg
+++ b/data/themes/performous+ (Colors)/sing_lyricscurrent.svg
@@ -63,10 +63,10 @@
   <text
      xml:space="preserve"
      id="text3481"
-     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:41.3177681px;line-height:125%;font-family:FreeSans;-inkscape-font-specification:'FreeSans Bold';text-align:center;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.58823529"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:41.3177681px;line-height:125%;font-family:FreeSans;-inkscape-font-specification:'FreeSans Bold';text-align:center;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      y="519.05145"
      x="410.00458"><tspan
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:41.3177681px;font-family:FreeSans;-inkscape-font-specification:'FreeSans Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.8;stroke-opacity:0.58823529;stroke-miterlimit:4;stroke-dasharray:none"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:41.3177681px;font-family:FreeSans;-inkscape-font-specification:'FreeSans Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1.5;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
        id="tspan2921"
        y="519.05145"
        x="410.00458">lyrics</tspan></text>

--- a/data/themes/performous+ (Colors)/sing_lyricshighlight.svg
+++ b/data/themes/performous+ (Colors)/sing_lyricshighlight.svg
@@ -65,12 +65,12 @@
     <text
        x="400"
        y="527.52618"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:36.74266561px;line-height:0%;font-family:FreeSans;text-align:center;writing-mode:lr;text-anchor:middle;display:inline;opacity:1;fill:#00ade5;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.47058824;-inkscape-font-specification:'FreeSans, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:36.74266561px;line-height:0%;font-family:FreeSans;text-align:center;writing-mode:lr;text-anchor:middle;display:inline;opacity:1;fill:#ffd100ff;fill-opacity:1;stroke:#000000;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-font-specification:'FreeSans, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal"
        id="text10203"
        xml:space="preserve"><tspan
          x="400"
          y="527.52618"
          id="tspan10205"
-         style="font-size:36.74266561px;text-align:center;text-anchor:middle;fill:#00ade5;fill-opacity:1;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none;-inkscape-font-specification:'FreeSans, Bold';font-family:FreeSans;font-weight:bold;font-style:normal;font-stretch:normal;font-variant:normal;writing-mode:lr;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;stroke:#000000;stroke-opacity:0.47058824">lyrics</tspan></text>
+         style="font-size:36.74266561px;text-align:center;text-anchor:middle;fill:#ffd100ff;fill-opacity:1;stroke-width:1.5;stroke-miterlimit:4;stroke-dasharray:none;-inkscape-font-specification:'FreeSans, Bold';font-family:FreeSans;font-weight:bold;font-style:normal;font-stretch:normal;font-variant:normal;writing-mode:lr;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;stroke:#000000;stroke-opacity:1">lyrics</tspan></text>
   </g>
 </svg>

--- a/data/themes/performous+ (Colors)/sing_lyricsnext.svg
+++ b/data/themes/performous+ (Colors)/sing_lyricsnext.svg
@@ -65,13 +65,13 @@
     <text
        x="421.95126"
        y="567.68427"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:45.70231628px;line-height:0%;font-family:FreeSans;-inkscape-font-specification:'FreeSans Bold';text-align:center;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#d3d3d3;fill-opacity:1;stroke:#000000;stroke-width:1.52341032;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.58823529"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:45.70231628px;line-height:0%;font-family:FreeSans;-inkscape-font-specification:'FreeSans Bold';text-align:center;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#d3d3d3;fill-opacity:1;stroke:#000000;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="text6611"
        xml:space="preserve"
        transform="scale(0.99957298,1.0004272)"><tspan
          x="421.95126"
          y="567.68427"
          id="tspan6613"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:45.70231628px;font-family:FreeSans;-inkscape-font-specification:'FreeSans Bold';text-align:center;text-anchor:middle;fill:#d3d3d3;fill-opacity:1;stroke:#000000;stroke-width:1.52341032;stroke-opacity:0.58823529">lyrics</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:45.70231628px;font-family:FreeSans;-inkscape-font-specification:'FreeSans Bold';text-align:center;text-anchor:middle;fill:#d3d3d3;fill-opacity:1;stroke:#000000;stroke-width:1.5;stroke-opacity:1">lyrics</tspan></text>
   </g>
 </svg>


### PR DESCRIPTION
### What does this PR do?

* slight adjustments to the wonderful Performous+ theme
  * changes the lyric text highlight color to the same as in the default theme
  * set stroke opacity for all lyrics texts to 1
  * set stroke width for all lyric texts to 1.5

This also slightly reduces the odd white color between the outline and highlighted lyric color.

### Closes Issue(s)

Addresses a point mentioned in #937 https://github.com/performous/performous/issues/937#issuecomment-1812446174. The lyrics' black outline is a bit thin which can make the lyrics hard to read on light backgrounds
