### PR TITLE
Fix issues on MacOS with ffmpeg

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,7 +33,6 @@ jobs:
         cmake
         cpprestsdk
         dylibbundler
-        ffmpeg@4
         fftw
         fmt
         fontconfig
@@ -78,6 +77,12 @@ jobs:
         id: install_deps
         run: |
            brew install $MACOS_DEPS
+
+      - name: Install dependency FFMPEG from source
+        id: install_ffmpeg_deps
+        run: |
+           brew install ffmpeg@4 --build-from-source 
+
       - name: Setup Python
         id: setup_python
         uses: actions/setup-python@v5 
@@ -89,6 +94,7 @@ jobs:
       - name: Build package
         id: build_package
         run: |
+          export PKG_CONFIG_PATH="/opt/homebrew/opt/ffmpeg@4/lib/pkgconfig"
           cd performous/osx-utils
           chmod +x ./macos-bundler.py
           pip3 install -r ./macos-bundler-requirements.txt

--- a/game/scorewindow.cc
+++ b/game/scorewindow.cc
@@ -24,7 +24,7 @@ ScoreWindow::ScoreWindow(Game& game, Instruments& instruments, Database& databas
 	}
 
 	// Instruments
-	std::remove_if(instruments.begin(), instruments.end(),[](std::unique_ptr<InstrumentGraph> const& i){ return i->getScore() < 100; }); // Dead.
+	instruments.erase(std::remove_if(instruments.begin(), instruments.end(),[](std::unique_ptr<InstrumentGraph> const& i){ return i->getScore() < 100; }), instruments.end()); // Dead.
 	for (std::unique_ptr<InstrumentGraph> const& i: instruments) {
 		input::DevType const& type = i->getGraphType();
 		std::string const& track_simple = i->getTrack();


### PR DESCRIPTION
This PR fixes issues on MacOS with ffmpeg. 

Some time ago the homebrew package for ffmpeg@4 does not provide the av*-libs anymore for cmake projects. Building ffmpeg from source solves the problems.