### PR TITLE
Added support for Comment and ProvidedBy tags so we can distinguish m…

### DIFF
--- a/data/themes/default/www/js/playlist-song-modal-body.js
+++ b/data/themes/default/www/js/playlist-song-modal-body.js
@@ -136,6 +136,28 @@ $(function () {
     }
 
     /*
+        If our song contains a ProvidedBy show it.
+        Else hide the complete div.
+    */
+    if (songObject.ProvidedBy.length > 1) {
+        $("#playlist-song-modal-body #modal-providedby-div").show();
+        $("#playlist-song-modal-body #modal-providedby-value").text(songObject.ProvidedBy);
+    } else {
+        $("#playlist-song-modal-body #modal-providedby-div").hide();
+    }
+
+    /*
+        If our song contains a comment show it.
+        Else hide the complete div.
+    */
+    if (songObject.Comment.length > 1) {
+        $("#playlist-song-modal-body #modal-comment-div").show();
+        $("#playlist-song-modal-body #modal-comment-value").text(songObject.Comment);
+    } else {
+        $("#playlist-song-modal-body #modal-comment-div").hide();
+    }
+
+    /*
         Click event handlers to either change a position of the song or remove the song.
     */
     $("#playlist-song-modal-body #modal-move-song-up").click(function () {

--- a/data/themes/default/www/js/playlist.js
+++ b/data/themes/default/www/js/playlist.js
@@ -22,10 +22,15 @@ $("#refresh-playlist").click(function () {
 
             $.each(database, function (iterator, songObject) {
                 totalTime += songObject.Duration + timeout;
+                var songMeta = "";
+                songMeta += songObject.Language.length > 0 ? " | " + songObject.Language : "";
+                songMeta += songObject.Edition.length > 0 ? " | " + songObject.Edition : "";
+                songMeta += songObject.ProvidedBy.length > 0 ? " | " + songObject.ProvidedBy : "";
+                songMeta += songObject.Comment.length > 0 ? " | " + songObject.Comment : "";
                 var position = String(iterator + 1).padStart(2, '0') + ".";
                 var errorMeta = songObject.HasError ? "⚠️" : "";
-                $("#playlist-songs").append("<a id=\"playlist-songs-" + iterator + "\" href=\"#\" class=\"list-group-item\" data-toggle=\"modal\" data-target=\"#dynamic-modal\">" + errorMeta + position + " " + songObject.Artist + " - " + songObject.Title + " - " + secondsToDate(totalTime) + "<span class=\"glyphicon glyphicon-info-sign\"></span></a>");
-                $("#playlist-songs-sortable").append("<a id=\"playlist-songs-sortable-" + iterator + "\" href=\"#\" class=\"list-group-item\" data-toggle=\"modal\" data-target=\"#dynamic-modal\">" + errorMeta + position + " " + songObject.Artist + " - " + songObject.Title + " - " + secondsToDate(totalTime) + "<span class=\"glyphicon glyphicon-info-sign\"></span></a>");
+                $("#playlist-songs").append("<a id=\"playlist-songs-" + iterator + "\" href=\"#\" class=\"list-group-item\" data-toggle=\"modal\" data-target=\"#dynamic-modal\">" + errorMeta + position + " " + songObject.Artist + " - " + songObject.Title + songMeta + " - " + secondsToDate(totalTime) + "<span class=\"glyphicon glyphicon-info-sign\"></span></a>");
+                $("#playlist-songs-sortable").append("<a id=\"playlist-songs-sortable-" + iterator + "\" href=\"#\" class=\"list-group-item\" data-toggle=\"modal\" data-target=\"#dynamic-modal\">" + errorMeta + position + " " + songObject.Artist + " - " + songObject.Title + songMeta + " - " + secondsToDate(totalTime) + "<span class=\"glyphicon glyphicon-info-sign\"></span></a>");
                 songObject.Position = iterator;
                 songObject.PositionStr = position;
                 $("#playlist-songs-" + iterator).data("modal-songObject", JSON.stringify(songObject));

--- a/data/themes/default/www/js/search.js
+++ b/data/themes/default/www/js/search.js
@@ -49,13 +49,15 @@ $("#search-database").click(function (e, callback) {
             var database = data;
             clearList("searched-songs");
 
-            $.each(database, function (iterator, songObject){
+            $.each(database, function (iterator, songObject) {
                 var songMeta = "";
                 songMeta += songObject.Language.length > 0 ? " | " + songObject.Language : "";
                 songMeta += songObject.Edition.length > 0 ? " | " + songObject.Edition : "";
+                songMeta += songObject.ProvidedBy.length > 0 ? " | " + songObject.ProvidedBy : "";
+                songMeta += songObject.Comment.length > 0 ? " | " + songObject.Comment : "";
                 var errorMeta = songObject.HasError ? "⚠️" : "";
                 $("#searched-songs").append("<a href=\"#\" id=\"searched-songs-" + iterator + "\" class=\"list-group-item\" >" + errorMeta + songObject.Artist + " - " + songObject.Title + songMeta + "<span class=\"glyphicon glyphicon-plus\"></span></a>");
-                $("#searched-songs-"+iterator).data("songObject", JSON.stringify(songObject));
+                $("#searched-songs-" + iterator).data("songObject", JSON.stringify(songObject));
             });
 
             if(database.length === 0) {
@@ -80,14 +82,17 @@ $("#search-database").click(function (e, callback) {
             var database = data;
 
             clearList("searched-songs");
-
-            $.each(database, function (iterator, songObject){
+            $.each(database, function (iterator, songObject) {
                 var songMeta = "";
                 songMeta += songObject.Language.length > 0 ? " | " + songObject.Language : "";
                 songMeta += songObject.Edition.length > 0 ? " | " + songObject.Edition : "";
+                songMeta += songObject.Source.length > 0 ? " | " + songObject.Source : "";
+                songMeta += songObject.App.length > 0 ? " | " + songObject.App : "";
+                songMeta += songObject.AppVersion.length > 0 ? " | " + songObject.AppVersion : "";
+                songMeta += songObject.Comment.length > 0 ? " | " + songObject.Comment : "";
                 var errorMeta = songObject.HasError ? "⚠️" : "";
                 $("#searched-songs").append("<a href=\"#\" id=\"searched-songs-" + iterator + "\" class=\"list-group-item\" >" + errorMeta + songObject.Artist + " - " + songObject.Title + songMeta + "<span class=\"glyphicon glyphicon-plus\"></span></a>");
-                $("#searched-songs-"+iterator).data("songObject", JSON.stringify(songObject));
+                $("#searched-songs-" + iterator).data("songObject", JSON.stringify(songObject));
             });
 
             if(database.length === 0) {

--- a/data/themes/default/www/playlist-song-modal-body.html
+++ b/data/themes/default/www/playlist-song-modal-body.html
@@ -14,6 +14,14 @@
 			<label class="control-label" for="modal-creator-value">creator</label>
 			<span id="modal-creator-value" class="show"></span>
 		</div>
+		<div id="modal-providedby-div" class="col-sm-4">
+			<label class="control-label" for="modal-providedby-value">provided by</label>
+			<span id="modal-providedby-value" class="show"></span>
+		</div>
+		<div id="modal-comment-div" class="col-sm-4">
+			<label class="control-label" for="modal-comment-value">comment</label>
+			<span id="modal-comment-value" class="show"></span>
+		</div>
 	</div>
 	<!-- Simple buttons to move the song one position up or down. -->
 	<div class="form-group row col-sm-12">

--- a/game/notegraph.cc
+++ b/game/notegraph.cc
@@ -158,7 +158,7 @@ void NoteGraph::drawNotes(Window& window) {
 				t1 = &m_notebar; t2 = &m_notebar_hl;
 			break;
 			case Note::Type::GOLDEN:
-			case Note::Type::GOLDEN2: //fallthrough
+			case Note::Type::GOLDENRAP: //fallthrough
 				t1 = &m_notebargold; t2 = &m_notebargold_hl;
 			break;
 			case Note::Type::FREESTYLE:  // Freestyle notes use custom handling

--- a/game/notes.cc
+++ b/game/notes.cc
@@ -23,7 +23,7 @@ double Note::score(double n, double b, double e) const {
 double Note::scoreMultiplier() const {
 	switch(type) {
 		case Note::Type::GOLDEN:
-		case Note::Type::GOLDEN2:
+		case Note::Type::GOLDENRAP:
 			return 2.0;
 		case Note::Type::SLEEP:
 			return 0.0;

--- a/game/notes.hh
+++ b/game/notes.hh
@@ -61,7 +61,7 @@ struct Note {
 	/// which players sung well
 	mutable std::vector<Color> stars;
 	/// note type
-	enum class Type { FREESTYLE = 'F', NORMAL = ':', GOLDEN = '*', GOLDEN2 = 'G', SLIDE = '+', SLEEP = '-', RAP = 'R',
+	enum class Type { FREESTYLE = 'F', NORMAL = ':', GOLDEN = '*', GOLDENRAP = 'G', SLIDE = '+', SLEEP = '-', RAP = 'R',
 	  TAP = '1', HOLDBEGIN = '2', HOLDEND = '3', ROLL = '4', MINE = 'M', LIFT = 'L'} type;
 	float note; ///< MIDI pitch of the note (at the end for slide notes)
 	float notePrev; ///< MIDI pitch of the previous note (should be same as note for everything but SLIDE)

--- a/game/player.cc
+++ b/game/player.cc
@@ -57,7 +57,7 @@ void Player::update() {
 		}
 		if (endTime < m_scoreIt->end) break;  // The note continues past this timestep
 		// Check if we got a star
-		if ((m_scoreIt->type == Note::Type::NORMAL || m_scoreIt->type == Note::Type::SLIDE || m_scoreIt->type == Note::Type::GOLDEN || m_scoreIt->type == Note::Type::GOLDEN2)
+		if ((m_scoreIt->type == Note::Type::NORMAL || m_scoreIt->type == Note::Type::SLIDE || m_scoreIt->type == Note::Type::GOLDEN || m_scoreIt->type == Note::Type::GOLDENRAP)
 		  && (m_noteScore / m_vocal.m_scoreFactor / m_scoreIt->maxScore() > 0.8)) {
 			m_scoreIt->stars.push_back(m_color);
 		}

--- a/game/requesthandler.cc
+++ b/game/requesthandler.cc
@@ -22,7 +22,7 @@ void RequestHandler::Error(pplx::task<void>& t) {
 	try {
 		t.get();
 	}
-	catch(...) {
+	catch (...) {
 	}
 }
 
@@ -34,35 +34,42 @@ void RequestHandler::HandleFile(web::http::http_request request, std::string fil
 
 	concurrency::streams::fstream::open_istream(utility::conversions::to_string_t(fileToSend), std::ios::in).then([=](concurrency::streams::istream is) {
 		std::string content_type = "";
-		if(path.find(".html") != std::string::npos) {
+		if (path.find(".html") != std::string::npos) {
 			content_type = "text/html";
-		} else if(path.find(".js") != std::string::npos) {
+		}
+		else if (path.find(".js") != std::string::npos) {
 			content_type = "text/javascript";
-		} else if (path.find(".css") != std::string::npos) {
+		}
+		else if (path.find(".css") != std::string::npos) {
 			content_type = "text/css";
-		} else if (path.find(".png") != std::string::npos) {
+		}
+		else if (path.find(".png") != std::string::npos) {
 			content_type = "image/png";
-		} else if (path.find(".gif") != std::string::npos) {
+		}
+		else if (path.find(".gif") != std::string::npos) {
 			content_type = "image/gif";
-		} else if (path.find(".ico") != std::string::npos) {
+		}
+		else if (path.find(".ico") != std::string::npos) {
 			content_type = "image/x-icon";
 		}
 
 		request.reply(web::http::status_codes::OK, is, utility::conversions::to_string_t(content_type)).then([](pplx::task<void> t) {
 			try {
 				t.get();
-			} catch(...){
+			}
+			catch (...) {
 				//
 			}
-		});
+			});
 
-	}).then([=](pplx::task<void>t) {
-		try {
-			t.get();
-		} catch(...) {
-			request.reply(web::http::status_codes::InternalError,utility::conversions::to_string_t("INTERNAL ERROR "));
-		}
-	});
+		}).then([=](pplx::task<void>t) {
+			try {
+				t.get();
+			}
+			catch (...) {
+				request.reply(web::http::status_codes::InternalError, utility::conversions::to_string_t("INTERNAL ERROR "));
+			}
+			});
 }
 
 void RequestHandler::Get(web::http::http_request request)
@@ -70,34 +77,44 @@ void RequestHandler::Get(web::http::http_request request)
 	std::string content_type = "text/html";
 	auto uri = request.relative_uri().path();
 	auto query = utility::conversions::to_utf8string(request.relative_uri().query());
-	if(query != "") {
+	if (query != "") {
 		uri += utility::conversions::to_string_t("?") + request.relative_uri().query();
 	}
 	std::clog << "requesthandler/debug: path is: " << utility::conversions::to_utf8string(uri) << std::endl;
 	auto path = utility::conversions::to_utf8string(request.relative_uri().path());
 	if (path == "/") {
 		HandleFile(request, findFile("index.html").string());
-	} else if (path == "/api/getDataBase.json") { //get database
+	}
+	else if (path == "/api/getDataBase.json") { //get database
 		m_songs.setFilter("");
-		if(query == "sort=artist&order=ascending") {
+		if (query == "sort=artist&order=ascending") {
 			m_songs.sortSpecificChange(2);
-		} else if(query == "sort=artist&order=descending") {
+		}
+		else if (query == "sort=artist&order=descending") {
 			m_songs.sortSpecificChange(2, true);
-		} else if(query == "sort=title&order=ascending") {
+		}
+		else if (query == "sort=title&order=ascending") {
 			m_songs.sortSpecificChange(1);
-		} else if(query == "sort=title&order=descending") {
+		}
+		else if (query == "sort=title&order=descending") {
 			m_songs.sortSpecificChange(1, true);
-		} else if(query == "sort=language&order=ascending") {
+		}
+		else if (query == "sort=language&order=ascending") {
 			m_songs.sortSpecificChange(6);
-		} else if(query == "sort=language&order=descending") {
+		}
+		else if (query == "sort=language&order=descending") {
 			m_songs.sortSpecificChange(6, true);
-		} else if(query == "sort=edition&order=ascending") {
+		}
+		else if (query == "sort=edition&order=ascending") {
 			m_songs.sortSpecificChange(3);
-		} else if(query == "sort=edition&order=descending") {
+		}
+		else if (query == "sort=edition&order=descending") {
 			m_songs.sortSpecificChange(3, true);
-		} else if(query == "sort=creator&order=ascending") {
+		}
+		else if (query == "sort=creator&order=ascending") {
 			m_songs.sortSpecificChange(10);
-		} else if(query == "sort=creator&order=descending") {
+		}
+		else if (query == "sort=creator&order=descending") {
 			m_songs.sortSpecificChange(10, true);
 		}
 		// make sure to apply the filtering
@@ -105,22 +122,24 @@ void RequestHandler::Get(web::http::http_request request)
 		web::json::value jsonRoot = SongsToJsonObject();
 		request.reply(web::http::status_codes::OK, jsonRoot);
 		return;
-	}  else if(path == "/api/language") {
+	}
+	else if (path == "/api/language") {
 		auto localeMap = GenerateLocaleDict();
 		web::json::value jsonRoot = web::json::value::object();
-			for (auto const &kv : localeMap) {
-				std::string key = kv.first;
-				//Hack to get an easy key value pair within the json object.
-				if(key == "Web interface by Niek Nooijens and Arjan Speiard, for full credits regarding Performous see /docs/Authors.txt"){
-					key = "Credits";
-				}
-				std::replace(key.begin(), key.end(), ' ','_');
-				key = UnicodeUtil::toLower(key);
-				jsonRoot[utility::conversions::to_string_t(key)] = web::json::value(utility::conversions::to_string_t(kv.second));
+		for (auto const& kv : localeMap) {
+			std::string key = kv.first;
+			//Hack to get an easy key value pair within the json object.
+			if (key == "Web interface by Niek Nooijens and Arjan Speiard, for full credits regarding Performous see /docs/Authors.txt") {
+				key = "Credits";
 			}
+			std::replace(key.begin(), key.end(), ' ', '_');
+			key = UnicodeUtil::toLower(key);
+			jsonRoot[utility::conversions::to_string_t(key)] = web::json::value(utility::conversions::to_string_t(kv.second));
+		}
 		request.reply(web::http::status_codes::OK, jsonRoot);
 		return;
-	} else if(path == "/api/getCurrentPlaylist.json") {
+	}
+	else if (path == "/api/getCurrentPlaylist.json") {
 		web::json::value jsonRoot = web::json::value::array();
 		unsigned i = 0;
 		for (auto const& song : m_game.getCurrentPlayList().getList()) {
@@ -132,16 +151,20 @@ void RequestHandler::Get(web::http::http_request request)
 			songObject[utility::conversions::to_string_t("Creator")] = web::json::value::string(utility::conversions::to_string_t(song->creator));
 			songObject[utility::conversions::to_string_t("Duration")] = web::json::value(song->getDurationSeconds());
 			songObject[utility::conversions::to_string_t("HasError")] = web::json::value::boolean(song->loadStatus == Song::LoadStatus::ERROR);
+			songObject[utility::conversions::to_string_t("ProvidedBy")] = web::json::value(utility::conversions::to_string_t(song->providedBy));
+			songObject[utility::conversions::to_string_t("Comment")] = web::json::value(utility::conversions::to_string_t(song->comment));
 			jsonRoot[i] = songObject;
 			i++;
 		}
 
 		request.reply(web::http::status_codes::OK, jsonRoot);
 		return;
-	} else if(path == "/api/getplaylistTimeout") {
+	}
+	else if (path == "/api/getplaylistTimeout") {
 		request.reply(web::http::status_codes::OK, std::to_string(config["game/playlist_screen_timeout"].ui()));
 		return;
-	} else {
+	}
+	else {
 		HandleFile(request);
 	}
 }
@@ -150,7 +173,7 @@ void RequestHandler::Post(web::http::http_request request)
 {
 	auto uri = request.relative_uri().path();
 	auto query = utility::conversions::to_utf8string(request.relative_uri().query());
-	if(query != "") {
+	if (query != "") {
 		uri += utility::conversions::to_string_t("?") + request.relative_uri().query();
 	}
 	std::clog << "requesthandler/debug: path is: " << utility::conversions::to_utf8string(uri) << std::endl;
@@ -159,7 +182,7 @@ void RequestHandler::Post(web::http::http_request request)
 
 	web::json::value jsonPostBody = ExtractJsonFromRequest(request);
 
-	if(jsonPostBody == web::json::value::null()) {
+	if (jsonPostBody == web::json::value::null()) {
 		request.reply(web::http::status_codes::BadRequest, "Post body is malformed. Please make a valid request.");
 		return;
 	}
@@ -167,7 +190,7 @@ void RequestHandler::Post(web::http::http_request request)
 	if (path == "/api/add") {
 		m_songs.setFilter("");
 		std::shared_ptr<Song> songPointer = GetSongFromJSON(jsonPostBody);
-		if(!songPointer) {
+		if (!songPointer) {
 			auto artist = utility::conversions::to_utf8string(jsonPostBody[utility::conversions::to_string_t("Artist")].as_string());
 			auto title = utility::conversions::to_utf8string(jsonPostBody[utility::conversions::to_string_t("Title")].as_string());
 			request.reply(web::http::status_codes::NotFound, "Song \"" + artist + " - " + title + "\" was not found.");
@@ -188,8 +211,9 @@ void RequestHandler::Post(web::http::http_request request)
 			request.reply(web::http::status_codes::OK, "success");
 			return;
 		}
-	} else if(path == "/api/remove") {
-		if(m_game.getCurrentPlayList().isEmpty()) {
+	}
+	else if (path == "/api/remove") {
+		if (m_game.getCurrentPlayList().isEmpty()) {
 			request.reply(web::http::status_codes::BadRequest, "Playlist is empty.");
 			return;
 		}
@@ -201,13 +225,15 @@ void RequestHandler::Post(web::http::http_request request)
 
 			request.reply(web::http::status_codes::OK, "success");
 			return;
-		} catch(web::json::json_exception const & e) {
+		}
+		catch (web::json::json_exception const& e) {
 			std::string str = std::string("JSON Exception: ") + e.what();
 			request.reply(web::http::status_codes::BadRequest, str);
 			return;
 		}
-	} else if(path == "/api/setposition") {
-		if(m_game.getCurrentPlayList().isEmpty()) {
+	}
+	else if (path == "/api/setposition") {
+		if (m_game.getCurrentPlayList().isEmpty()) {
 			request.reply(web::http::status_codes::BadRequest, "Playlist is empty.");
 			return;
 		}
@@ -230,16 +256,18 @@ void RequestHandler::Post(web::http::http_request request)
 				request.reply(web::http::status_codes::BadRequest, "Not gonna move the song to \"" + std::to_string(positionToMoveTo + 1) + "\" since the list ain't that long. Please make a valid request.");
 				return;
 			}
-		} catch(web::json::json_exception const & e) {
+		}
+		catch (web::json::json_exception const& e) {
 			std::string str = std::string("JSON Exception: ") + e.what();
 			request.reply(web::http::status_codes::BadRequest, str);
 			return;
 		}
-	} else if(path == "/api/search") {
+	}
+	else if (path == "/api/search") {
 		auto query = utility::conversions::to_utf8string(jsonPostBody[utility::conversions::to_string_t("query")].as_string());
 		m_songs.setFilter(query);
 		web::json::value jsonRoot = web::json::value::array();
-		for(size_t i = 0; i < m_songs.size(); i++) {
+		for (size_t i = 0; i < m_songs.size(); i++) {
 			web::json::value songObject = web::json::value::object();
 			songObject[utility::conversions::to_string_t("Title")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->title));
 			songObject[utility::conversions::to_string_t("Artist")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->artist));
@@ -247,12 +275,15 @@ void RequestHandler::Post(web::http::http_request request)
 			songObject[utility::conversions::to_string_t("Language")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->language));
 			songObject[utility::conversions::to_string_t("Creator")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->creator));
 			songObject[utility::conversions::to_string_t("HasError")] = web::json::value::boolean(m_songs[i]->loadStatus == Song::LoadStatus::ERROR);
+			songObject[utility::conversions::to_string_t("ProvidedBy")] = web::json::value(utility::conversions::to_string_t(m_songs[i]->providedBy));
+			songObject[utility::conversions::to_string_t("Comment")] = web::json::value(utility::conversions::to_string_t(m_songs[i]->comment));
 			jsonRoot[i] = songObject;
 		}
 		request.reply(web::http::status_codes::OK, jsonRoot);
 		return;
-	} else {
-		request.reply(web::http::status_codes::NotFound, "The path \""+ path +"\" was not found.");
+	}
+	else {
+		request.reply(web::http::status_codes::NotFound, "The path \"" + path + "\" was not found.");
 		return;
 	}
 }
@@ -270,24 +301,24 @@ void RequestHandler::Put(web::http::http_request request)
 web::json::value RequestHandler::ExtractJsonFromRequest(web::http::http_request request) {
 	web::json::value jsonBody = web::json::value::null();
 	request.extract_json().then([&jsonBody](pplx::task<web::json::value> task)
-	{
-		 try
-		 {
-			jsonBody = task.get();
-		 }
-		 catch (web::json::json_exception const & e)
-		 {
-			std::clog << "webserver/error: JSON exception was thrown \"" << e.what() << "\"." << std::endl;
-		 }
-	}).wait();
+		{
+			try
+			{
+				jsonBody = task.get();
+			}
+			catch (web::json::json_exception const& e)
+			{
+				std::clog << "webserver/error: JSON exception was thrown \"" << e.what() << "\"." << std::endl;
+			}
+		}).wait();
 
-	return jsonBody;
+		return jsonBody;
 }
 
 
 web::json::value RequestHandler::SongsToJsonObject() {
 	web::json::value jsonRoot = web::json::value::array();
-	for (size_t i=0; i< m_songs.size(); i++) {
+	for (size_t i = 0; i < m_songs.size(); i++) {
 		web::json::value songObject = web::json::value::object();
 		songObject[utility::conversions::to_string_t("Title")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->title));
 		songObject[utility::conversions::to_string_t("Artist")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->artist));
@@ -296,6 +327,8 @@ web::json::value RequestHandler::SongsToJsonObject() {
 		songObject[utility::conversions::to_string_t("Creator")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->creator));
 		songObject[utility::conversions::to_string_t("name")] = web::json::value::string(utility::conversions::to_string_t(m_songs[i]->artist + " " + m_songs[i]->title));
 		songObject[utility::conversions::to_string_t("HasError")] = web::json::value::boolean(m_songs[i]->loadStatus == Song::LoadStatus::ERROR);
+		songObject[utility::conversions::to_string_t("ProvidedBy")] = web::json::value(utility::conversions::to_string_t(m_songs[i]->providedBy));
+		songObject[utility::conversions::to_string_t("Comment")] = web::json::value(utility::conversions::to_string_t(m_songs[i]->comment));
 		jsonRoot[i] = songObject;
 	}
 
@@ -305,12 +338,14 @@ web::json::value RequestHandler::SongsToJsonObject() {
 std::shared_ptr<Song> RequestHandler::GetSongFromJSON(web::json::value jsonDoc) {
 	m_songs.setFilter("");
 
-	for(size_t i = 0; i< m_songs.size(); i++) {
-		if(m_songs[i]->title == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Title")].as_string()) &&
-		   m_songs[i]->artist == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Artist")].as_string()) &&
-		   m_songs[i]->edition == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Edition")].as_string()) &&
-		   m_songs[i]->language == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Language")].as_string()) &&
-		   m_songs[i]->creator == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Creator")].as_string()) ) {
+	for (size_t i = 0; i < m_songs.size(); i++) {
+		if (m_songs[i]->title == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Title")].as_string()) &&
+			m_songs[i]->artist == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Artist")].as_string()) &&
+			m_songs[i]->edition == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Edition")].as_string()) &&
+			m_songs[i]->language == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Language")].as_string()) &&
+			m_songs[i]->creator == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Creator")].as_string()) &&
+			m_songs[i]->providedBy == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("ProvidedBy")].as_string()) &&
+			m_songs[i]->comment == utility::conversions::to_utf8string(jsonDoc[utility::conversions::to_string_t("Comment")].as_string())) {
 			std::clog << "webserver/info: Found requested song." << std::endl;
 			return m_songs[i];
 		}
@@ -323,7 +358,7 @@ std::shared_ptr<Song> RequestHandler::GetSongFromJSON(web::json::value jsonDoc) 
 std::map<std::string, std::string> RequestHandler::GenerateLocaleDict() {
 	std::vector<std::string> translationKeys = GetTranslationKeys();
 	std::map<std::string, std::string> localeMap;
-	for (auto const &translationKey : translationKeys) {
+	for (auto const& translationKey : translationKeys) {
 		localeMap[translationKey] = _(translationKey);
 	}
 	return localeMap;

--- a/game/song.cc
+++ b/game/song.cc
@@ -20,6 +20,8 @@ Song::Song(nlohmann::json const& song) : dummyVocal(TrackName::VOCAL_LEAD), rand
     artist = getJsonEntry<std::string>(song, "artist").value_or("");
     title = getJsonEntry<std::string>(song, "title").value_or("");
     language = getJsonEntry<std::string>(song, "language").value_or("");
+    tags = getJsonEntry<std::string>(song, "tags").value_or("");
+    version = getJsonEntry<std::string>(song, "version").value_or("");
     edition = getJsonEntry<std::string>(song, "edition").value_or("");
     creator = getJsonEntry<std::string>(song, "creator").value_or("");
     providedBy = getJsonEntry<std::string>(song, "providedBy").value_or("");
@@ -31,6 +33,8 @@ Song::Song(nlohmann::json const& song) : dummyVocal(TrackName::VOCAL_LEAD), rand
     midifilename = getJsonEntry<std::string>(song, "midiFile").value_or("");
     videoGap = getJsonEntry<double>(song, "videoGap").value_or(0.0);
     start = getJsonEntry<double>(song, "start").value_or(0.0);
+    end = getJsonEntry<double>(song, "end").value_or(0.0);
+    year = getJsonEntry<int>(song, "year").value_or(0.0);
     preview_start = getJsonEntry<double>(song, "previewStart").value_or(0.0);
     m_duration = getJsonEntry<double>(song, "duration").value_or(0.0);
     music[TrackName::BGMUSIC] = getJsonEntry<std::string>(song, "songFile").value_or("");

--- a/game/song.cc
+++ b/game/song.cc
@@ -22,6 +22,8 @@ Song::Song(nlohmann::json const& song) : dummyVocal(TrackName::VOCAL_LEAD), rand
     language = getJsonEntry<std::string>(song, "language").value_or("");
     edition = getJsonEntry<std::string>(song, "edition").value_or("");
     creator = getJsonEntry<std::string>(song, "creator").value_or("");
+    providedBy = getJsonEntry<std::string>(song, "providedBy").value_or("");
+    comment = getJsonEntry<std::string>(song, "comment").value_or("");
     genre = getJsonEntry<std::string>(song, "genre").value_or("");
     cover = getJsonEntry<std::string>(song, "cover").value_or("");
     background = getJsonEntry<std::string>(song, "background").value_or("");

--- a/game/song.hh
+++ b/game/song.hh
@@ -66,6 +66,8 @@ public:
 	std::string text; ///< songtext
 	std::string creator; ///< creator
 	std::string language; ///< language
+	std::string providedBy; ///< source of the mapped file.
+	std::string comment; ///< comment of the mapped file.
 	using MusicFiles = std::map<std::string, fs::path>;
 	MusicFiles music; ///< music files (background, guitar, rhythm/bass, drums, vocals)
 	fs::path cover; ///< cd cover

--- a/game/song.hh
+++ b/game/song.hh
@@ -15,6 +15,7 @@ class SongParser;
 
 namespace TrackName {
 	const std::string BGMUSIC = "background";
+	const std::string INSTRUMENTAL = "Instrumental";
 	const std::string PREVIEW = "Preview";
 	const std::string GUITAR = "Guitar";
 	const std::string GUITAR_COOP = "Coop guitar";
@@ -60,6 +61,7 @@ public:
 	std::vector<BPM> m_bpms;
 	std::vector<std::string> category; ///< category of song
 	std::string genre; ///< genre
+	std::string tags; ///< tags
 	std::string edition; ///< license
 	std::string title; ///< songtitle
 	std::string artist; ///< artist
@@ -68,6 +70,7 @@ public:
 	std::string language; ///< language
 	std::string providedBy; ///< source of the mapped file.
 	std::string comment; ///< comment of the mapped file.
+	std::string version; ///< version of the mapped file.
 	using MusicFiles = std::map<std::string, fs::path>;
 	MusicFiles music; ///< music files (background, guitar, rhythm/bass, drums, vocals)
 	fs::path cover; ///< cd cover
@@ -79,6 +82,8 @@ public:
 	std::string collateByArtistOnly;  ///< String for sorting by artist only
 	double videoGap = 0.0; ///< gap with video
 	double start = 0.0; ///< start of song
+	double end = 0.0; ///< end of song
+	int year = 0; ///< year of the song
 	double preview_start = getNaN(); ///< starting time for the preview
 	double m_duration = 0.0;
 	using Stops = std::vector<std::pair<double,double> >;

--- a/game/songparser-txt.cc
+++ b/game/songparser-txt.cc
@@ -109,6 +109,8 @@ bool SongParser::txtParseField(std::string const& line) {
 	std::string value = trim(line.substr(pos + 1));
 	if (value.empty()) return true;
 
+	if (key == "VERSION") m_song.version = value.substr(value.find_first_not_of(" "));
+
 	// Parse header data that is stored in SongParser rather than in song (and thus needs to be read every time)
 	if (key == "BPM") assign(m_bpm, value);
 	else if (key == "RELATIVE") assign(m_relative, value);
@@ -126,16 +128,20 @@ bool SongParser::txtParseField(std::string const& line) {
 	else if (key == "GENRE") m_song.genre = value.substr(value.find_first_not_of(" "));
 	else if (key == "CREATOR") m_song.creator = value.substr(value.find_first_not_of(" "));
 	else if (key == "COVER") m_song.cover = absolute(value, m_song.path);
-	else if (key == "MP3") m_song.music[TrackName::BGMUSIC] = absolute(value, m_song.path);
+	else if (key == "MP3" || key == "AUDIO") m_song.music[TrackName::BGMUSIC] = absolute(value, m_song.path);
+	else if (key == "INSTRUMENTAL") m_song.music[TrackName::INSTRUMENTAL] = absolute(value, m_song.path);
 	else if (key == "VOCALS") m_song.music[TrackName::VOCAL_LEAD] = absolute(value, m_song.path);
 	else if (key == "VIDEO") m_song.video = absolute(value, m_song.path);
 	else if (key == "BACKGROUND") m_song.background = absolute(value, m_song.path);
 	else if (key == "START") assign(m_song.start, value);
+	else if (key == "END") assign(m_song.end, value);
+	else if (key == "YEAR") assign(m_song.year, value);
 	else if (key == "VIDEOGAP") assign(m_song.videoGap, value);
 	else if (key == "PREVIEWSTART") assign(m_song.preview_start, value);
 	else if (key == "LANGUAGE") m_song.language = value.substr(value.find_first_not_of(" "));
 	else if (key == "PROVIDEDBY") m_song.providedBy = value.substr(value.find_first_not_of(" "));
 	else if (key == "COMMENT") m_song.comment = value.substr(value.find_first_not_of(" "));
+	else if (key == "TAGS") m_song.tags = value.substr(value.find_first_not_of(" "));
 	return true;
 }
 
@@ -176,7 +182,7 @@ bool SongParser::txtParseNote(std::string line) {
 		case Note::Type::RAP:
 		case Note::Type::FREESTYLE:
 		case Note::Type::GOLDEN:
-		case Note::Type::GOLDEN2:
+		case Note::Type::GOLDENRAP:
 		{
 			unsigned int length = 0;
 			if (!(iss >> ts >> length >> n.note)) throw std::runtime_error("Invalid note line format");

--- a/game/songparser-txt.cc
+++ b/game/songparser-txt.cc
@@ -134,6 +134,8 @@ bool SongParser::txtParseField(std::string const& line) {
 	else if (key == "VIDEOGAP") assign(m_song.videoGap, value);
 	else if (key == "PREVIEWSTART") assign(m_song.preview_start, value);
 	else if (key == "LANGUAGE") m_song.language = value.substr(value.find_first_not_of(" "));
+	else if (key == "PROVIDEDBY") m_song.providedBy = value.substr(value.find_first_not_of(" "));
+	else if (key == "COMMENT") m_song.comment = value.substr(value.find_first_not_of(" "));
 	return true;
 }
 

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -154,6 +154,15 @@ void Songs::CacheSonglist() {
 		if(!song->edition.empty()) {
 			songObject["edition"] = song->edition;
 		}
+		if (!song->tags.empty()) {
+			songObject["tags"] = song->tags;
+		}
+		if (!song->version.empty()) {
+			songObject["version"] = song->version;
+		}
+		if (song->year != 0) {
+			songObject["year"] = song->year;
+		}
 		if(!song->language.empty()) {
 			songObject["language"] = song->language;
 		}
@@ -178,6 +187,9 @@ void Songs::CacheSonglist() {
 		if(!song->music[TrackName::BGMUSIC].string().empty()) {
 			songObject["songFile"] = song->music[TrackName::BGMUSIC].string();
 		}
+		if (!song->music[TrackName::INSTRUMENTAL].string().empty()) {
+			songObject["instrumental"] = song->music[TrackName::INSTRUMENTAL].string();
+		}
 		if(!song->midifilename.string().empty()) {
 			songObject["midiFile"] = song->midifilename.string();
 		}
@@ -186,6 +198,9 @@ void Songs::CacheSonglist() {
 		}
 		if(!std::isnan(song->start)) {
 			songObject["start"] = song->start;
+		}
+		if (!std::isnan(song->end)) {
+			songObject["end"] = song->end;
 		}
 		if(!std::isnan(song->videoGap)) {
 			songObject["videoGap"] = song->videoGap;

--- a/game/songs.cc
+++ b/game/songs.cc
@@ -160,6 +160,12 @@ void Songs::CacheSonglist() {
 		if(!song->creator.empty()) {
 			songObject["creator"] = song->creator;
 		}
+		if (!song->providedBy.empty()) {
+			songObject["providedBy"] = song->providedBy;
+		}
+		if (!song->comment.empty()) {
+			songObject["comment"] = song->comment;
+		}
 		if(!song->genre.empty()) {
 			songObject["genre"] = song->genre;
 		}


### PR DESCRIPTION
### What does this PR do?

Introduces a new field `PROVIDEDBY`
This helps in distinguishing where the mapped file came from and which program made it at which version.
Aside from this `#COMMENT` is sometimes used which is now also supported

### Closes Issue(s)

closes #961

### Motivation

I'm trying to get a couple new standardized fields into the ultrastar format.
This allows hosting websites to add their name to song files whilst creator tools like composer add their specific version and appname.

This way everyone knows where the txt came from and which program is used to create it.

Since the varying sources of which you can download songs from differ in quality this is a nicely added bonus to see where it came from.

Might be a niche for just me, but if everyone opts in it'd make for a way better system and maybe even a newly introduced system which combines all the sources out there.... (that's my endgoal)

### Testing

You can test this by adding the following tags:
```
#PROVIDEDBY:https://usdb.animux.de
#COMMENT:Some comment
```

All tags are opt in. But if everyone plays by the rules every txt will have these fields eventually

The tags are shown within the webserver-ui: Playlist and search screen.
All extra tags are seperated by the `|` symbol. And the popup if you click a song also mentions the tags + content if they're there.


### Update
I've recently added a couple of new fields and fallback keys these are
`#VERSION` -> Defines the version of the mapped song. This version applies to the Format project https://github.com/UltraStar-Deluxe/format logic which changes through versions has not been added yet as everything is at this moment backwards compatible. Starting with version 2.0.0 we need to add specific handlers for the different versions.
`#YEAR` -> Defines the year of when the song came out
`#AUDIO` -> Is going to replace the `#MP3` header
`#INSTRUMENTAL` -> Aside from Audio we can now specify the instrumental track within the same file. This allows us to mix them in software for several usecases
`#END` -> Specifies the time in milliseconds from the beginning of the audio file at which the song ends. This value can be used to stop playback before any silence or outro at the end of the audio file
`#TAGS` -> A list of arbitrary tags we can help searching for songs

Replaced `GOLDEN2` enum value to `GOLDENRAP` as this is what the G stands for