### PR TITLE
Check if song text is not ascii/utf8

### DIFF
--- a/game/songparser.cc
+++ b/game/songparser.cc
@@ -10,76 +10,85 @@
 
 namespace SongParserUtil {
 
-	void assign (int& var, std::string const& str) {
+	void assign(int& var, std::string const& str) {
 		try {
-			var = std::stoi (str);
-		} catch (...) {
-			throw std::runtime_error ("\"" + str + "\" is not valid integer value");
+			var = std::stoi(str);
+		}
+		catch (...) {
+			throw std::runtime_error("\"" + str + "\" is not valid integer value");
 		}
 	}
-	void assign (unsigned& var, std::string const& str) {
+	void assign(unsigned& var, std::string const& str) {
 		try {
 			var = stou(str);
-		} catch (...) {
-			throw std::runtime_error ("\"" + str + "\" is not valid unsigned integer value");
+		}
+		catch (...) {
+			throw std::runtime_error("\"" + str + "\" is not valid unsigned integer value");
 		}
 	}
-	void assign (float& var, std::string str) {
-		std::replace (str.begin(), str.end(), ',', '.');  // Fix decimal separators
+	void assign(float& var, std::string str) {
+		std::replace(str.begin(), str.end(), ',', '.');  // Fix decimal separators
 		try {
-			var = std::stof (str);
-		} catch (...) {
-			throw std::runtime_error ("\"" + str + "\" is not valid floating point value");
+			var = std::stof(str);
+		}
+		catch (...) {
+			throw std::runtime_error("\"" + str + "\" is not valid floating point value");
 		}
 	}
-	void assign (double& var, std::string str) {
-		std::replace (str.begin(), str.end(), ',', '.');  // Fix decimal separators
+	void assign(double& var, std::string str) {
+		std::replace(str.begin(), str.end(), ',', '.');  // Fix decimal separators
 		try {
-			var = std::stod (str);
-		} catch (...) {
-			throw std::runtime_error ("\"" + str + "\" is not valid floating point value");
+			var = std::stod(str);
+		}
+		catch (...) {
+			throw std::runtime_error("\"" + str + "\" is not valid floating point value");
 		}
 	}
-	void assign (bool& var, std::string const& str) {
+	void assign(bool& var, std::string const& str) {
 		auto lowerStr = UnicodeUtil::toLower(str);
 		auto is_yes = lowerStr == "yes" || str == "1";
 		auto is_no = lowerStr == "no" || str == "0";
-		if (!is_yes && !is_no) { throw std::runtime_error ("Invalid boolean value: " + str); }
+		if (!is_yes && !is_no) { throw std::runtime_error("Invalid boolean value: " + str); }
 		var = is_yes;
 	}
-	void eraseLast (std::string& s, char ch) {
-		if (!s.empty() && (*s.rbegin() == ch)) {s.erase (s.size() - 1); }
+	void eraseLast(std::string& s, char ch) {
+		if (!s.empty() && (*s.rbegin() == ch)) { s.erase(s.size() - 1); }
 	}
 }
 
-SongParser::SongParser(Song& s): m_song(s) {
+SongParser::SongParser(Song& s) : m_song(s) {
 	try {
 		enum class Type { NONE, TXT, XML, INI, SM } type = Type::NONE;
 		// Read the file, determine the type and do some initial validation checks
-		std::ifstream f (s.filename.string(), std::ios::binary);
+		std::ifstream f(s.filename.string(), std::ios::binary);
 		if (!f.is_open()) {
-			throw SongParserException (s, "Could not open song file", 0);
+			throw SongParserException(s, "Could not open song file", 0);
 		}
 		m_ss << f.rdbuf();
 		size_t size = m_ss.str().length();
 		if ((size < 10) || (size > 100000)) {
-			throw SongParserException (s, "Does not look like a song file (wrong size)", 1, true);
+			throw SongParserException(s, "Does not look like a song file (wrong size)", 1, true);
+		}
+		if (!isText(m_ss.str())) {
+			throw SongParserException(s, "Does not look like a song file (binary)", 1, true);
 		}
 		// Convert m_ss; filename supplied for possible warning messages
-		if (xmlCheck (m_ss.str())) {
+		if (xmlCheck(m_ss.str())) {
 			type = Type::XML;	// XMLPP should deal with encoding so we don't have to.
 		}
 		else {
 			std::string ss = UnicodeUtil::convertToUTF8(m_ss.str(), s.filename.string());
-			if (smCheck (ss)) type = Type::SM;
-			else if (txtCheck (ss)) {
+			if (smCheck(ss)) {
+				type = Type::SM;
+			}
+			else if (txtCheck(ss)) {
 				type = Type::TXT;
 			}
-			else if (iniCheck (ss)) {
+			else if (iniCheck(ss)) {
 				type = Type::INI;
 			}
 			else {
-				throw SongParserException (s, "Does not look like a song file (wrong header)", 1, true);
+				throw SongParserException(s, "Does not look like a song file (wrong header)", 1, true);
 			}
 			m_ss.str(ss);
 		}
@@ -111,20 +120,25 @@ SongParser::SongParser(Song& s): m_song(s) {
 			s.preview_start = ((type == Type::INI || s.getDurationSeconds() < 50.0) ? 5.0 : 30.0);  // 5 s for band mode, 30 s for others
 		}
 		guessFiles();
-		if (!m_song.midifilename.empty()) {midParseHeader(); }
-		if(s.loadStatus != Song::LoadStatus::ERROR) {
+		if (!m_song.midifilename.empty()) { 
+			midParseHeader(); 
+		}
+		if (s.loadStatus != Song::LoadStatus::ERROR) {
 			s.loadStatus = Song::LoadStatus::HEADER;
 		}
-	} catch (SongParserException&) {
+	}
+	catch (SongParserException&) {
 		throw;
-	} catch (std::runtime_error& e) {
-		throw SongParserException (m_song, e.what(), m_linenum);
-	} catch (std::exception& e) {
-		throw SongParserException (m_song, "Internal error: " + std::string (e.what()), m_linenum);
+	}
+	catch (std::runtime_error& e) {
+		throw SongParserException(m_song, e.what(), m_linenum);
+	}
+	catch (std::exception& e) {
+		throw SongParserException(m_song, "Internal error: " + std::string(e.what()), m_linenum);
 	}
 }
 
-void SongParser::guessFiles () {
+void SongParser::guessFiles() {
 	// List of fields containing filenames, and auto-matching regexps, in order of priority
 	const std::vector<std::pair<fs::path*, char const*> > fields = {
 		{ &m_song.cover, R"((cover|album|label|banner|bn|\[co\])\.(png|jpeg|jpg|svg)$)" },
@@ -158,7 +172,7 @@ void SongParser::guessFiles () {
 	bool missing = false;
 	for (auto const& p : fields) {
 		fs::path& file = *p.first;
-		if (!file.empty() && !is_regular_file (file)) {
+		if (!file.empty() && !is_regular_file(file)) {
 			logMissing += "  " + file.filename().string();
 			file.clear();
 		}
@@ -170,7 +184,7 @@ void SongParser::guessFiles () {
 		return;	// All OK!
 	}
 	// Try matching all files in song folder with any field
-	std::set<fs::path> files (fs::directory_iterator {m_song.path}, fs::directory_iterator {});
+	std::set<fs::path> files(fs::directory_iterator{ m_song.path }, fs::directory_iterator{});
 	for (unsigned i = 0; i < fields.size(); ++i) {
 		fs::path& field = *fields[i].first;
 		if (field.empty()) {
@@ -181,7 +195,7 @@ void SongParser::guessFiles () {
 				logFound += "  " + name;
 			}
 		}
-		files.erase (field);  // Remove from available options
+		files.erase(field);  // Remove from available options
 	}
 
 	m_song.music[TrackName::PREVIEW].clear();  // We don't currently support preview tracks (TODO: proper handling in audio.cc).
@@ -199,49 +213,49 @@ void SongParser::guessFiles () {
 	std::clog << std::flush;
 }
 
-void SongParser::vocalsTogether () {
-	auto togetherIt = m_song.vocalTracks.find ("Together");
-	if (togetherIt == m_song.vocalTracks.end()) {return; }
+void SongParser::vocalsTogether() {
+	auto togetherIt = m_song.vocalTracks.find("Together");
+	if (togetherIt == m_song.vocalTracks.end()) { return; }
 	Notes& together = togetherIt->second.notes;
-	if (!together.empty()) {return; }
+	if (!together.empty()) { return; }
 	Notes notes;
 	// Collect usable vocal tracks
 	struct TrackInfo {
 		typedef Notes::const_iterator It;
 		It it, end;
 		TrackInfo(It begin, It end) :
-			it (begin), end (end) {}
+			it(begin), end(end) {}
 	};
 	std::vector<TrackInfo> tracks;
 	for (auto& nt : m_song.vocalTracks) {
-		togetherIt->second.noteMin = std::min (togetherIt->second.noteMin, nt.second.noteMin);
-		togetherIt->second.noteMax = std::max (togetherIt->second.noteMax, nt.second.noteMax);
+		togetherIt->second.noteMin = std::min(togetherIt->second.noteMin, nt.second.noteMin);
+		togetherIt->second.noteMax = std::max(togetherIt->second.noteMax, nt.second.noteMax);
 
 		Notes& n = nt.second.notes;
-		if (!n.empty()) {tracks.push_back (TrackInfo (n.begin(), n.end())); }
+		if (!n.empty()) { tracks.push_back(TrackInfo(n.begin(), n.end())); }
 	}
-	if (tracks.empty()) {return; }
+	if (tracks.empty()) { return; }
 	// Combine notes
 	// FIXME: This should do combining on sentence level rather than note-by-note
 	TrackInfo* trk = &tracks.front();
 	while (trk) {
 		Note const& n = *trk->it;
 		// std::cerr << " " << n.syllable << ": " << n.begin << "-" << n.end << std::endl;
-		notes.push_back (n);
+		notes.push_back(n);
 		++trk->it;
 		trk = nullptr;
 		// Iterate all tracks past the processed note and find the new earliest track
 		for (TrackInfo& trk2 : tracks) {
 			// Skip until a sentence that begins after the note ended
-			while (trk2.it != trk2.end && trk2.it->begin < n.end) {++trk2.it; }
-			if (trk2.it == trk2.end) {continue; }
-			if (!trk || (trk2.it->begin < trk->it->begin)) {trk = &trk2; }
+			while (trk2.it != trk2.end && trk2.it->begin < n.end) { ++trk2.it; }
+			if (trk2.it == trk2.end) { continue; }
+			if (!trk || (trk2.it->begin < trk->it->begin)) { trk = &trk2; }
 		}
 	}
-	together.swap (notes);
+	together.swap(notes);
 }
 
-void SongParser::finalize () {
+void SongParser::finalize() {
 	vocalsTogether();
 	for (auto& nt : m_song.vocalTracks) {
 		VocalTrack& vocal = nt.second;
@@ -251,7 +265,7 @@ void SongParser::finalize () {
 			std::clog << "songparser/debug: In " << m_song.artist << " - " << m_song.title << std::endl;
 			for (auto itn = vocal.notes.begin(); itn != vocal.notes.end();) {
 				if (itn->type == Note::Type::SLEEP) { itn->end = itn->begin; ++itn; continue; }
-				auto next = (itn +1);
+				auto next = (itn + 1);
 
 				// Try to fix overlapping syllables.
 				if (next != vocal.notes.end() && Note::overlapping(*itn, *next)) {
@@ -261,20 +275,23 @@ void SongParser::finalize () {
 					std::clog << "songparser/info: Changing ending to: " << newEnd << ", will give a length of: " << (newEnd - (itn->begin)) << std::endl;
 					if ((newEnd - itn->begin) >= beatDur) {
 						itn->end = newEnd;
-					} else if (next->type != Note::Type::SLEEP) {
+					}
+					else if (next->type != Note::Type::SLEEP) {
 						std::clog << "songparser/info: Resulting note would be too short, will combine them instead." << std::endl;
 						itn->syllable += std::string("-") += next->syllable;
 						itn->end = next->end;
 						vocal.notes.erase(next);
-					} else {
+					}
+					else {
 						next->begin = next->end = itn->end;
 					}
 				}
 				Note::Type type = itn->type;
-				if(type == Note::Type::SLEEP && lastType == Note::Type::SLEEP) {
+				if (type == Note::Type::SLEEP && lastType == Note::Type::SLEEP) {
 					std::clog << "songparser/info: " + m_song.filename.string() + ": Discarding empty sentence" << std::endl;
 					itn = vocal.notes.erase(itn);
-				} else {
+				}
+				else {
 					++itn;
 				}
 				lastType = type;
@@ -282,7 +299,7 @@ void SongParser::finalize () {
 		}
 		// Adjust negative notes
 		if (vocal.noteMin <= 0) {
-		 	float shift = (1 - std::floor(vocal.noteMin / 12)) * 12;
+			float shift = (1 - std::floor(vocal.noteMin / 12)) * 12;
 			vocal.noteMin += shift;
 			vocal.noteMax += shift;
 			for (auto& elem : vocal.notes) {
@@ -291,7 +308,8 @@ void SongParser::finalize () {
 			}
 		}
 		// Set begin/end times
-		if (!vocal.notes.empty()) { vocal.beginTime = vocal.notes.front().begin, vocal.endTime = vocal.notes.back().end; } else { vocal.beginTime = vocal.endTime = 0.0; }
+		if (!vocal.notes.empty()) { vocal.beginTime = vocal.notes.front().begin, vocal.endTime = vocal.notes.back().end; }
+		else { vocal.beginTime = vocal.endTime = 0.0; }
 		// Compute maximum score
 		double max_score = 0.0;
 		for (auto& note : vocal.notes) { max_score += note.maxScore(); }
@@ -299,12 +317,12 @@ void SongParser::finalize () {
 	}
 	if (m_tsPerBeat) {
 		// Add song beat markers
-		for (unsigned ts = 0; ts < m_tsEnd; ts += m_tsPerBeat) { m_song.beats.push_back (tsTime (static_cast<double>(ts))); }
+		for (unsigned ts = 0; ts < m_tsEnd; ts += m_tsPerBeat) { m_song.beats.push_back(tsTime(static_cast<double>(ts))); }
 	}
 }
 
 Song::BPM SongParser::getBPM(Song const& s, double ts) const {
-	for (auto& itb: boost::adaptors::reverse(s.m_bpms)) {
+	for (auto& itb : boost::adaptors::reverse(s.m_bpms)) {
 		if (itb.begin <= ts) return itb;
 	}
 	throw std::runtime_error("No BPM definition prior to this note...");
@@ -312,12 +330,12 @@ Song::BPM SongParser::getBPM(Song const& s, double ts) const {
 
 void SongParser::addBPM(double ts, float bpm) {
 	Song& s = m_song;
-	if (!(( bpm >= 1.0f) && ( bpm < 1e12) )) { throw std::runtime_error("Invalid BPM value"); }
-	if (!s.m_bpms.empty() && ( s.m_bpms.back().ts >= ts) ) {
+	if (!((bpm >= 1.0f) && (bpm < 1e12))) { throw std::runtime_error("Invalid BPM value"); }
+	if (!s.m_bpms.empty() && (s.m_bpms.back().ts >= ts)) {
 		if (s.m_bpms.back().ts < ts) { throw std::runtime_error("Invalid BPM timestamp"); }
 		s.m_bpms.pop_back();	// Some ITG songs contain repeated BPM definitions...
 	}
-	s.m_bpms.push_back (Song::BPM (tsTime (ts), ts, bpm));
+	s.m_bpms.push_back(Song::BPM(tsTime(ts), ts, bpm));
 }
 
 double SongParser::tsTime(double ts) const {

--- a/game/util.cc
+++ b/game/util.cc
@@ -13,22 +13,46 @@ template <> double sconv(std::string const& s) { return std::stod(s); }
 template <> std::string sconv(std::string const& s) { return s; }
 
 /** Converts a std::string into an unsigned int. **/
-unsigned stou(std::string const & str, size_t * idx, int base) {
-	std::uint64_t result = std::stoul(str, idx, base);
-	unsigned uival;
-	std::uint64_t mask = ~0xfffffffful;
-		//Do we want this this function to throw? STL functions just overflow.
-		if( (result & mask) == 0 )
-			uival = static_cast<unsigned>(result);
-		else throw std::out_of_range(str + " is out of range of unsigned.");
-	return uival;
+unsigned stou(std::string const& str, size_t* idx, int base) {
+    std::uint64_t result = std::stoul(str, idx, base);
+    unsigned uival;
+    std::uint64_t mask = ~0xfffffffful;
+    //Do we want this this function to throw? STL functions just overflow.
+    if ((result & mask) == 0)
+        uival = static_cast<unsigned>(result);
+    else throw std::out_of_range(str + " is out of range of unsigned.");
+    return uival;
 }
 
 std::string format(std::chrono::seconds const& unixtime, std::string const& format, bool utc) {
-	auto const time = static_cast<std::time_t>(unixtime.count());
-	auto stream = std::stringstream();
+    auto const time = static_cast<std::time_t>(unixtime.count());
+    auto stream = std::stringstream();
 
-	stream << std::put_time(utc ? std::gmtime(&time) : std::localtime(&time), format.c_str());
+    stream << std::put_time(utc ? std::gmtime(&time) : std::localtime(&time), format.c_str());
 
-	return stream.str();
+    return stream.str();
+}
+
+bool startsWithUTF8BOM(std::string const& s) {
+    if (s.size() < 3)
+        return false;
+    auto const b0 = static_cast<unsigned char>(s[0]);
+    auto const b1 = static_cast<unsigned char>(s[1]);
+    auto const b2 = static_cast<unsigned char>(s[2]);
+    if (b0 == 0xEF && b1 == 0xBB && b2 == 0xBF)
+        return true;
+
+    return false;
+}
+
+bool isText(std::string const& s, size_t bytesToCheck) {
+    auto const start = startsWithUTF8BOM(s) ? 3U : 0U;
+    auto const end = std::min(bytesToCheck, s.size());
+
+    for (auto n = start; n < end; ++n) {
+        if (s[n] < 32 && s[n] != '\n' && s[n] != '\r' && s[n] != '\t')
+            return false;
+    }
+
+    return true;
 }

--- a/game/util.hh
+++ b/game/util.hh
@@ -53,6 +53,9 @@ struct UnlockGuard {
 std::uint32_t stou(std::string const & str, size_t * idx = nullptr, int base = 10);
 std::string format(std::chrono::seconds const& unixtime, std::string const& format, bool utc = false);
 
+bool startsWithUTF8BOM(std::string const& s);
+bool isText(std::string const& s, size_t bytesToCheck = 32);
+
 /** Templated conversion from strongly typed enums to the underlying type. **/
 template <typename E>
 constexpr auto to_underlying(E e) noexcept -> std::enable_if_t<std::is_enum<E>::value, std::underlying_type_t<E>> {

--- a/testing/utiltest.cc
+++ b/testing/utiltest.cc
@@ -42,22 +42,6 @@ namespace {
 		EXPECT_EQ("02:01:00 1970-01-01", format(time, "%X %Y-%m-%d", true));
 	}
 
-	TEST(UnitTest_Utils, startsWithUTF8BOM_empty) {
-		EXPECT_FALSE(startsWithUTF8BOM(""));
-	}
-
-	TEST(UnitTest_Utils, startsWithUTF8BOM_bom) {
-		auto const bom = std::string{ char(0xEF), char(0xBB), char(0xBF) };
-
-		EXPECT_TRUE(startsWithUTF8BOM(bom));
-	}
-
-	TEST(UnitTest_Utils, startsWithUTF8BOM_bom_and_text) {
-		auto const bom = std::string{ char(0xEF), char(0xBB), char(0xBF) };
-
-		EXPECT_TRUE(startsWithUTF8BOM(bom + "text"));
-	}
-
 	TEST(UnitTest_Utils, isText_text) {
 		EXPECT_TRUE(isText("text"));
 	}
@@ -122,5 +106,35 @@ namespace {
 	TEST(UnitTest_Utils, isText_utf8_euro_wrong_follow_byte) {
 		auto const euro_utf8 = std::string{ char(0xE2), char(0x82), char(0xAC), char(0xAC), char(0xAC) };
 		EXPECT_FALSE(isText("euro sign: " + euro_utf8));
+	}
+	
+	TEST(UnitTest_Utils, isText_utf8_4_byte_f09284a0) {
+		auto const utf8 = std::string{ char(0xF0), char(0x92), char(0x84), char(0xA0) };
+		EXPECT_TRUE(isText(utf8));
+	}
+
+	TEST(UnitTest_Utils, isText_utf8_4_byte_f0908d88) {
+		auto const utf8 = std::string{ char(0xF0), char(0x90), char(0x8D), char(0x88) };
+		EXPECT_TRUE(isText(utf8));
+	}
+
+	TEST(UnitTest_Utils, isText_text_utf8_4_byte) {
+		auto const utf8 = std::string{ char(0xF0), char(0x90), char(0x8D), char(0x88) };
+		EXPECT_TRUE(isText("4 byte utf-8: " + utf8));
+	}
+
+	TEST(UnitTest_Utils, isText_text_utf8_4_byte_text) {
+		auto const utf8 = std::string{ char(0xF0), char(0x90), char(0x8D), char(0x88) };
+		EXPECT_TRUE(isText("4 byte utf-8 " + utf8 + " inside ascii"));
+	}
+
+	TEST(UnitTest_Utils, isText_utf8_euro_border_1) {
+		auto const euro_utf8 = std::string{ char(0xE2), char(0x82), char(0xAC) };
+		EXPECT_TRUE(isText("euro sign: " + euro_utf8, 12));
+	}
+
+	TEST(UnitTest_Utils, isText_utf8_euro_border_2) {
+		auto const euro_utf8 = std::string{ char(0xE2), char(0x82), char(0xAC) };
+		EXPECT_TRUE(isText("euro sign: " + euro_utf8, 13));
 	}
 }

--- a/testing/utiltest.cc
+++ b/testing/utiltest.cc
@@ -41,4 +41,59 @@ namespace {
 		EXPECT_EQ("02:01:00 1970-01-01", format(time, "%H:%M:%S %Y-%m-%d", true));
 		EXPECT_EQ("02:01:00 1970-01-01", format(time, "%X %Y-%m-%d", true));
 	}
+
+	TEST(UnitTest_Utils, startsWithUTF8BOM_empty) {
+		EXPECT_FALSE(startsWithUTF8BOM(""));
+	}
+
+	TEST(UnitTest_Utils, startsWithUTF8BOM_bom) {
+		auto const bom = std::string{ char(0xEF), char(0xBB), char(0xBF) };
+
+		EXPECT_TRUE(startsWithUTF8BOM(bom));
+	}
+
+	TEST(UnitTest_Utils, startsWithUTF8BOM_bom_and_text) {
+		auto const bom = std::string{ char(0xEF), char(0xBB), char(0xBF) };
+
+		EXPECT_TRUE(startsWithUTF8BOM(bom + "text"));
+	}
+
+	TEST(UnitTest_Utils, isText_text) {
+		EXPECT_TRUE(isText("text"));
+	}
+
+	TEST(UnitTest_Utils, isText_text_and_binary) {
+		auto const binary = std::string{ char(0x01), char(0x02), char(0x03) };
+		EXPECT_FALSE(isText("text" + binary + "other"));
+	}
+
+	TEST(UnitTest_Utils, isText_bom_and_text) {
+		auto const bom = std::string{ char(0xEF), char(0xBB), char(0xBF) };
+
+		EXPECT_TRUE(isText(bom + "text"));
+	}
+
+	TEST(UnitTest_Utils, isText_bom_and_text_and_binary) {
+		auto const bom = std::string{ char(0xEF), char(0xBB), char(0xBF) };
+
+		EXPECT_TRUE(isText(bom + "text\0other"));
+	}
+
+	TEST(UnitTest_Utils, isText_binary) {
+		auto const binary = std::string{ char(0x01), char(0x02), char(0x03) };
+
+		EXPECT_FALSE(isText(binary));
+	}
+
+	TEST(UnitTest_Utils, isText_with_nl) {
+		EXPECT_TRUE(isText("first\nsecond"));
+	}
+
+	TEST(UnitTest_Utils, isText_with_lf) {
+		EXPECT_TRUE(isText("first\rsecond"));
+	}
+
+	TEST(UnitTest_Utils, isText_with_tab) {
+		EXPECT_TRUE(isText("first\tsecond"));
+	}
 }

--- a/testing/utiltest.cc
+++ b/testing/utiltest.cc
@@ -79,6 +79,18 @@ namespace {
 		EXPECT_TRUE(isText(bom + "text\0other"));
 	}
 
+	TEST(UnitTest_Utils, isText_binary_zeros) {
+		auto const binary = std::string{ char(0x00), char(0x00), char(0x00), char(0x00) };
+
+		EXPECT_FALSE(isText(binary));
+	}
+
+	TEST(UnitTest_Utils, isText_binary_ffs) {
+		auto const binary = std::string{ char(0xff), char(0xff), char(0xff), char(0xff) };
+
+		EXPECT_FALSE(isText(binary));
+	}
+
 	TEST(UnitTest_Utils, isText_binary) {
 		auto const binary = std::string{ char(0x01), char(0x02), char(0x03) };
 
@@ -95,5 +107,20 @@ namespace {
 
 	TEST(UnitTest_Utils, isText_with_tab) {
 		EXPECT_TRUE(isText("first\tsecond"));
+	}
+
+	TEST(UnitTest_Utils, isText_utf8_umla) {
+		auto const auml_utf8 = std::string{ char(0xC3), char(0xA4) };
+		EXPECT_TRUE(isText("German auml: " + auml_utf8));
+	}
+
+	TEST(UnitTest_Utils, isText_utf8_euro) {
+		auto const euro_utf8 = std::string{ char(0xE2), char(0x82), char(0xAC) };
+		EXPECT_TRUE(isText("euro sign: " + euro_utf8));
+	}
+
+	TEST(UnitTest_Utils, isText_utf8_euro_wrong_follow_byte) {
+		auto const euro_utf8 = std::string{ char(0xE2), char(0x82), char(0xAC), char(0xAC), char(0xAC) };
+		EXPECT_FALSE(isText("euro sign: " + euro_utf8));
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR checks if song text contains non ASCII or UTF8 respecting UTF8-BOM. This prevents that performous crashes while loading defect songs where the song text is a binary file.

### Closes Issue(s)

None.

### Motivation

Since I use USDB-Syncer there are defect songs in my song database. This causes that performous crashes while trying to load header data. The song text files contains zeros or 0xffs only.

