### PR TITLE
Update actions for Node 20

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Checkout Git
         id: checkout_git
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build the AppImage
         id: build_appimage
@@ -52,7 +52,7 @@ jobs:
 
       # Upload artifacts during pull-requests
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'pull_request' }}
         with:
           name: ${{ env.ARTIFACT_NAME }}
@@ -61,7 +61,7 @@ jobs:
       # Upload artifacts on master
       - name: Upload artifact with unified name
         if: ${{ github.ref == 'refs/heads/master' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.MASTER_ARTIFACT_NAME }}
           path: ${{ env.MASTER_ARTIFACT_PATH }}

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -39,7 +39,7 @@ jobs:
       complete_version: ${{ steps.versioning.outputs.complete_version }}
     steps:
       - name: Checkout Performous
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ${{ github.workspace }}/performous
           repository: ${{ github.event.repository.full_name }}
@@ -74,7 +74,7 @@ jobs:
       - name: Create the Main release
         id: create_release
         if: ${{ github.event_name != 'pull_request' && github.ref_type == 'tag' }}
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v0.1.15
         with:
           tag_name: ${{ github.ref_name }}
           name: Performous ${{ github.ref_name }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -116,10 +116,10 @@ jobs:
           echo "CONTAINER_NAME=${BUILD_CONTAINER}" >> $GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Login to the container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.REPO_NAME }}
@@ -127,7 +127,7 @@ jobs:
 
       - name: Build ${{ matrix.os }} ${{ matrix.version }} Container
         if: needs.determine_docker_version.outputs[format('build_{0}_containers', matrix.os)] == 'true' || needs.determine_docker_version.outputs['build_docker_containers'] == 'true'
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: docker/
           file: ./docker/Dockerfile.${{ matrix.os }}
@@ -163,7 +163,7 @@ jobs:
 
       # Upload artifacts during pull-requests
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'pull_request' }}
         with:
           name: ${{ env.ARTIFACT_NAME }}
@@ -172,7 +172,7 @@ jobs:
       # Upload artifacts on master
       - name: Upload artifact with unified name
         if: ${{ github.ref == 'refs/heads/master' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.MASTER_ARTIFACT_NAME }}
           path: ${{ env.MASTER_ARTIFACT_PATH }}
@@ -189,7 +189,7 @@ jobs:
           file: ${{ env.ARTIFACT_PATH }}
 
       - name: Push container
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         # Containers can't be pushed during PRs because of the way permissions
         # are delegated to secrets.GITHUB_TOKEN
         if: ${{ needs.determine_docker_version.outputs.build_docker_containers == 'true' && github.event_name != 'pull_request' }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - name: Checkout Git
         id: checkout_git
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: performous
 
@@ -80,7 +80,7 @@ jobs:
            brew install $MACOS_DEPS
       - name: Setup Python
         id: setup_python
-        uses: actions/setup-python@v4 
+        uses: actions/setup-python@v5 
         with:
             python-version: 'pypy3.9' 
             cache: 'pip'
@@ -110,7 +110,7 @@ jobs:
           make test
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'pull_request' }}
         with:
           name: ${{ env.ARTIFACT_NAME }}
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload artifact with unified name
         if: ${{ github.ref == 'refs/heads/master' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.MASTER_ARTIFACT_NAME }}
           path: ${{ env.MASTER_ARTIFACT_PATH }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Checkout Git
         id: checkout_git
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: performous
 
@@ -76,7 +76,7 @@ jobs:
            echo ("MASTER_ARTIFACT_FILENAME=Performous-latest-msvc.exe") >> $env:GITHUB_ENV
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'pull_request' }}
         with:
           name: ${{ env.ARTIFACT_FILENAME }}
@@ -84,7 +84,7 @@ jobs:
 
       - name: Upload artifact with unified name
         if: ${{ github.ref == 'refs/heads/master' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.MASTER_ARTIFACT_FILENAME }}
           path: ${{ env.MASTER_ARTIFACT_PATH }}
@@ -108,7 +108,7 @@ jobs:
     steps:
       - name: Checkout Git
         id: checkout_git
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: performous
       - name: Setup action env and echoing
@@ -192,7 +192,7 @@ jobs:
            powershell -command "echo ('MASTER_ARTIFACT_PATH=${{ env.workpath }}/performous/build/Performous-latest-mingw-w64.exe') >> \$env:GITHUB_ENV"
            powershell -command "echo ('MASTER_ARTIFACT_FILENAME=Performous-latest-mingw-w64.exe') >> \$env:GITHUB_ENV"
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'pull_request' }}
         with:
           name: ${{ env.ARTIFACT_FILENAME }}
@@ -200,7 +200,7 @@ jobs:
 
       - name: Upload artifact with unified name
         if: ${{ github.ref == 'refs/heads/master' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.MASTER_ARTIFACT_FILENAME }}
           path: ${{ env.MASTER_ARTIFACT_PATH }}


### PR DESCRIPTION
### What does this PR do?

Update imported, public actions to newer versions where applicable to stop warnings about Node 16 deprecation.

There are other actions that we own and will need to be updated:
```
Build the Windows packages / Create Windows installer with MSVC 
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: abdes/gha-setup-ninja@master, performous/github-action-get-latest-release@v0.7.0, actions/checkout@v3, Lord-Kamina/always-upload-cache/restore@refresh-cache, Lord-Kamina/always-upload-cache/save@refresh-cache. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```
Hopefully just rebasing our changes to the updates in the repos we forked from will take care of it. I believe that complaint about `actions/checkout@v3` is from the action being used within one of the actions that we own. I updated it in all the workflow files.

### Motivation

We noticed the deprecation warnings when releasing 1.3.1
