### PR TITLE
Add Fedora 42

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -114,6 +114,8 @@ jobs:
             version: 40
           - os: fedora
             version: 41
+          - os: fedora
+            version: 42
     steps:
       - name: Container name
         run: |


### PR DESCRIPTION
### What does this PR do?

Adds Fedora 42 packages

### Motivation

Fedora 42 became GA on April 15th.
