### PR TITLE
Visual Studio TestExplorer detects the google tests

### DIFF
--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -9,9 +9,11 @@ set(SOURCE_FILES
 	"fixednotegraphscalertest.cc"
 	"microphones_test.cc"
 	"notegraphscalerfactorytest.cc"
-	"printer.cc"
 	"ringbuffertest.cc"
 	"utiltest.cc"
+
+	"main.cc"
+	"printer.cc"
 )
 set(GAME_SOURCES
 	"../game/analyzer.cc"

--- a/testing/colortest.cc
+++ b/testing/colortest.cc
@@ -2,79 +2,77 @@
 
 #include "common.hh"
 
-namespace {
-	TEST(UnitTest_Color, default_ctor_white) {
-		EXPECT_EQ(1.0f, Color().r);
-		EXPECT_EQ(1.0f, Color().g);
-		EXPECT_EQ(1.0f, Color().b);
-		EXPECT_EQ(1.0f, Color().a);
-	}
+TEST(UnitTest_Color, default_ctor_white) {
+    EXPECT_EQ(1.0f, Color().r);
+    EXPECT_EQ(1.0f, Color().g);
+    EXPECT_EQ(1.0f, Color().b);
+    EXPECT_EQ(1.0f, Color().a);
+}
 
-	TEST(UnitTest_Color, ctor_rgb) {
-		EXPECT_EQ(0.1f, Color(0.1f, 0.2f, 0.3f).r);
-		EXPECT_EQ(0.2f, Color(0.1f, 0.2f, 0.3f).g);
-		EXPECT_EQ(0.3f, Color(0.1f, 0.2f, 0.3f).b);
-		EXPECT_EQ(1.0f, Color(0.1f, 0.2f, 0.3f).a);
-	}
+TEST(UnitTest_Color, ctor_rgb) {
+    EXPECT_EQ(0.1f, Color(0.1f, 0.2f, 0.3f).r);
+    EXPECT_EQ(0.2f, Color(0.1f, 0.2f, 0.3f).g);
+    EXPECT_EQ(0.3f, Color(0.1f, 0.2f, 0.3f).b);
+    EXPECT_EQ(1.0f, Color(0.1f, 0.2f, 0.3f).a);
+}
 
-	TEST(UnitTest_Color, ctor_rgba) {
-		EXPECT_EQ(0.1f, Color(0.1f, 0.2f, 0.3f, 0.4f).r);
-		EXPECT_EQ(0.2f, Color(0.1f, 0.2f, 0.3f, 0.4f).g);
-		EXPECT_EQ(0.3f, Color(0.1f, 0.2f, 0.3f, 0.4f).b);
-		EXPECT_EQ(0.4f, Color(0.1f, 0.2f, 0.3f, 0.4f).a);
-	}
+TEST(UnitTest_Color, ctor_rgba) {
+    EXPECT_EQ(0.1f, Color(0.1f, 0.2f, 0.3f, 0.4f).r);
+    EXPECT_EQ(0.2f, Color(0.1f, 0.2f, 0.3f, 0.4f).g);
+    EXPECT_EQ(0.3f, Color(0.1f, 0.2f, 0.3f, 0.4f).b);
+    EXPECT_EQ(0.4f, Color(0.1f, 0.2f, 0.3f, 0.4f).a);
+}
 
-	TEST(UnitTest_Color, alpha_factory) {
-		EXPECT_EQ(1.0f, Color::alpha(0.1f).r);
-		EXPECT_EQ(1.0f, Color::alpha(0.1f).g);
-		EXPECT_EQ(1.0f, Color::alpha(0.1f).b);
-		EXPECT_EQ(0.1f, Color::alpha(0.1f).a);
-	}
+TEST(UnitTest_Color, alpha_factory) {
+    EXPECT_EQ(1.0f, Color::alpha(0.1f).r);
+    EXPECT_EQ(1.0f, Color::alpha(0.1f).g);
+    EXPECT_EQ(1.0f, Color::alpha(0.1f).b);
+    EXPECT_EQ(0.1f, Color::alpha(0.1f).a);
+}
 
-	TEST(UnitTest_Color, ctor_ccs_name) {
-		auto const colors = std::map<std::string, Color> {
-			{"maroon", Color("#800000FF")},
-			{"red", Color("#FF0000FF")},
-			{"green", Color("#008000FF")},
-			{"lime", Color("#00FF00FF")},
-			{"navy", Color("#000080FF")},
-			{"blue", Color("#0000FFFF")},
-			{"purple", Color("#800080FF")},
-			{"fuchsia", Color("#FF00FFFF")},
-			{"olive", Color("#808000FF")},
-			{"yellow", Color("#FFFF00FF")},
-			{"teal", Color("#008080FF")},
-			{"aqua", Color("#00FFFFFF")},
-			{"white", Color("#FFFFFFFF")},
-			{"none", Color("#00000000")},
-			{"black", Color("#000000FF")},
-			{"gray", Color("#808080FF")},
-			{"silver", Color("#C0C0C0FF")}
-		};
+TEST(UnitTest_Color, ctor_ccs_name) {
+    auto const colors = std::map<std::string, Color>{
+        {"maroon", Color("#800000FF")},
+        {"red", Color("#FF0000FF")},
+        {"green", Color("#008000FF")},
+        {"lime", Color("#00FF00FF")},
+        {"navy", Color("#000080FF")},
+        {"blue", Color("#0000FFFF")},
+        {"purple", Color("#800080FF")},
+        {"fuchsia", Color("#FF00FFFF")},
+        {"olive", Color("#808000FF")},
+        {"yellow", Color("#FFFF00FF")},
+        {"teal", Color("#008080FF")},
+        {"aqua", Color("#00FFFFFF")},
+        {"white", Color("#FFFFFFFF")},
+        {"none", Color("#00000000")},
+        {"black", Color("#000000FF")},
+        {"gray", Color("#808080FF")},
+        {"silver", Color("#C0C0C0FF")}
+    };
 
-		for(auto const [name, color] : colors)
-			EXPECT_EQ(color, Color(name));
-	}
+    for (auto const [name, color] : colors)
+        EXPECT_EQ(color, Color(name));
+}
 
-	TEST(UnitTest_Color, ctor_ccs_name_undefined) {
-		EXPECT_EQ(Color(1.0f, 0.0f, 1.0f, 1.0f), Color("undefined"));
-	}
+TEST(UnitTest_Color, ctor_ccs_name_undefined) {
+    EXPECT_EQ(Color(1.0f, 0.0f, 1.0f, 1.0f), Color("undefined"));
+}
 
-	TEST(UnitTest_Color, ctor_ccs_name_upper_case) {
-		EXPECT_EQ(Color(1.0f, 0.0f, 1.0f, 1.0f), Color("White"));
-		EXPECT_EQ(Color(1.0f, 0.0f, 1.0f, 1.0f), Color("BLACK"));
-	}
+TEST(UnitTest_Color, ctor_ccs_name_upper_case) {
+    EXPECT_EQ(Color(1.0f, 0.0f, 1.0f, 1.0f), Color("White"));
+    EXPECT_EQ(Color(1.0f, 0.0f, 1.0f, 1.0f), Color("BLACK"));
+}
 
-	TEST(UnitTest_Color, ctor_ccs_rgb) {
-		EXPECT_EQ(Color(1.0f, 0.0f, 1.0f, 1.0f), Color("#FF00FF"));
-	}
+TEST(UnitTest_Color, ctor_ccs_rgb) {
+    EXPECT_EQ(Color(1.0f, 0.0f, 1.0f, 1.0f), Color("#FF00FF"));
+}
 
-	TEST(UnitTest_Color, ctor_ccs_rgba) {
-		EXPECT_EQ(Color(1.0f, 0.0f, 1.0f, 0.0f), Color("#FF00FF00"));
-	}
+TEST(UnitTest_Color, ctor_ccs_rgba) {
+    EXPECT_EQ(Color(1.0f, 0.0f, 1.0f, 0.0f), Color("#FF00FF00"));
+}
 
-	TEST(UnitTest_Color, ctor_ccs_lower_case) {
-		EXPECT_EQ(Color(1.0f, 0.0f, 0.0f, 1.0f), Color("#ff0000ff"));
-	}
+TEST(UnitTest_Color, ctor_ccs_lower_case) {
+    EXPECT_EQ(Color(1.0f, 0.0f, 0.0f, 1.0f), Color("#ff0000ff"));
 }
 

--- a/testing/configitemtest.cc
+++ b/testing/configitemtest.cc
@@ -2,341 +2,339 @@
 
 #include "common.hh"
 
-namespace {
-	TEST(UnitTest_ConfigItem, i) {
-		EXPECT_EQ(0, ConfigItem(0).i());
-		EXPECT_EQ(1, ConfigItem(1).i());
-		EXPECT_EQ(1000, ConfigItem(1000).i());
-
-		EXPECT_THROW(ConfigItem().i(), std::exception);
-		EXPECT_THROW(ConfigItem(static_cast<unsigned short>(0)).i(), std::exception);
-		EXPECT_THROW(ConfigItem(true).i(), std::exception);
-		EXPECT_THROW(ConfigItem(0.1f).i(), std::exception);
-		EXPECT_THROW(ConfigItem(std::string{}).i(), std::exception);
-		EXPECT_THROW(ConfigItem(std::vector<std::string>{}).i(), std::exception);
-	}
-
-	TEST(UnitTest_ConfigItem, ui) {
-		EXPECT_EQ(0, ConfigItem(static_cast<unsigned short>(0)).ui());
-		EXPECT_EQ(1, ConfigItem(static_cast<unsigned short>(1)).ui());
-		EXPECT_EQ(1000, ConfigItem(static_cast<unsigned short>(1000)).ui());
-
-		EXPECT_THROW(ConfigItem().ui(), std::exception);
-		EXPECT_THROW(ConfigItem(3).ui(), std::exception);
-		EXPECT_THROW(ConfigItem(true).ui(), std::exception);
-		EXPECT_THROW(ConfigItem(0.1f).ui(), std::exception);
-		EXPECT_THROW(ConfigItem(std::string{}).ui(), std::exception);
-		EXPECT_THROW(ConfigItem(std::vector<std::string>{}).ui(), std::exception);
-	}
-
-	TEST(UnitTest_ConfigItem, f) {
-		EXPECT_EQ(0.0f, ConfigItem(0.0f).f());
-		EXPECT_EQ(1.1f, ConfigItem(1.1f).f());
-		EXPECT_EQ(1000.0f, ConfigItem(1000.0f).f());
-
-		EXPECT_THROW(ConfigItem().f(), std::exception);
-		EXPECT_THROW(ConfigItem(0).f(), std::exception);
-		EXPECT_THROW(ConfigItem(static_cast<unsigned short>(0)).f(), std::exception);
-		EXPECT_THROW(ConfigItem(true).f(), std::exception);
-		EXPECT_THROW(ConfigItem(std::string{}).f(), std::exception);
-		EXPECT_THROW(ConfigItem(std::vector<std::string>{}).f(), std::exception);
-	}
-
-	TEST(UnitTest_ConfigItem, b) {
-		EXPECT_EQ(true, ConfigItem(true).b());
-		EXPECT_EQ(false, ConfigItem(false).b());
-
-		EXPECT_THROW(ConfigItem().b(), std::exception);
-		EXPECT_THROW(ConfigItem(0).b(), std::exception);
-		EXPECT_THROW(ConfigItem(static_cast<unsigned short>(0)).b(), std::exception);
-		EXPECT_THROW(ConfigItem(0.1f).b(), std::exception);
-		EXPECT_THROW(ConfigItem(std::string{}).b(), std::exception);
-		EXPECT_THROW(ConfigItem(std::vector<std::string>{}).b(), std::exception);
-	}
-
-	TEST(UnitTest_ConfigItem, s) {
-		EXPECT_EQ("", ConfigItem(std::string{}).s());
-		EXPECT_EQ("Test", ConfigItem(std::string{"Test"}).s());
-
-		EXPECT_THROW(ConfigItem().s(), std::exception);
-		EXPECT_THROW(ConfigItem(false).s(), std::exception);
-		EXPECT_THROW(ConfigItem(0).s(), std::exception);
-		EXPECT_THROW(ConfigItem(0.1f).s(), std::exception);
-		EXPECT_THROW(ConfigItem(std::vector<std::string>{}).s(), std::exception);
-	}
+TEST(UnitTest_ConfigItem, i) {
+    EXPECT_EQ(0, ConfigItem(0).i());
+    EXPECT_EQ(1, ConfigItem(1).i());
+    EXPECT_EQ(1000, ConfigItem(1000).i());
+
+    EXPECT_THROW(ConfigItem().i(), std::exception);
+    EXPECT_THROW(ConfigItem(static_cast<unsigned short>(0)).i(), std::exception);
+    EXPECT_THROW(ConfigItem(true).i(), std::exception);
+    EXPECT_THROW(ConfigItem(0.1f).i(), std::exception);
+    EXPECT_THROW(ConfigItem(std::string{}).i(), std::exception);
+    EXPECT_THROW(ConfigItem(std::vector<std::string>{}).i(), std::exception);
+}
+
+TEST(UnitTest_ConfigItem, ui) {
+    EXPECT_EQ(0, ConfigItem(static_cast<unsigned short>(0)).ui());
+    EXPECT_EQ(1, ConfigItem(static_cast<unsigned short>(1)).ui());
+    EXPECT_EQ(1000, ConfigItem(static_cast<unsigned short>(1000)).ui());
+
+    EXPECT_THROW(ConfigItem().ui(), std::exception);
+    EXPECT_THROW(ConfigItem(3).ui(), std::exception);
+    EXPECT_THROW(ConfigItem(true).ui(), std::exception);
+    EXPECT_THROW(ConfigItem(0.1f).ui(), std::exception);
+    EXPECT_THROW(ConfigItem(std::string{}).ui(), std::exception);
+    EXPECT_THROW(ConfigItem(std::vector<std::string>{}).ui(), std::exception);
+}
+
+TEST(UnitTest_ConfigItem, f) {
+    EXPECT_EQ(0.0f, ConfigItem(0.0f).f());
+    EXPECT_EQ(1.1f, ConfigItem(1.1f).f());
+    EXPECT_EQ(1000.0f, ConfigItem(1000.0f).f());
+
+    EXPECT_THROW(ConfigItem().f(), std::exception);
+    EXPECT_THROW(ConfigItem(0).f(), std::exception);
+    EXPECT_THROW(ConfigItem(static_cast<unsigned short>(0)).f(), std::exception);
+    EXPECT_THROW(ConfigItem(true).f(), std::exception);
+    EXPECT_THROW(ConfigItem(std::string{}).f(), std::exception);
+    EXPECT_THROW(ConfigItem(std::vector<std::string>{}).f(), std::exception);
+}
+
+TEST(UnitTest_ConfigItem, b) {
+    EXPECT_EQ(true, ConfigItem(true).b());
+    EXPECT_EQ(false, ConfigItem(false).b());
+
+    EXPECT_THROW(ConfigItem().b(), std::exception);
+    EXPECT_THROW(ConfigItem(0).b(), std::exception);
+    EXPECT_THROW(ConfigItem(static_cast<unsigned short>(0)).b(), std::exception);
+    EXPECT_THROW(ConfigItem(0.1f).b(), std::exception);
+    EXPECT_THROW(ConfigItem(std::string{}).b(), std::exception);
+    EXPECT_THROW(ConfigItem(std::vector<std::string>{}).b(), std::exception);
+}
+
+TEST(UnitTest_ConfigItem, s) {
+    EXPECT_EQ("", ConfigItem(std::string{}).s());
+    EXPECT_EQ("Test", ConfigItem(std::string{ "Test" }).s());
+
+    EXPECT_THROW(ConfigItem().s(), std::exception);
+    EXPECT_THROW(ConfigItem(false).s(), std::exception);
+    EXPECT_THROW(ConfigItem(0).s(), std::exception);
+    EXPECT_THROW(ConfigItem(0.1f).s(), std::exception);
+    EXPECT_THROW(ConfigItem(std::vector<std::string>{}).s(), std::exception);
+}
 
-	TEST(UnitTest_ConfigItem, ol) {
-		EXPECT_THAT(ConfigItem(std::vector<std::string>{}).ol(), IsEmpty());
-		EXPECT_THAT(ConfigItem(std::vector<std::string>{"A"}).ol(), ElementsAre("A"));
-		EXPECT_THAT(ConfigItem(std::vector<std::string>{"A", "B", "C"}).ol(), ElementsAre("A", "B", "C"));
-
-		EXPECT_THROW(ConfigItem().ol(), std::exception);
-		EXPECT_THROW(ConfigItem(false).ol(), std::exception);
-		EXPECT_THROW(ConfigItem(0).ol(), std::exception);
-		EXPECT_THROW(ConfigItem(0.1f).ol(), std::exception);
-		EXPECT_THROW(ConfigItem(std::string{}).ol(), std::exception);
-	}
-
-	TEST(UnitTest_ConfigItem, so) {
-		EXPECT_THROW(ConfigItem(std::vector<std::string>{}).so(), std::exception);
-		EXPECT_EQ("A", ConfigItem(std::vector<std::string>{"A"}).so());
-		EXPECT_EQ("A", ConfigItem(std::vector<std::string>{"A", "B", "C"}).so());
-
-		EXPECT_THROW(ConfigItem().so(), std::exception);
-		EXPECT_THROW(ConfigItem(false).so(), std::exception);
-		EXPECT_THROW(ConfigItem(0).so(), std::exception);
-		EXPECT_THROW(ConfigItem(0.1f).so(), std::exception);
-		EXPECT_THROW(ConfigItem(std::string{}).so(), std::exception);
-	}
-
-	TEST(UnitTest_ConfigItem, select_empty) {
-		EXPECT_NO_THROW(ConfigItem(std::vector<std::string>{}).select(0));
-		EXPECT_NO_THROW(ConfigItem(std::vector<std::string>{}).select(1));
-		EXPECT_NO_THROW(ConfigItem(std::vector<std::string>{}).select(-1));
-	}
+TEST(UnitTest_ConfigItem, ol) {
+    EXPECT_THAT(ConfigItem(std::vector<std::string>{}).ol(), IsEmpty());
+    EXPECT_THAT(ConfigItem(std::vector<std::string>{"A"}).ol(), ElementsAre("A"));
+    EXPECT_THAT(ConfigItem(std::vector<std::string>{"A", "B", "C"}).ol(), ElementsAre("A", "B", "C"));
+
+    EXPECT_THROW(ConfigItem().ol(), std::exception);
+    EXPECT_THROW(ConfigItem(false).ol(), std::exception);
+    EXPECT_THROW(ConfigItem(0).ol(), std::exception);
+    EXPECT_THROW(ConfigItem(0.1f).ol(), std::exception);
+    EXPECT_THROW(ConfigItem(std::string{}).ol(), std::exception);
+}
+
+TEST(UnitTest_ConfigItem, so) {
+    EXPECT_THROW(ConfigItem(std::vector<std::string>{}).so(), std::exception);
+    EXPECT_EQ("A", ConfigItem(std::vector<std::string>{"A"}).so());
+    EXPECT_EQ("A", ConfigItem(std::vector<std::string>{"A", "B", "C"}).so());
+
+    EXPECT_THROW(ConfigItem().so(), std::exception);
+    EXPECT_THROW(ConfigItem(false).so(), std::exception);
+    EXPECT_THROW(ConfigItem(0).so(), std::exception);
+    EXPECT_THROW(ConfigItem(0.1f).so(), std::exception);
+    EXPECT_THROW(ConfigItem(std::string{}).so(), std::exception);
+}
+
+TEST(UnitTest_ConfigItem, select_empty) {
+    EXPECT_NO_THROW(ConfigItem(std::vector<std::string>{}).select(0));
+    EXPECT_NO_THROW(ConfigItem(std::vector<std::string>{}).select(1));
+    EXPECT_NO_THROW(ConfigItem(std::vector<std::string>{}).select(-1));
+}
 
-	TEST(UnitTest_ConfigItem, select_out_of_range_1) {
-		EXPECT_NO_THROW(ConfigItem(std::vector<std::string>{"A"}).select(1));
-		EXPECT_NO_THROW(ConfigItem(std::vector<std::string>{"A"}).select(-1));
+TEST(UnitTest_ConfigItem, select_out_of_range_1) {
+    EXPECT_NO_THROW(ConfigItem(std::vector<std::string>{"A"}).select(1));
+    EXPECT_NO_THROW(ConfigItem(std::vector<std::string>{"A"}).select(-1));
 
-		auto item = ConfigItem(std::vector<std::string>{"A"});
+    auto item = ConfigItem(std::vector<std::string>{"A"});
 
-		item.select(1);
+    item.select(1);
 
-		EXPECT_EQ("A", item.so());
+    EXPECT_EQ("A", item.so());
 
-		item.select(9);
+    item.select(9);
 
-		EXPECT_EQ("A", item.so());
-	}
+    EXPECT_EQ("A", item.so());
+}
 
-	TEST(UnitTest_ConfigItem, select_out_of_range_3) {
-		EXPECT_NO_THROW(ConfigItem(std::vector<std::string>{"A", "B", "C"}).select(3));
-		EXPECT_NO_THROW(ConfigItem(std::vector<std::string>{"A", "B", "C"}).select(-1));
+TEST(UnitTest_ConfigItem, select_out_of_range_3) {
+    EXPECT_NO_THROW(ConfigItem(std::vector<std::string>{"A", "B", "C"}).select(3));
+    EXPECT_NO_THROW(ConfigItem(std::vector<std::string>{"A", "B", "C"}).select(-1));
 
-		auto item = ConfigItem(std::vector<std::string>{"A", "B", "C"});
+    auto item = ConfigItem(std::vector<std::string>{"A", "B", "C"});
 
-		item.select(3);
+    item.select(3);
 
-		EXPECT_EQ("C", item.so());
+    EXPECT_EQ("C", item.so());
 
-		item.select(9);
+    item.select(9);
 
-		EXPECT_EQ("C", item.so());
-	}
+    EXPECT_EQ("C", item.so());
+}
 
-	TEST(UnitTest_ConfigItem, select) {
-		EXPECT_NO_THROW(ConfigItem(std::vector<std::string>{"A", "B", "C"}).select(0));
-		EXPECT_NO_THROW(ConfigItem(std::vector<std::string>{"A", "B", "C"}).select(1));
-		EXPECT_NO_THROW(ConfigItem(std::vector<std::string>{"A", "B", "C"}).select(2));
+TEST(UnitTest_ConfigItem, select) {
+    EXPECT_NO_THROW(ConfigItem(std::vector<std::string>{"A", "B", "C"}).select(0));
+    EXPECT_NO_THROW(ConfigItem(std::vector<std::string>{"A", "B", "C"}).select(1));
+    EXPECT_NO_THROW(ConfigItem(std::vector<std::string>{"A", "B", "C"}).select(2));
 
-		auto item = ConfigItem(std::vector<std::string>{"A", "B", "C"});
+    auto item = ConfigItem(std::vector<std::string>{"A", "B", "C"});
 
-		item.select(0);
-		EXPECT_EQ("A", item.so());
+    item.select(0);
+    EXPECT_EQ("A", item.so());
 
-		item.select(1);
-		EXPECT_EQ("B", item.so());
+    item.select(1);
+    EXPECT_EQ("B", item.so());
 
-		item.select(2);
-		EXPECT_EQ("C", item.so());
+    item.select(2);
+    EXPECT_EQ("C", item.so());
 
-		item.select(1);
-		EXPECT_EQ("B", item.so());
+    item.select(1);
+    EXPECT_EQ("B", item.so());
 
-		item.select(0);
-		EXPECT_EQ("A", item.so());
-	}
+    item.select(0);
+    EXPECT_EQ("A", item.so());
+}
 
-	TEST(UnitTest_ConfigItem, sl) {
-		auto item = ConfigItem(std::vector<std::string>{});
+TEST(UnitTest_ConfigItem, sl) {
+    auto item = ConfigItem(std::vector<std::string>{});
 
-		item.setType("string_list");
+    item.setType("string_list");
 
-		EXPECT_THAT(item.sl(), IsEmpty());
+    EXPECT_THAT(item.sl(), IsEmpty());
 
-		item.sl() = std::vector<std::string>{"A"};
+    item.sl() = std::vector<std::string>{ "A" };
 
-		EXPECT_THAT(item.sl(), ElementsAre("A"));
+    EXPECT_THAT(item.sl(), ElementsAre("A"));
 
-		item.sl() = std::vector<std::string>{"A", "B", "C"};
+    item.sl() = std::vector<std::string>{ "A", "B", "C" };
 
-		EXPECT_THAT(item.sl(), ElementsAre("A", "B", "C"));
-	}
+    EXPECT_THAT(item.sl(), ElementsAre("A", "B", "C"));
+}
 
-	TEST(UnitTest_ConfigItem, getType) {
-		EXPECT_EQ("bool", ConfigItem(true).getType());
-		EXPECT_EQ("int", ConfigItem(2).getType());
-		EXPECT_EQ("uint", ConfigItem(static_cast<unsigned short>(4)).getType());
-		EXPECT_EQ("float", ConfigItem(1.2f).getType());
-		EXPECT_EQ("string", ConfigItem(std::string{}).getType());
-		EXPECT_EQ("option_list", ConfigItem(std::vector<std::string>{}).getType());
-	}
+TEST(UnitTest_ConfigItem, getType) {
+    EXPECT_EQ("bool", ConfigItem(true).getType());
+    EXPECT_EQ("int", ConfigItem(2).getType());
+    EXPECT_EQ("uint", ConfigItem(static_cast<unsigned short>(4)).getType());
+    EXPECT_EQ("float", ConfigItem(1.2f).getType());
+    EXPECT_EQ("string", ConfigItem(std::string{}).getType());
+    EXPECT_EQ("option_list", ConfigItem(std::vector<std::string>{}).getType());
+}
 
-	TEST(UnitTest_ConfigItem, getName) {
-		EXPECT_EQ("", ConfigItem(true).getName());
-	}
+TEST(UnitTest_ConfigItem, getName) {
+    EXPECT_EQ("", ConfigItem(true).getName());
+}
 
-	TEST(UnitTest_ConfigItem, setName) {
-		const auto item = [](){ auto item = ConfigItem(); item.setName("Test/Item"); return item;}();
+TEST(UnitTest_ConfigItem, setName) {
+    const auto item = []() { auto item = ConfigItem(); item.setName("Test/Item"); return item; }();
 
-		EXPECT_EQ("Test/Item", item.getName());
-	}
+    EXPECT_EQ("Test/Item", item.getName());
+}
 
-	TEST(UnitTest_ConfigItem, getShortDesc) {
-		EXPECT_EQ("", ConfigItem().getShortDesc());
-	}
+TEST(UnitTest_ConfigItem, getShortDesc) {
+    EXPECT_EQ("", ConfigItem().getShortDesc());
+}
 
-	TEST(UnitTest_ConfigItem, setDescription) {
-		const auto item = [](){ auto item = ConfigItem(); item.setDescription("Short"); return item;}();
+TEST(UnitTest_ConfigItem, setDescription) {
+    const auto item = []() { auto item = ConfigItem(); item.setDescription("Short"); return item; }();
 
-		EXPECT_EQ("Short", item.getShortDesc());
-	}
+    EXPECT_EQ("Short", item.getShortDesc());
+}
 
-	TEST(UnitTest_ConfigItem, getLongDesc) {
-		EXPECT_EQ("", ConfigItem().getLongDesc());
-	}
+TEST(UnitTest_ConfigItem, getLongDesc) {
+    EXPECT_EQ("", ConfigItem().getLongDesc());
+}
 
-	TEST(UnitTest_ConfigItem, setLongDescription) {
-		const auto item = [](){ auto item = ConfigItem(); item.setLongDescription("Long"); return item;}();
+TEST(UnitTest_ConfigItem, setLongDescription) {
+    const auto item = []() { auto item = ConfigItem(); item.setLongDescription("Long"); return item; }();
 
-		EXPECT_EQ("Long", item.getLongDesc());
-	}
+    EXPECT_EQ("Long", item.getLongDesc());
+}
 
-	TEST(UnitTest_ConfigItem, getEnum_empty) {
-		EXPECT_TRUE(ConfigItem().getEnum().empty());
-	}
+TEST(UnitTest_ConfigItem, getEnum_empty) {
+    EXPECT_TRUE(ConfigItem().getEnum().empty());
+}
 
-	TEST(UnitTest_ConfigItem, getEnum_addEnum_1) {
-		auto item = ConfigItem(static_cast<unsigned short>(0));
+TEST(UnitTest_ConfigItem, getEnum_addEnum_1) {
+    auto item = ConfigItem(static_cast<unsigned short>(0));
 
-		item.addEnum("A");
+    item.addEnum("A");
 
-		EXPECT_FALSE(item.getEnum().empty());
-		EXPECT_EQ(1, item.getEnum().size());
-		EXPECT_EQ("A", item.getEnum().at(0));
-	}
+    EXPECT_FALSE(item.getEnum().empty());
+    EXPECT_EQ(1, item.getEnum().size());
+    EXPECT_EQ("A", item.getEnum().at(0));
+}
 
-	TEST(UnitTest_ConfigItem, getEnum_addEnum_3) {
-		auto item = ConfigItem(static_cast<unsigned short>(0));
+TEST(UnitTest_ConfigItem, getEnum_addEnum_3) {
+    auto item = ConfigItem(static_cast<unsigned short>(0));
 
-		item.addEnum("C");
-		item.addEnum("A");
-		item.addEnum("B");
+    item.addEnum("C");
+    item.addEnum("A");
+    item.addEnum("B");
 
-		EXPECT_FALSE(item.getEnum().empty());
-		EXPECT_EQ(3, item.getEnum().size());
-		EXPECT_EQ("C", item.getEnum().at(0));
-		EXPECT_EQ("A", item.getEnum().at(1));
-		EXPECT_EQ("B", item.getEnum().at(2));
-	}
+    EXPECT_FALSE(item.getEnum().empty());
+    EXPECT_EQ(3, item.getEnum().size());
+    EXPECT_EQ("C", item.getEnum().at(0));
+    EXPECT_EQ("A", item.getEnum().at(1));
+    EXPECT_EQ("B", item.getEnum().at(2));
+}
 
-	TEST(UnitTest_ConfigItem, getEnumName_0) {
-		auto item = ConfigItem(static_cast<unsigned short>(0));
+TEST(UnitTest_ConfigItem, getEnumName_0) {
+    auto item = ConfigItem(static_cast<unsigned short>(0));
 
-		item.addEnum("C");
-		item.addEnum("A");
-		item.addEnum("B");
+    item.addEnum("C");
+    item.addEnum("A");
+    item.addEnum("B");
 
-		EXPECT_EQ("C", item.getEnumName());
-	}
+    EXPECT_EQ("C", item.getEnumName());
+}
 
-	TEST(UnitTest_ConfigItem, getEnumName_1) {
-		auto item = ConfigItem(static_cast<unsigned short>(1));
+TEST(UnitTest_ConfigItem, getEnumName_1) {
+    auto item = ConfigItem(static_cast<unsigned short>(1));
 
-		item.addEnum("C");
-		item.addEnum("A");
-		item.addEnum("B");
+    item.addEnum("C");
+    item.addEnum("A");
+    item.addEnum("B");
 
-		EXPECT_EQ("A", item.getEnumName());
-	}
+    EXPECT_EQ("A", item.getEnumName());
+}
 
-	TEST(UnitTest_ConfigItem, getEnumName_2) {
-		auto item = ConfigItem(static_cast<unsigned short>(2));
+TEST(UnitTest_ConfigItem, getEnumName_2) {
+    auto item = ConfigItem(static_cast<unsigned short>(2));
 
-		item.addEnum("C");
-		item.addEnum("A");
-		item.addEnum("B");
+    item.addEnum("C");
+    item.addEnum("A");
+    item.addEnum("B");
 
-		EXPECT_EQ("B", item.getEnumName());
-	}
+    EXPECT_EQ("B", item.getEnumName());
+}
 
-	TEST(UnitTest_ConfigItem, getEnumName_selectEnum) {
-		auto item = ConfigItem(static_cast<unsigned short>(0));
+TEST(UnitTest_ConfigItem, getEnumName_selectEnum) {
+    auto item = ConfigItem(static_cast<unsigned short>(0));
 
-		item.addEnum("C");
-		item.addEnum("A");
-		item.addEnum("B");
+    item.addEnum("C");
+    item.addEnum("A");
+    item.addEnum("B");
 
-		item.selectEnum("B");
+    item.selectEnum("B");
 
-		EXPECT_EQ("B", item.getEnumName());
-	}
+    EXPECT_EQ("B", item.getEnumName());
+}
 
-	TEST(UnitTest_ConfigItem, getSelection) {
-		auto item = ConfigItem(static_cast<unsigned short>(0));
+TEST(UnitTest_ConfigItem, getSelection) {
+    auto item = ConfigItem(static_cast<unsigned short>(0));
 
-		item.addEnum("C");
-		item.addEnum("A");
-		item.addEnum("B");
+    item.addEnum("C");
+    item.addEnum("A");
+    item.addEnum("B");
 
-		EXPECT_EQ(0, item.getSelection());
-	}
+    EXPECT_EQ(0, item.getSelection());
+}
 
-	TEST(UnitTest_ConfigItem, selectEnum_getSelection) {
-		auto item = ConfigItem(static_cast<unsigned short>(0));
+TEST(UnitTest_ConfigItem, selectEnum_getSelection) {
+    auto item = ConfigItem(static_cast<unsigned short>(0));
 
-		item.addEnum("C");
-		item.addEnum("A");
-		item.addEnum("B");
+    item.addEnum("C");
+    item.addEnum("A");
+    item.addEnum("B");
 
-		item.selectEnum("A");
+    item.selectEnum("A");
 
-		EXPECT_EQ(0, item.getSelection());
-	}
+    EXPECT_EQ(0, item.getSelection());
+}
 
-	TEST(UnitTest_ConfigItem, increase) {
-		auto item = ConfigItem(static_cast<unsigned short>(0));
+TEST(UnitTest_ConfigItem, increase) {
+    auto item = ConfigItem(static_cast<unsigned short>(0));
 
-		item.addEnum("C");
-		item.addEnum("A");
-		item.addEnum("B");
+    item.addEnum("C");
+    item.addEnum("A");
+    item.addEnum("B");
 
-		EXPECT_EQ(0, item.ui());
+    EXPECT_EQ(0, item.ui());
 
-		++item;
+    ++item;
 
-		EXPECT_EQ(1, item.ui());
+    EXPECT_EQ(1, item.ui());
 
-		++item;
+    ++item;
 
-		EXPECT_EQ(2, item.ui());
+    EXPECT_EQ(2, item.ui());
 
-		++item;
+    ++item;
 
-		EXPECT_EQ(2, item.ui());
-	}
+    EXPECT_EQ(2, item.ui());
+}
 
-	TEST(UnitTest_ConfigItem, decrease) {
-		auto item = ConfigItem(static_cast<unsigned short>(2));
+TEST(UnitTest_ConfigItem, decrease) {
+    auto item = ConfigItem(static_cast<unsigned short>(2));
 
-		item.addEnum("C");
-		item.addEnum("A");
-		item.addEnum("B");
+    item.addEnum("C");
+    item.addEnum("A");
+    item.addEnum("B");
 
-		EXPECT_EQ(2, item.ui());
+    EXPECT_EQ(2, item.ui());
 
-		--item;
+    --item;
 
-		EXPECT_EQ(1, item.ui());
+    EXPECT_EQ(1, item.ui());
 
-		--item;
+    --item;
 
-		EXPECT_EQ(0, item.ui());
+    EXPECT_EQ(0, item.ui());
 
-		--item;
+    --item;
 
-		EXPECT_EQ(0, item.ui());
-	}
+    EXPECT_EQ(0, item.ui());
 }
 

--- a/testing/fixednotegraphscalertest.cc
+++ b/testing/fixednotegraphscalertest.cc
@@ -7,160 +7,160 @@
 #include "common.hh"
 
 namespace {
-	Note make(float note, std::string const& text, double begin = 0., double end = 1., Note::Type type = Note::Type::NORMAL) {
-		auto result = Note();
+    Note make(float note, std::string const& text, double begin = 0., double end = 1., Note::Type type = Note::Type::NORMAL) {
+        auto result = Note();
 
-		result.note = note;
-		result.syllable = text;
-		result.begin = begin;
-		result.end = end;
-		result.type = type;
+        result.note = note;
+        result.syllable = text;
+        result.begin = begin;
+        result.end = end;
+        result.type = type;
 
-		return result;
-	}
+        return result;
+    }
+}
 
-	TEST(UnitTest_FixedNoteGraphScaler, calculate_1_time_0) {
-		auto vocal = VocalTrack("Songname");
+TEST(UnitTest_FixedNoteGraphScaler, calculate_1_time_0) {
+    auto vocal = VocalTrack("Songname");
 
-		vocal.noteMin = 0.f;
-		vocal.noteMax = 0.f;
-		vocal.notes.emplace_back(make(0.f, "A"));
+    vocal.noteMin = 0.f;
+    vocal.noteMax = 0.f;
+    vocal.notes.emplace_back(make(0.f, "A"));
 
-		auto scaler = FixedNoteGraphScaler();
+    auto scaler = FixedNoteGraphScaler();
 
-		scaler.initialize(vocal);
+    scaler.initialize(vocal);
 
-		const auto dimension = scaler.calculate(vocal, vocal.notes.begin(), 0);
+    const auto dimension = scaler.calculate(vocal, vocal.notes.begin(), 0);
 
-		EXPECT_EQ(0.f, dimension.min1);
-		EXPECT_EQ(0.f, dimension.max1);
-		EXPECT_EQ(0.f, dimension.min2);
-		EXPECT_EQ(0.f, dimension.max2);
-	}
+    EXPECT_EQ(0.f, dimension.min1);
+    EXPECT_EQ(0.f, dimension.max1);
+    EXPECT_EQ(0.f, dimension.min2);
+    EXPECT_EQ(0.f, dimension.max2);
+}
 
-	TEST(UnitTest_FixedNoteGraphScaler, calculate_1_time_1) {
-		auto vocal = VocalTrack("Songname");
+TEST(UnitTest_FixedNoteGraphScaler, calculate_1_time_1) {
+    auto vocal = VocalTrack("Songname");
 
-		vocal.noteMin = 0.f;
-		vocal.noteMax = 0.f;
-		vocal.notes.emplace_back(make(0.f, "A"));
+    vocal.noteMin = 0.f;
+    vocal.noteMax = 0.f;
+    vocal.notes.emplace_back(make(0.f, "A"));
 
-		auto scaler = FixedNoteGraphScaler();
+    auto scaler = FixedNoteGraphScaler();
 
-		scaler.initialize(vocal);
+    scaler.initialize(vocal);
 
-		const auto dimension = scaler.calculate(vocal, vocal.notes.begin(), 1);
+    const auto dimension = scaler.calculate(vocal, vocal.notes.begin(), 1);
 
-		EXPECT_EQ(0.f, dimension.min1);
-		EXPECT_EQ(0.f, dimension.max1);
-		EXPECT_EQ(0.f, dimension.min2);
-		EXPECT_EQ(0.f, dimension.max2);
-	}
+    EXPECT_EQ(0.f, dimension.min1);
+    EXPECT_EQ(0.f, dimension.max1);
+    EXPECT_EQ(0.f, dimension.min2);
+    EXPECT_EQ(0.f, dimension.max2);
+}
 
-	TEST(UnitTest_FixedNoteGraphScaler, calculate_3_time_0) {
-		auto vocal = VocalTrack("Songname");
+TEST(UnitTest_FixedNoteGraphScaler, calculate_3_time_0) {
+    auto vocal = VocalTrack("Songname");
 
-		vocal.noteMin = 0.f;
-		vocal.noteMax = 0.f;
-		vocal.notes.emplace_back(make(0.f, "A"));
-		vocal.notes.emplace_back(make(1.f, "A", 1., 2.));
-		vocal.notes.emplace_back(make(3.f, "A", 2., 3.));
+    vocal.noteMin = 0.f;
+    vocal.noteMax = 0.f;
+    vocal.notes.emplace_back(make(0.f, "A"));
+    vocal.notes.emplace_back(make(1.f, "A", 1., 2.));
+    vocal.notes.emplace_back(make(3.f, "A", 2., 3.));
 
-		auto scaler = FixedNoteGraphScaler();
+    auto scaler = FixedNoteGraphScaler();
 
-		scaler.initialize(vocal);
+    scaler.initialize(vocal);
 
-		const auto dimension = scaler.calculate(vocal, vocal.notes.begin(), 0);
+    const auto dimension = scaler.calculate(vocal, vocal.notes.begin(), 0);
 
-		EXPECT_EQ(0.f, dimension.min1);
-		EXPECT_EQ(3.f, dimension.max1);
-		EXPECT_EQ(0.f, dimension.min2);
-		EXPECT_EQ(3.f, dimension.max2);
-	}
+    EXPECT_EQ(0.f, dimension.min1);
+    EXPECT_EQ(3.f, dimension.max1);
+    EXPECT_EQ(0.f, dimension.min2);
+    EXPECT_EQ(3.f, dimension.max2);
+}
 
-	TEST(UnitTest_FixedNoteGraphScaler, calculate_3_time_1) {
-		auto vocal = VocalTrack("Songname");
+TEST(UnitTest_FixedNoteGraphScaler, calculate_3_time_1) {
+    auto vocal = VocalTrack("Songname");
 
-		vocal.noteMin = 0.f;
-		vocal.noteMax = 0.f;
-		vocal.notes.emplace_back(make(0.f, "A"));
-		vocal.notes.emplace_back(make(1.f, "A", 1., 2.));
-		vocal.notes.emplace_back(make(3.f, "A", 2., 3.));
+    vocal.noteMin = 0.f;
+    vocal.noteMax = 0.f;
+    vocal.notes.emplace_back(make(0.f, "A"));
+    vocal.notes.emplace_back(make(1.f, "A", 1., 2.));
+    vocal.notes.emplace_back(make(3.f, "A", 2., 3.));
 
-		auto scaler = FixedNoteGraphScaler();
+    auto scaler = FixedNoteGraphScaler();
 
-		scaler.initialize(vocal);
+    scaler.initialize(vocal);
 
-		const auto dimension = scaler.calculate(vocal, vocal.notes.begin(), 1);
+    const auto dimension = scaler.calculate(vocal, vocal.notes.begin(), 1);
 
-		EXPECT_EQ(0.f, dimension.min1);
-		EXPECT_EQ(3.f, dimension.max1);
-		EXPECT_EQ(0.f, dimension.min2);
-		EXPECT_EQ(3.f, dimension.max2);
-	}
+    EXPECT_EQ(0.f, dimension.min1);
+    EXPECT_EQ(3.f, dimension.max1);
+    EXPECT_EQ(0.f, dimension.min2);
+    EXPECT_EQ(3.f, dimension.max2);
+}
 
-	TEST(UnitTest_FixedNoteGraphScaler, calculate_vocal_min) {
-		auto vocal = VocalTrack("Songname");
+TEST(UnitTest_FixedNoteGraphScaler, calculate_vocal_min) {
+    auto vocal = VocalTrack("Songname");
 
-		vocal.noteMin = 0.f;
-		vocal.noteMax = 2.f;
-		vocal.notes.emplace_back(make(1.f, "A"));
-		vocal.notes.emplace_back(make(2.f, "A", 1., 2.));
-		vocal.notes.emplace_back(make(3.f, "A", 2., 3.));
+    vocal.noteMin = 0.f;
+    vocal.noteMax = 2.f;
+    vocal.notes.emplace_back(make(1.f, "A"));
+    vocal.notes.emplace_back(make(2.f, "A", 1., 2.));
+    vocal.notes.emplace_back(make(3.f, "A", 2., 3.));
 
-		auto scaler = FixedNoteGraphScaler();
+    auto scaler = FixedNoteGraphScaler();
 
-		scaler.initialize(vocal);
+    scaler.initialize(vocal);
 
-		const auto dimension = scaler.calculate(vocal, vocal.notes.begin(), 1);
+    const auto dimension = scaler.calculate(vocal, vocal.notes.begin(), 1);
 
-		EXPECT_EQ(1.f, dimension.min1);
-		EXPECT_EQ(3.f, dimension.max1);
-		EXPECT_EQ(1.f, dimension.min2);
-		EXPECT_EQ(3.f, dimension.max2);
-	}
+    EXPECT_EQ(1.f, dimension.min1);
+    EXPECT_EQ(3.f, dimension.max1);
+    EXPECT_EQ(1.f, dimension.min2);
+    EXPECT_EQ(3.f, dimension.max2);
+}
 
-	TEST(UnitTest_FixedNoteGraphScaler, calculate_vocal_max) {
-		auto vocal = VocalTrack("Songname");
+TEST(UnitTest_FixedNoteGraphScaler, calculate_vocal_max) {
+    auto vocal = VocalTrack("Songname");
 
-		vocal.noteMin = 2.f;
-		vocal.noteMax = 5.f;
-		vocal.notes.emplace_back(make(0.f, "A"));
-		vocal.notes.emplace_back(make(2.f, "A", 1., 2.));
-		vocal.notes.emplace_back(make(3.f, "A", 2., 3.));
+    vocal.noteMin = 2.f;
+    vocal.noteMax = 5.f;
+    vocal.notes.emplace_back(make(0.f, "A"));
+    vocal.notes.emplace_back(make(2.f, "A", 1., 2.));
+    vocal.notes.emplace_back(make(3.f, "A", 2., 3.));
 
-		auto scaler = FixedNoteGraphScaler();
+    auto scaler = FixedNoteGraphScaler();
 
-		scaler.initialize(vocal);
+    scaler.initialize(vocal);
 
-		const auto dimension = scaler.calculate(vocal, vocal.notes.begin(), 1);
+    const auto dimension = scaler.calculate(vocal, vocal.notes.begin(), 1);
 
-		EXPECT_EQ(0.f, dimension.min1);
-		EXPECT_EQ(3.f, dimension.max1);
-		EXPECT_EQ(0.f, dimension.min2);
-		EXPECT_EQ(3.f, dimension.max2);
-	}
+    EXPECT_EQ(0.f, dimension.min1);
+    EXPECT_EQ(3.f, dimension.max1);
+    EXPECT_EQ(0.f, dimension.min2);
+    EXPECT_EQ(3.f, dimension.max2);
+}
 
-	TEST(UnitTest_FixedNoteGraphScaler, calculate_ignore_SLEEP) {
-		auto vocal = VocalTrack("Songname");
+TEST(UnitTest_FixedNoteGraphScaler, calculate_ignore_SLEEP) {
+    auto vocal = VocalTrack("Songname");
 
-		vocal.noteMin = 0.f;
-		vocal.noteMax = 3.f;
-		vocal.notes.emplace_back(make(0.f, "A", 0., 1.));
-		vocal.notes.emplace_back(make(3.f, "A", 1., 2., Note::Type::SLEEP));
-		vocal.notes.emplace_back(make(1.f, "A", 2., 3.));
+    vocal.noteMin = 0.f;
+    vocal.noteMax = 3.f;
+    vocal.notes.emplace_back(make(0.f, "A", 0., 1.));
+    vocal.notes.emplace_back(make(3.f, "A", 1., 2., Note::Type::SLEEP));
+    vocal.notes.emplace_back(make(1.f, "A", 2., 3.));
 
-		auto scaler = FixedNoteGraphScaler();
+    auto scaler = FixedNoteGraphScaler();
 
-		scaler.initialize(vocal);
+    scaler.initialize(vocal);
 
-		const auto dimension = scaler.calculate(vocal, vocal.notes.begin(), 0);
+    const auto dimension = scaler.calculate(vocal, vocal.notes.begin(), 0);
 
-		EXPECT_EQ(0.f, dimension.min1);
-		EXPECT_EQ(1.f, dimension.max1);
-		EXPECT_EQ(0.f, dimension.min2);
-		EXPECT_EQ(1.f, dimension.max2);
-	}
+    EXPECT_EQ(0.f, dimension.min1);
+    EXPECT_EQ(1.f, dimension.max1);
+    EXPECT_EQ(0.f, dimension.min2);
+    EXPECT_EQ(1.f, dimension.max2);
 }
 
 

--- a/testing/main.cc
+++ b/testing/main.cc
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/testing/notegraphscalerfactorytest.cc
+++ b/testing/notegraphscalerfactorytest.cc
@@ -7,61 +7,60 @@
 #include "common.hh"
 
 namespace {
-	ConfigItem makeConfigItem(int i) { return ConfigItem{static_cast<unsigned short>(i)};}
+    ConfigItem makeConfigItem(int i) { return ConfigItem{ static_cast<unsigned short>(i) }; }
+}
 
-	TEST(UnitTest_NoteGraphScalerFactory, dynamic) {
-		const auto vocal = VocalTrack("Songname");
-		auto config = Config{{"game/notegraphscalingmode", makeConfigItem(0)}};
-		const auto scaler = NoteGraphScalerFactory(config).create(vocal);
+TEST(UnitTest_NoteGraphScalerFactory, dynamic) {
+    const auto vocal = VocalTrack("Songname");
+    auto config = Config{ {"game/notegraphscalingmode", makeConfigItem(0)} };
+    const auto scaler = NoteGraphScalerFactory(config).create(vocal);
 
-		ASSERT_NE(nullptr, scaler);
-		EXPECT_NE(nullptr, std::dynamic_pointer_cast<DynamicNoteGraphScaler>(scaler));
-	}
+    ASSERT_NE(nullptr, scaler);
+    EXPECT_NE(nullptr, std::dynamic_pointer_cast<DynamicNoteGraphScaler>(scaler));
+}
 
-	TEST(UnitTest_NoteGraphScalerFactory, fixed) {
-		const auto vocal = VocalTrack("Songname");
-		auto config = Config{{"game/notegraphscalingmode", makeConfigItem(1)}};
-		const auto scaler = NoteGraphScalerFactory(config).create(vocal);
+TEST(UnitTest_NoteGraphScalerFactory, fixed) {
+    const auto vocal = VocalTrack("Songname");
+    auto config = Config{ {"game/notegraphscalingmode", makeConfigItem(1)} };
+    const auto scaler = NoteGraphScalerFactory(config).create(vocal);
 
-		ASSERT_NE(nullptr, scaler);
-		EXPECT_NE(nullptr, std::dynamic_pointer_cast<FixedNoteGraphScaler>(scaler));
-	}
+    ASSERT_NE(nullptr, scaler);
+    EXPECT_NE(nullptr, std::dynamic_pointer_cast<FixedNoteGraphScaler>(scaler));
+}
 
-	TEST(UnitTest_NoteGraphScalerFactory, auto_1) {
-		const auto vocal = VocalTrack("Songname");
-		auto config = Config{{"game/notegraphscalingmode", makeConfigItem(2)}};
-		const auto scaler = NoteGraphScalerFactory(config).create(vocal);
+TEST(UnitTest_NoteGraphScalerFactory, auto_1) {
+    const auto vocal = VocalTrack("Songname");
+    auto config = Config{ {"game/notegraphscalingmode", makeConfigItem(2)} };
+    const auto scaler = NoteGraphScalerFactory(config).create(vocal);
 
-		ASSERT_NE(nullptr, scaler);
-		EXPECT_NE(nullptr, std::dynamic_pointer_cast<FixedNoteGraphScaler>(scaler));
-	}
+    ASSERT_NE(nullptr, scaler);
+    EXPECT_NE(nullptr, std::dynamic_pointer_cast<FixedNoteGraphScaler>(scaler));
+}
 
-	TEST(UnitTest_NoteGraphScalerFactory, auto_2) {
-		const auto vocal = VocalTrack("Songname");
-		auto config = Config{{"game/notegraphscalingmode", makeConfigItem(3)}};
-		const auto scaler = NoteGraphScalerFactory(config).create(vocal);
+TEST(UnitTest_NoteGraphScalerFactory, auto_2) {
+    const auto vocal = VocalTrack("Songname");
+    auto config = Config{ {"game/notegraphscalingmode", makeConfigItem(3)} };
+    const auto scaler = NoteGraphScalerFactory(config).create(vocal);
 
-		ASSERT_NE(nullptr, scaler);
-		EXPECT_NE(nullptr, std::dynamic_pointer_cast<FixedNoteGraphScaler>(scaler));
-	}
+    ASSERT_NE(nullptr, scaler);
+    EXPECT_NE(nullptr, std::dynamic_pointer_cast<FixedNoteGraphScaler>(scaler));
+}
 
-	TEST(UnitTest_NoteGraphScalerFactory, auto_3) {
-		const auto vocal = VocalTrack("Songname");
-		auto config = Config{{"game/notegraphscalingmode", makeConfigItem(4)}};
-		const auto scaler = NoteGraphScalerFactory(config).create(vocal);
+TEST(UnitTest_NoteGraphScalerFactory, auto_3) {
+    const auto vocal = VocalTrack("Songname");
+    auto config = Config{ {"game/notegraphscalingmode", makeConfigItem(4)} };
+    const auto scaler = NoteGraphScalerFactory(config).create(vocal);
 
-		ASSERT_NE(nullptr, scaler);
-		EXPECT_NE(nullptr, std::dynamic_pointer_cast<FixedNoteGraphScaler>(scaler));
-	}
+    ASSERT_NE(nullptr, scaler);
+    EXPECT_NE(nullptr, std::dynamic_pointer_cast<FixedNoteGraphScaler>(scaler));
+}
 
-	TEST(UnitTest_NoteGraphScalerFactory, auto_4) {
-		const auto vocal = VocalTrack("Songname");
-		auto config = Config{{"game/notegraphscalingmode", makeConfigItem(5)}};
-		const auto scaler = NoteGraphScalerFactory(config).create(vocal);
+TEST(UnitTest_NoteGraphScalerFactory, auto_4) {
+    const auto vocal = VocalTrack("Songname");
+    auto config = Config{ {"game/notegraphscalingmode", makeConfigItem(5)} };
+    const auto scaler = NoteGraphScalerFactory(config).create(vocal);
 
-		ASSERT_NE(nullptr, scaler);
-		EXPECT_NE(nullptr, std::dynamic_pointer_cast<FixedNoteGraphScaler>(scaler));
-	}
-
+    ASSERT_NE(nullptr, scaler);
+    EXPECT_NE(nullptr, std::dynamic_pointer_cast<FixedNoteGraphScaler>(scaler));
 }
 

--- a/testing/performous_test.runsettings
+++ b/testing/performous_test.runsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <GoogleTest>
+    <PathToTestExecutable>testing/performous_test.exe</PathToTestExecutable>
+
+  </GoogleTest>
+
+</RunSettings>

--- a/testing/utiltest.cc
+++ b/testing/utiltest.cc
@@ -2,139 +2,137 @@
 
 #include "game/util.hh"
 
-namespace {
-	TEST(UnitTest_Utils, clamp) {
-		EXPECT_EQ(0.0, clamp(-1.0, 0.0, 1.0));
-		EXPECT_EQ(0.5, clamp(0.5, 0.0, 1.0));
-		EXPECT_EQ(1.0, clamp(2.0, 0.0, 1.0));
-	}
+TEST(UnitTest_Utils, clamp) {
+    EXPECT_EQ(0.0, clamp(-1.0, 0.0, 1.0));
+    EXPECT_EQ(0.5, clamp(0.5, 0.0, 1.0));
+    EXPECT_EQ(1.0, clamp(2.0, 0.0, 1.0));
+}
 
-	TEST(UnitTest_Utils, smoothstep_1) {
-		EXPECT_EQ(0.0, smoothstep(0));
-		EXPECT_EQ(0.5, smoothstep(0.5));
-		EXPECT_EQ(1.0, smoothstep(1.0));
-	}
+TEST(UnitTest_Utils, smoothstep_1) {
+    EXPECT_EQ(0.0, smoothstep(0));
+    EXPECT_EQ(0.5, smoothstep(0.5));
+    EXPECT_EQ(1.0, smoothstep(1.0));
+}
 
-	TEST(UnitTest_Utils, smoothstep_1_clamping) {
-		EXPECT_EQ(0.0, smoothstep(-1.0));
-		EXPECT_EQ(1.0, smoothstep(2.0));
-	}
+TEST(UnitTest_Utils, smoothstep_1_clamping) {
+    EXPECT_EQ(0.0, smoothstep(-1.0));
+    EXPECT_EQ(1.0, smoothstep(2.0));
+}
 
-	TEST(UnitTest_Utils, smoothstep_3) {
-		EXPECT_EQ(0.0, smoothstep(-1., 1., -1.0));
-		EXPECT_EQ(0.5, smoothstep(-1., 1., 0.0));
-		EXPECT_EQ(1.0, smoothstep(-1., 1., 1.0));
-	}
+TEST(UnitTest_Utils, smoothstep_3) {
+    EXPECT_EQ(0.0, smoothstep(-1., 1., -1.0));
+    EXPECT_EQ(0.5, smoothstep(-1., 1., 0.0));
+    EXPECT_EQ(1.0, smoothstep(-1., 1., 1.0));
+}
 
-	TEST(UnitTest_Utils, smoothstep_3_clamping) {
-		EXPECT_EQ(0.0, smoothstep(-1., 1., -2.0));
-		EXPECT_EQ(1.0, smoothstep(-1., 1., 2.0));
-	}
+TEST(UnitTest_Utils, smoothstep_3_clamping) {
+    EXPECT_EQ(0.0, smoothstep(-1., 1., -2.0));
+    EXPECT_EQ(1.0, smoothstep(-1., 1., 2.0));
+}
 
-	TEST(UnitTest_Utils, format) {
-		auto const time = std::chrono::seconds(7260);
+TEST(UnitTest_Utils, format) {
+    auto const time = std::chrono::seconds(7260);
 
-		// next two tests are not working when compiled with mingw. see https://sourceforge.net/p/mingw-w64/bugs/793/
-		//EXPECT_EQ("01/01/70 02:01", format(time, "%D %R"));
-		//EXPECT_EQ("02:01:00 1970-01-01", format(time, "%T %F"));
-		EXPECT_EQ("01/01/70 02:01", format(time, "%m/%d/%y %H:%M", true));
-		EXPECT_EQ("02:01:00 1970-01-01", format(time, "%H:%M:%S %Y-%m-%d", true));
-		EXPECT_EQ("02:01:00 1970-01-01", format(time, "%X %Y-%m-%d", true));
-	}
+    // next two tests are not working when compiled with mingw. see https://sourceforge.net/p/mingw-w64/bugs/793/
+    //EXPECT_EQ("01/01/70 02:01", format(time, "%D %R"));
+    //EXPECT_EQ("02:01:00 1970-01-01", format(time, "%T %F"));
+    EXPECT_EQ("01/01/70 02:01", format(time, "%m/%d/%y %H:%M", true));
+    EXPECT_EQ("02:01:00 1970-01-01", format(time, "%H:%M:%S %Y-%m-%d", true));
+    EXPECT_EQ("02:01:00 1970-01-01", format(time, "%X %Y-%m-%d", true));
+}
 
-	TEST(UnitTest_Utils, isText_text) {
-		EXPECT_TRUE(isText("text"));
-	}
+TEST(UnitTest_Utils, isText_text) {
+    EXPECT_TRUE(isText("text"));
+}
 
-	TEST(UnitTest_Utils, isText_text_and_binary) {
-		auto const binary = std::string{ char(0x01), char(0x02), char(0x03) };
-		EXPECT_FALSE(isText("text" + binary + "other"));
-	}
+TEST(UnitTest_Utils, isText_text_and_binary) {
+    auto const binary = std::string{ char(0x01), char(0x02), char(0x03) };
+    EXPECT_FALSE(isText("text" + binary + "other"));
+}
 
-	TEST(UnitTest_Utils, isText_bom_and_text) {
-		auto const bom = std::string{ char(0xEF), char(0xBB), char(0xBF) };
+TEST(UnitTest_Utils, isText_bom_and_text) {
+    auto const bom = std::string{ char(0xEF), char(0xBB), char(0xBF) };
 
-		EXPECT_TRUE(isText(bom + "text"));
-	}
+    EXPECT_TRUE(isText(bom + "text"));
+}
 
-	TEST(UnitTest_Utils, isText_bom_and_text_and_binary) {
-		auto const bom = std::string{ char(0xEF), char(0xBB), char(0xBF) };
+TEST(UnitTest_Utils, isText_bom_and_text_and_binary) {
+    auto const bom = std::string{ char(0xEF), char(0xBB), char(0xBF) };
 
-		EXPECT_TRUE(isText(bom + "text\0other"));
-	}
+    EXPECT_TRUE(isText(bom + "text\0other"));
+}
 
-	TEST(UnitTest_Utils, isText_binary_zeros) {
-		auto const binary = std::string{ char(0x00), char(0x00), char(0x00), char(0x00) };
+TEST(UnitTest_Utils, isText_binary_zeros) {
+    auto const binary = std::string{ char(0x00), char(0x00), char(0x00), char(0x00) };
 
-		EXPECT_FALSE(isText(binary));
-	}
+    EXPECT_FALSE(isText(binary));
+}
 
-	TEST(UnitTest_Utils, isText_binary_ffs) {
-		auto const binary = std::string{ char(0xff), char(0xff), char(0xff), char(0xff) };
+TEST(UnitTest_Utils, isText_binary_ffs) {
+    auto const binary = std::string{ char(0xff), char(0xff), char(0xff), char(0xff) };
 
-		EXPECT_FALSE(isText(binary));
-	}
+    EXPECT_FALSE(isText(binary));
+}
 
-	TEST(UnitTest_Utils, isText_binary) {
-		auto const binary = std::string{ char(0x01), char(0x02), char(0x03) };
+TEST(UnitTest_Utils, isText_binary) {
+    auto const binary = std::string{ char(0x01), char(0x02), char(0x03) };
 
-		EXPECT_FALSE(isText(binary));
-	}
+    EXPECT_FALSE(isText(binary));
+}
 
-	TEST(UnitTest_Utils, isText_with_nl) {
-		EXPECT_TRUE(isText("first\nsecond"));
-	}
+TEST(UnitTest_Utils, isText_with_nl) {
+    EXPECT_TRUE(isText("first\nsecond"));
+}
 
-	TEST(UnitTest_Utils, isText_with_lf) {
-		EXPECT_TRUE(isText("first\rsecond"));
-	}
+TEST(UnitTest_Utils, isText_with_lf) {
+    EXPECT_TRUE(isText("first\rsecond"));
+}
 
-	TEST(UnitTest_Utils, isText_with_tab) {
-		EXPECT_TRUE(isText("first\tsecond"));
-	}
+TEST(UnitTest_Utils, isText_with_tab) {
+    EXPECT_TRUE(isText("first\tsecond"));
+}
 
-	TEST(UnitTest_Utils, isText_utf8_umla) {
-		auto const auml_utf8 = std::string{ char(0xC3), char(0xA4) };
-		EXPECT_TRUE(isText("German auml: " + auml_utf8));
-	}
+TEST(UnitTest_Utils, isText_utf8_umla) {
+    auto const auml_utf8 = std::string{ char(0xC3), char(0xA4) };
+    EXPECT_TRUE(isText("German auml: " + auml_utf8));
+}
 
-	TEST(UnitTest_Utils, isText_utf8_euro) {
-		auto const euro_utf8 = std::string{ char(0xE2), char(0x82), char(0xAC) };
-		EXPECT_TRUE(isText("euro sign: " + euro_utf8));
-	}
+TEST(UnitTest_Utils, isText_utf8_euro) {
+    auto const euro_utf8 = std::string{ char(0xE2), char(0x82), char(0xAC) };
+    EXPECT_TRUE(isText("euro sign: " + euro_utf8));
+}
 
-	TEST(UnitTest_Utils, isText_utf8_euro_wrong_follow_byte) {
-		auto const euro_utf8 = std::string{ char(0xE2), char(0x82), char(0xAC), char(0xAC), char(0xAC) };
-		EXPECT_FALSE(isText("euro sign: " + euro_utf8));
-	}
-	
-	TEST(UnitTest_Utils, isText_utf8_4_byte_f09284a0) {
-		auto const utf8 = std::string{ char(0xF0), char(0x92), char(0x84), char(0xA0) };
-		EXPECT_TRUE(isText(utf8));
-	}
+TEST(UnitTest_Utils, isText_utf8_euro_wrong_follow_byte) {
+    auto const euro_utf8 = std::string{ char(0xE2), char(0x82), char(0xAC), char(0xAC), char(0xAC) };
+    EXPECT_FALSE(isText("euro sign: " + euro_utf8));
+}
 
-	TEST(UnitTest_Utils, isText_utf8_4_byte_f0908d88) {
-		auto const utf8 = std::string{ char(0xF0), char(0x90), char(0x8D), char(0x88) };
-		EXPECT_TRUE(isText(utf8));
-	}
+TEST(UnitTest_Utils, isText_utf8_4_byte_f09284a0) {
+    auto const utf8 = std::string{ char(0xF0), char(0x92), char(0x84), char(0xA0) };
+    EXPECT_TRUE(isText(utf8));
+}
 
-	TEST(UnitTest_Utils, isText_text_utf8_4_byte) {
-		auto const utf8 = std::string{ char(0xF0), char(0x90), char(0x8D), char(0x88) };
-		EXPECT_TRUE(isText("4 byte utf-8: " + utf8));
-	}
+TEST(UnitTest_Utils, isText_utf8_4_byte_f0908d88) {
+    auto const utf8 = std::string{ char(0xF0), char(0x90), char(0x8D), char(0x88) };
+    EXPECT_TRUE(isText(utf8));
+}
 
-	TEST(UnitTest_Utils, isText_text_utf8_4_byte_text) {
-		auto const utf8 = std::string{ char(0xF0), char(0x90), char(0x8D), char(0x88) };
-		EXPECT_TRUE(isText("4 byte utf-8 " + utf8 + " inside ascii"));
-	}
+TEST(UnitTest_Utils, isText_text_utf8_4_byte) {
+    auto const utf8 = std::string{ char(0xF0), char(0x90), char(0x8D), char(0x88) };
+    EXPECT_TRUE(isText("4 byte utf-8: " + utf8));
+}
 
-	TEST(UnitTest_Utils, isText_utf8_euro_border_1) {
-		auto const euro_utf8 = std::string{ char(0xE2), char(0x82), char(0xAC) };
-		EXPECT_TRUE(isText("euro sign: " + euro_utf8, 12));
-	}
+TEST(UnitTest_Utils, isText_text_utf8_4_byte_text) {
+    auto const utf8 = std::string{ char(0xF0), char(0x90), char(0x8D), char(0x88) };
+    EXPECT_TRUE(isText("4 byte utf-8 " + utf8 + " inside ascii"));
+}
 
-	TEST(UnitTest_Utils, isText_utf8_euro_border_2) {
-		auto const euro_utf8 = std::string{ char(0xE2), char(0x82), char(0xAC) };
-		EXPECT_TRUE(isText("euro sign: " + euro_utf8, 13));
-	}
+TEST(UnitTest_Utils, isText_utf8_euro_border_1) {
+    auto const euro_utf8 = std::string{ char(0xE2), char(0x82), char(0xAC) };
+    EXPECT_TRUE(isText("euro sign: " + euro_utf8, 12));
+}
+
+TEST(UnitTest_Utils, isText_utf8_euro_border_2) {
+    auto const euro_utf8 = std::string{ char(0xE2), char(0x82), char(0xAC) };
+    EXPECT_TRUE(isText("euro sign: " + euro_utf8, 13));
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds files so that the Visual Studio TestExplorer  detects the google tests.

The anonymous namespaces will be removed. Now the TestExplorer shows the tests under <Empty Namespace>.  Else it is mixed with "anonymous namespace".

![image](https://github.com/performous/performous/assets/55762382/1fd7c58b-45b2-4bf3-8dfb-55f3a9eee54e)

### Closes Issue(s)

None

### Motivation

The TestExplorer makes it easy to run single tests and debug them.

### Testing

- Only developers on windows with visual studio. 
- TestExplorer must be installed and (included with vs 2022) Google Test Adapter must be installed.
- Open TestExplorer
- Compile whole project
- Tests should be displayed 