### PR TITLE
Fix a couple outstanding CI issues

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -88,7 +88,7 @@ jobs:
             brew tap performous/pinned_cmake3
 
       - name: Install dependencies with homebrew.
-        uses: gerlero/brew-install@v1
+        uses: Lord-Kamina/brew-install@main
         with:
           packages: ${{ env.MACOS_DEPS }}
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -30,7 +30,7 @@ jobs:
         aubio
         boost
         cairo
-        cmake
+        performous/pinned_cmake3/cmake@3.31.7
         cpprestsdk
         dylibbundler
         ffmpeg@7
@@ -72,42 +72,55 @@ jobs:
         id: update_brew
         run: |
           brew update
+
       # brew fetch runs downloads in parallel, which is faster
       # than letting install do it
-      - name: Fetch Dependencies
-        id: fetch_deps
+
+#      - name: Fetch Dependencies
+#        id: fetch_deps
+#        run: |
+#          brew fetch --deps $MACOS_DEPS
+
+      - name: Install cmake3
         run: |
-          brew fetch --deps $MACOS_DEPS
+            # uninstall version 4 of cmake
+            brew uninstall cmake
+            brew tap performous/pinned_cmake3
 
-      - name: Install Dependencies
-        id: install_deps
-        run: |
-           brew unlink python && brew link --overwrite python
-           brew install $MACOS_DEPS 2>&1
-           #brew unlink boost@1.87
-           #brew link --force boost@1.85
+      - name: Install dependencies with homebrew.
+        uses: gerlero/brew-install@v1
+        with:
+          packages: ${{ env.MACOS_DEPS }}
 
-           # uninstall version 4 of cmake
-           brew uninstall cmake
-
-           # we need to create a tap of the core formulae in order for this to work
-           # this will auto-enable developer mode (we'll turn it off later)
-           brew tap --force homebrew/core 
-
-           # create a new, local tap to work in
-           # by default, this creates a Git repos for the tap
-           # add --no-git if you don't want a repos to be created
-           brew tap-new --no-git performous/pinned_cmake
-
-            # copy the formula for cmake 3 to the local tap
-            brew extract cmake --version 3.31.6 performous/pinned_cmake
-
-            # install the formula (this will build locally)
-            brew install performous/pinned_cmake/cmake@3.31.6
-
-            # cleanup the stuff we don't need anymore
-            brew untap homebrew/core
-            brew developer off
+#      - name: Install Dependencies
+#        id: install_deps
+#        run: |
+#           brew unlink python && brew link --overwrite python
+#           brew install $MACOS_DEPS 2>&1
+#           #brew unlink boost@1.87
+#           #brew link --force boost@1.85
+#
+#           # uninstall version 4 of cmake
+#           brew uninstall cmake
+#
+#           # we need to create a tap of the core formulae in order for this to work
+#           # this will auto-enable developer mode (we'll turn it off later)
+#           brew tap --force homebrew/core 
+#
+#           # create a new, local tap to work in
+#           # by default, this creates a Git repos for the tap
+#           # add --no-git if you don't want a repos to be created
+#           brew tap-new --no-git performous/pinned_cmake
+#
+#            # copy the formula for cmake 3 to the local tap
+#            brew extract cmake --version 3.31.6 performous/pinned_cmake
+#
+#            # install the formula (this will build locally)
+#            brew install performous/pinned_cmake/cmake@3.31.6
+#
+#            # cleanup the stuff we don't need anymore
+#            brew untap homebrew/core
+#            brew developer off
 
       - name: Build package
         id: build_package

--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -11,10 +11,10 @@ ENV PACKAGE_TYPE="RPM"
 RUN <<EOR
 #!/bin/bash -x
 	dnf install -y \
-		https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm \
-		https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
+		https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm	
+#		https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
 	dnf install -y git cmake gcc-c++ gettext cairo-devel librsvg2-devel libsigc++20-devel \
-		glibmm24-devel libxml++-devel boost-devel SDL2-devel libepoxy-devel ffmpeg-devel \
+		glibmm24-devel libxml++-devel boost-devel SDL2-devel libepoxy-devel ffmpeg-free-devel \
 		portaudio-devel help2man redhat-lsb opencv-devel portmidi-devel libjpeg-turbo-devel \
 		pango-devel glm-devel openblas-devel fftw-devel cpprest-devel \
 		aubio-devel json-devel rpm-build fmt-devel gtest-devel gmock-devel gtest


### PR DESCRIPTION

### What does this PR do?

* On Fedora:

	* Changes `ffmpeg-devel` to `ffmpeg-free-devel`. Why?

		1) Licensing issues.
		2) I don’t think we actually even need libfdk_aac.
		3) Hopefully this gets rid of the constant CI failures due to that package being unavailable.

* On mac:
	* Hopefully set-up a homebrew with a cache, so macOS builds don't take an hour each.

<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

<!-- List here all the issues closed by this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
