### PR TITLE
When a song directory is empty, don't bother scanning for songs.

### DIFF
--- a/game/songs.cc
+++ b/game/songs.cc
@@ -256,6 +256,11 @@ void Songs::CacheSonglist() {
 void Songs::reload_internal(fs::path const& parent, Cache cache) {
 	try {
 		std::regex expression(R"((\.txt|^song\.ini|^notes\.xml|\.sm)$)", std::regex_constants::icase);
+		if (fs::is_empty(parent))
+		{
+			std::clog << "songs/notice: Directory " << parent << " is empty. Skipping directory. " << '\n';
+			return;
+		}
 		auto iterator = fs::recursive_directory_iterator(parent, fs::directory_options::follow_directory_symlink);
 		auto maxDepth = iterator.depth() + 10;
 		for (const auto &dir : iterator) { //loop through files
@@ -265,7 +270,7 @@ void Songs::reload_internal(fs::path const& parent, Cache cache) {
 			}
 			if (iterator.depth() > maxDepth) {
 				std::clog << "songs/info: >>> Not scanning: " << parent.string() << " (maximum depth reached, possibly due to cyclic symlinks)\n";
-				continue; 
+				continue;
 			}
 			fs::path p = dir.path();
 			if (!regex_search(p.filename().string(), expression)) {


### PR DESCRIPTION
### What does this PR do?

Fixes a runtime error where performous would crash if you had a folder specified (in config.xml) which didn't contain songs.
It now skips the folder and mentions it in the log.
<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

<!-- List here all the issues closed by this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
