### PR TITLE
Pause menu: Move "Quit" back to being the last option.

### DIFF
--- a/game/screen_sing.cc
+++ b/game/screen_sing.cc
@@ -154,11 +154,11 @@ void ScreenSing::createPauseMenu() {
 	if(!getGame().getCurrentPlayList().isEmpty() || config["game/autoplay"].b()){
 		m_menu.add(MenuOption(_("Skip"), _("Skip current song"))).screen("Playlist");
 	}
-	m_menu.add(MenuOption(_("Quit"), _("Exit to song browser"))).call([&game]() {
-		game.activateScreen("Songs");
-	});
 	m_menu.add(MenuOption(_("Abort"), _("Exit to song browser and mark song broken"))).call([&]() {
 		m_song->setBroken();
+		game.activateScreen("Songs");
+	});
+	m_menu.add(MenuOption(_("Quit"), _("Exit to song browser"))).call([&game]() {
 		game.activateScreen("Songs");
 	});
 	m_menu.close();


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/performous/performous/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

Puts "Quit" back at the bottom of the in-game pause menu.


<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

<!-- List here all the issues closed by this pull request. -->

### Motivation

For years, the last option in the "Pause" menu was "Quit", this was changed earlier this year, in a way that I think makes the user more prone to error and causing songs to be accidentally marked as "broken" when trying to quit to the menu.

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated documentation

### Additional Notes

I think the whole "Abort" option should be revisited in the future. I see how it can be useful but maybe we should have some sort of confirmation dialog or similar, to prevent accidentally marking songs as broken.

<!-- Anything else we should know when reviewing? -->
