### PR TITLE
Kiosk mode -> limit playlist and boot straight to songs.

### DIFF
--- a/data/config/schema.xml
+++ b/data/config/schema.xml
@@ -36,6 +36,11 @@ to save the current settings to XML.
 			<short>Paths</short>
 			<long>Setup song and data paths.</long>
 		</entry>
+		<entry name="kioskmode">
+			<short>Kiosk mode</short>
+			<long>Setup automatic song play for event displays</long>
+		</entry>
+		
 	</menu>
 
 	<!-- Gameplay preferences -->
@@ -439,4 +444,21 @@ to save the current settings to XML.
 		<short>Sort order</short>
 		<long>Currently active sort order.</long>
 	</entry>
+	<!-- Kiosk mode -->
+	<entry name="kioskmode/startupscreen" type="uint" value="0">
+		<limits>
+			<enum>Main menu</enum>
+			<enum>Song browser</enum>
+			<enum>Sing screen</enum>
+		</limits>
+		<short>Startup screen</short>
+		<long>Define which screen the game should start in (requires restart).</long>
+	</entry>
+	<entry name="kioskmode/playlist_limit" type="uint" value="0">
+		<!-- maximum of 16 bit is 65536, so 60000 should be a nice upper-limit -->
+		<limits min="0" max="100" step="1" />
+		<short>Max playlist length</short>
+		<long>The maximum amount of songs allowed in the playlist. (0 = unlimited)</long>
+	</entry>
+	
 </performous>

--- a/game/config.cmake.hh
+++ b/game/config.cmake.hh
@@ -24,5 +24,11 @@
 #define LIBXMLPP_VERSION_3_0 @LibXML++_VERSION_3_0@
 #define LIBXMLPP_VERSION_5_0 @LibXML++_VERSION_5_0@
 
+enum e_startup_screens {
+	SCREEN_INTRO = 0,
+	SCREEN_SONGS = 1,
+	SCREEN_SING = 2
+};
+
 #endif
 

--- a/game/game.cc
+++ b/game/game.cc
@@ -17,6 +17,7 @@ Game::Game(Window& window):
   m_loadingProgress(0.0f), m_logo(findFile("logo.svg")), m_logoAnim(0.0, 0.5)
 {
 	m_textMessage.dimensions.middle().center(-0.05f);
+	currentPlaylist.setLimit(config["kioskmode/playlist_limit"].ui());
 }
 
 void Game::activateScreen(std::string const& name) {

--- a/game/main.cc
+++ b/game/main.cc
@@ -91,7 +91,7 @@ static void checkEvents(Game& gm, Time eventTime) {
 		gm.getCurrentScreen()->manageEvent(event);
 	}
 
-	// Need to toggle full screen mode or adjust resolution?
+    // Need to toggle full screen mode or adjust resolution?
 	window.resize();
 }
 
@@ -139,10 +139,37 @@ void mainLoop(std::string const& songlist) {
 	gm.addScreen(std::make_unique<ScreenPaths>(gm, "Paths", audio, songs));
 	gm.addScreen(std::make_unique<ScreenPlayers>(gm, "Players", audio, database));
 	gm.addScreen(std::make_unique<ScreenPlaylist>(gm, "Playlist", audio, songs, backgrounds));
-	gm.activateScreen("Intro");
-	gm.loading(_("Entering main menu..."), 0.8f);
-	gm.updateScreen();  // exit/enter, any exception is fatal error
-	gm.loading(_("Loading complete!"), 1.0f);
+
+	switch((e_startup_screens)config["kioskmode/startupscreen"].ui()) {
+		case SCREEN_INTRO:
+			gm.activateScreen("Intro");
+			gm.loading(_("Entering main menu..."), 0.8f);
+			gm.updateScreen();  // exit/enter, any exception is fatal error
+			gm.loading(_("Loading complete!"), 1.0f);
+		break;
+		case SCREEN_SONGS:
+			gm.activateScreen("Songs");
+			gm.loading(_("Entering song select..."), 0.8f);
+			gm.updateScreen();  // exit/enter, any exception is fatal error
+			gm.loading(_("Loading complete!"), 1.0f);
+		break;
+		case SCREEN_SING:
+			Screen* s = gm.getScreen("Sing");
+			ScreenSing* ss = dynamic_cast<ScreenSing*> (s);
+			while(songs.empty()) {
+				gm.loading(_("loading songs... please wait"), 0.8f);
+				sleep(1);
+				songs.update();
+			}
+			unsigned randomsong = static_cast<unsigned>(std::rand()) % static_cast<unsigned>(songs.size());
+			ss->setSong(songs[randomsong]);
+			gm.activateScreen("Sing");
+			gm.loading(_("Entering karaoke display..."), 0.8f);
+			gm.updateScreen();  // exit/enter, any exception is fatal error
+			gm.loading(_("Loading complete!"), 1.0f);
+		break;
+	}
+
 	// Main loop
 	auto time = Clock::now();
 	unsigned frames = 0;

--- a/game/playlist.cc
+++ b/game/playlist.cc
@@ -3,9 +3,13 @@
 #include <algorithm>
 #include <random>
 
-void PlayList::addSong(std::shared_ptr<Song> song) {
-	std::lock_guard<std::mutex> l(m_mutex);
-	m_list.push_back(song);
+bool PlayList::addSong(std::shared_ptr<Song> song) {
+	if(m_limit == 0 || m_limit >= m_list.size() + 1) {
+		std::lock_guard<std::mutex> l(m_mutex);
+		m_list.push_back(song);
+		return true;
+	}
+	return false;
 }
 
 std::shared_ptr<Song> PlayList::getNext() {

--- a/game/playlist.hh
+++ b/game/playlist.hh
@@ -16,7 +16,7 @@ public:
 	typedef std::vector< std::shared_ptr<Song> > SongList;
 
 	/// Adds a new song to the queue
-	void addSong(std::shared_ptr<Song> song);
+	bool addSong(std::shared_ptr<Song> song);
 	/// Returns the next song and removes it from the queue
 	std::shared_ptr<Song> getNext();
 	/// Returns all currently queued songs
@@ -33,6 +33,8 @@ public:
 	void removeSong(unsigned index);
 	/// swaps two songs
 	void swap (unsigned index1, unsigned index2);
+	/// sets limit to the max amount of songs
+	void setLimit(unsigned int limit) { m_limit = limit; };
 	/// Moves a song from an index to another index.
 	void move(unsigned fromIndex, unsigned toIndex);
 	/// gets a specific song and removes it from the queue
@@ -42,5 +44,6 @@ public:
 private:
 	SongList m_list;
 	mutable std::mutex m_mutex;
+	unsigned int m_limit = 0;
 };
 

--- a/game/requesthandler.cc
+++ b/game/requesthandler.cc
@@ -181,11 +181,13 @@ void RequestHandler::Post(web::http::http_request request)
 		}
 		else {
 			std::clog << "requesthandler/debug: Adding " << songPointer->artist << " - " << songPointer->title << " to the playlist " << std::endl;
-			m_game.getCurrentPlayList().addSong(songPointer);
-			ScreenPlaylist* m_pp = dynamic_cast<ScreenPlaylist*>(m_game.getScreen("Playlist"));
-			m_pp->triggerSongListUpdate();
-
-			request.reply(web::http::status_codes::OK, "success");
+			if(m_game.getCurrentPlayList().addSong(songPointer)) {
+				ScreenPlaylist* m_pp = dynamic_cast<ScreenPlaylist*>(m_game.getScreen("Playlist"));
+				m_pp->triggerSongListUpdate();
+				request.reply(web::http::status_codes::OK, "success");
+			} else {
+				request.reply(web::http::status_codes::Forbidden, "Too many songs already in playlist");
+			}
 			return;
 		}
 	} else if(path == "/api/remove") {

--- a/game/screen_intro.cc
+++ b/game/screen_intro.cc
@@ -72,6 +72,7 @@ void ScreenIntro::manageEvent(SDL_Event event) {
 		}
 		else if (key == SDL_SCANCODE_S && modifier & Platform::shortcutModifier()) {
 			writeConfig(getGame(), modifier & KMOD_ALT);
+			getGame().getCurrentPlayList().setLimit(config["kioskmode/playlist_limit"].ui());
 			getGame().flashMessage((modifier & KMOD_ALT)
 				? _("Settings saved as system defaults.") : _("Settings saved."));
 		}

--- a/game/screen_songs.cc
+++ b/game/screen_songs.cc
@@ -220,7 +220,9 @@ bool ScreenSongs::addSong() {
 	auto& pl = getGame().getCurrentPlayList();
 	auto song = m_songs.currentPtr();
 	if (song->loadStatus != Song::LoadStatus::ERROR) {
-		pl.addSong(song);
+		if(!pl.addSong(song)) {
+			getGame().dialog(_("The playlist size reached it's configured limit."));
+		}
 	}
 	else {
 		getGame().dialog(_("Song load status is error. Please check what's wrong with it."));
@@ -604,10 +606,13 @@ std::unique_ptr<fvec_t, void(*)(fvec_t*)> ScreenSongs::previewBeatsBuffer = std:
 void ScreenSongs::createPlaylistMenu() {
 	m_menu.clear();
 	m_menu.add(MenuOption(_("Play"), "")).call([this]() {
-		getGame().getCurrentPlayList().addSong(m_songs.currentPtr());
-		m_menuPos = 1;
-		m_menu.close();
-		sing();
+		if(!getGame().getCurrentPlayList().addSong(m_songs.currentPtr())) {
+			getGame().dialog(_("Playlist reached it's configured limit."));
+		} else {
+			m_menuPos = 1;
+			m_menu.close();
+			sing();
+		}
 	});
 	m_menu.add(MenuOption(_("Shuffle"), "")).call([this]() {
 		getGame().getCurrentPlayList().shuffle();


### PR DESCRIPTION
…imit playlist size

<!--
PLEASE READ THIS MESSAGE.

### What does this PR do?

Adds the kiosk mode menu with settings allowing you to limit the playlist size and boot straight to the song screen.

### Closes Issue(s)
none

### Motivation

Too little personell at tomo conventions, so we're automating the karaoke booth.
To avoid abuse of the playlist system we limit the maximum amount of songs.
We also just want to connect power, and have the system boot straight into karaoke mode so any idiot can set it up.
Starting the webbrowser on a different screen will be done by shell script.
