### PR TITLE
Draft: Initial work to use Replay Gain values from libAv

### DIFF
--- a/game/audio.cc
+++ b/game/audio.cc
@@ -290,6 +290,14 @@ struct Sample {
 		if(!audioBuffer.read(mixbuf.data(), size, m_pos, 1.0)) {
 			eof = true;
 		}
+
+		// TODO: use ReplayGain to normalise audio volume
+		double replayGain = audioBuffer.replayGain();
+		if ( replayGain != 0.0 )
+		{
+			std::clog << "Sample() Replay Gain is [" << std::setprecision(3) << replayGain << "] dB" << std::endl;
+		}
+
 		const auto failVolume = static_cast<float>(config["audio/fail_volume"].ui()) / 100.0f;
 		for (size_t i = 0, iend = mixbuf.size(); i != iend; ++i) {
 			begin[i] += mixbuf[i] * failVolume;


### PR DESCRIPTION
_Draft_ RFC request only.

I'm trying to use the existing Replay Gain (Ref: https://en.wikipedia.org/wiki/ReplayGain ) functions in ffmpeg to normalise the audio volume in performous.

### What does this PR do?

Implements loading and logging of any Replay Gain meta information loaded from audio files.  Files might not have any Replay Gain information in them.  To add it, you can use a tool like `loudgain`.

### Closes Issue(s)

This PR does not close any issues.

### Motivation

When one has audio from different sources, more often than not, the base-level volume of the audio is different.  These differences are prevalent even in professionally mastered audio recordings simply due to their jurisdiction.  The long-term idea is to somewhat normalise the "loudness" of the audio track, such that continual _manual_ volume adjustments don't need to be made while enjoying performous.

I've raised this Draft PR as a discussion point, because I don't understand how the volume setting code works in performous.  I have implemented Replay Gain normalisation before, but I need some pointers on how performous handles track volumes so I can implement it in a design-sympathetic manner.
