### PR TITLE
fix: Gentoo ebuild and FindAubio.cmake

### DIFF
--- a/cmake/Modules/FindAubio.cmake
+++ b/cmake/Modules/FindAubio.cmake
@@ -3,6 +3,18 @@ include(LibFetchMacros)
 
 set(Aubio_GIT_VERSION "master")
 
+#set(BLA_VENDOR OpenBLAS)
+set(BLA_PKGCONFIG_BLAS openblas)
+find_package(BLAS REQUIRED)
+
+# also Accelerate.framework for mac
+
+if (NOT APPLE AND NOT BLAS_LIBRARIES MATCHES "openblas")
+	message(FATAL_ERROR "BLAS vendor is not OpenBLAS. Found: ${BLAS_LIBRARIES}")
+elseif (APPLE AND NOT BLAS_LIBRARIES MATCHES "Accelerate.framework")
+	message(FATAL_ERROR "BLAS vendor is not Accelerate.framework. Found: ${BLAS_LIBRARIES}")
+endif()
+
 if(SELF_BUILT_AUBIO STREQUAL "ALWAYS")
 	message(STATUS "aubio forced to build from source")
 	libfetch_git_pkg(Aubio
@@ -10,10 +22,13 @@ if(SELF_BUILT_AUBIO STREQUAL "ALWAYS")
 		REFERENCE  ${Aubio_GIT_VERSION}
 		#FIND_PATH  aubio/aubio.h
 	)
+
+	target_link_libraries(aubio PRIVATE ${BLAS_LIBRARIES})
 elseif(SELF_BUILT_AUBIO STREQUAL "NEVER")
 	find_package(PkgConfig REQUIRED)
 	pkg_check_modules(AUBIO REQUIRED QUIET IMPORTED_TARGET GLOBAL aubio>=${Aubio_FIND_VERSION})
 	add_library(aubio ALIAS PkgConfig::AUBIO)
+	target_link_libraries(PkgConfig::AUBIO INTERFACE ${BLAS_LIBRARIES})
 	set(Aubio_VERSION ${AUBIO_VERSION})
 	set(Aubio_INCLUDE_DIRS ${AUBIO_INCLUDE_DIRS})
 elseif(SELF_BUILT_AUBIO STREQUAL "AUTO")
@@ -26,8 +41,11 @@ elseif(SELF_BUILT_AUBIO STREQUAL "AUTO")
 			REFERENCE  ${Aubio_GIT_VERSION}
 			#FIND_PATH  aubio/aubio.h
 		)
+
+		target_link_libraries(aubio PRIVATE ${BLAS_LIBRARIES})
 	else()
 		add_library(aubio ALIAS PkgConfig::AUBIO)
+		target_link_libraries(PkgConfig::AUBIO INTERFACE ${BLAS_LIBRARIES})
 		set(Aubio_VERSION ${AUBIO_VERSION})
 		set(Aubio_INCLUDE_DIRS ${AUBIO_INCLUDE_DIRS})
 	endif()

--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -258,7 +258,6 @@ if(APPLE)
 	list(APPEND LIBS "-framework Accelerate -framework CoreFoundation")
 endif()
 list(APPEND LIBS ${FFTW3_LIBRARIES})
-list(APPEND LIBS ${BLAS_LIBRARIES})
 
 find_package(Threads)
 target_link_libraries(performous PRIVATE fs ced aubio ${LIBS} PkgConfig::deps Threads::Threads)


### PR DESCRIPTION
Aubio requires CBLAS (for example OpenCBLAS implementation) and not BLAS, this patch should fix the issue.