### PR TITLE
Add Fedora 41

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -110,6 +110,8 @@ jobs:
             version: 39
           - os: fedora
             version: 40
+          - os: fedora
+            version: 41
     steps:
       - name: Container name
         run: |


### PR DESCRIPTION
Add Fedora 41 which was released on Nov. 19th
