### PR TITLE
Add Ubuntu 24.04, Fedora 40, Remove Debian 10

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -92,8 +92,8 @@ jobs:
             version: 20.04
           - os: ubuntu
             version: 22.04
-          - os: debian
-            version: 10
+          - os: ubuntu
+            version: 24.04
           - os: debian
             version: 11
           - os: debian
@@ -108,6 +108,8 @@ jobs:
             version: 38
           - os: fedora
             version: 39
+          - os: fedora
+            version: 40
     steps:
       - name: Container name
         run: |


### PR DESCRIPTION
### What does this PR do?
Adds Ubuntu 24.04 and Fedora 40

Removes Debian 10, which is old and will be retired soon anyway. Currently the Debian 10 repos are having some kind of issue, which prevents dependencies being installed.

### Motivation

New OS's just released a few days ago. Time to retire old ones that are causing us problems.