### PR TITLE
Remove deprecated fmt function

### DIFF
--- a/cmake/Modules/FindSpdlog.cmake
+++ b/cmake/Modules/FindSpdlog.cmake
@@ -3,7 +3,16 @@ cmake_minimum_required(VERSION 3.24)
 include(LibFindMacros)
 include(LibFetchMacros)
 
-set(Spdlog_GIT_VERSION "v1.15.0")
+set(Spdlog_GIT_VERSION "v1.15.3")
+
+message(STATUS "FMT VERSION: ${fmt_VERSION}")
+
+if(fmt_VERSION VERSION_GREATER_EQUAL 11.1.0)
+	set(spdlog_needed "1.15.1")
+else()
+	set(spdlog_needed "1.12.0")
+	set(Spdlog_GIT_VERSION "v1.15.2")
+endif()
 
 if(SELF_BUILT_SPDLOG STREQUAL "ALWAYS")
 	message(STATUS "spdlog forced to build from source")
@@ -13,9 +22,9 @@ if(SELF_BUILT_SPDLOG STREQUAL "ALWAYS")
 		OVERRIDE_FIND_PACKAGE
 	)
 elseif(SELF_BUILT_SPDLOG STREQUAL "NEVER")
-	find_package(spdlog 1.12.0 REQUIRED PATHS /usr/lib PATH_SUFFIXES ${CMAKE_CXX_LIBRARY_ARCHITECTURE}/cmake/spdlog)
+	find_package(spdlog ${spdlog_needed} REQUIRED PATHS /usr/lib PATH_SUFFIXES ${CMAKE_CXX_LIBRARY_ARCHITECTURE}/cmake/spdlog)
 elseif(SELF_BUILT_SPDLOG STREQUAL "AUTO")
-	find_package(spdlog 1.12.0 PATHS /usr/lib PATH_SUFFIXES ${CMAKE_CXX_LIBRARY_ARCHITECTURE}/cmake/spdlog)
+	find_package(spdlog ${spdlog_needed} PATHS /usr/lib PATH_SUFFIXES ${CMAKE_CXX_LIBRARY_ARCHITECTURE}/cmake/spdlog)
 	if(NOT spdlog_FOUND)
 		message(STATUS "spdlog build from source because not found on system")
 		libfetch_git_pkg(Spdlog

--- a/game/log.cc
+++ b/game/log.cc
@@ -3,6 +3,7 @@
 #include "configuration.hh"
 #include "fs.hh"
 #include "profiler.hh"
+#include "util.hh"
 
 #include <boost/iostreams/device/file_descriptor.hpp>
 #include <boost/iostreams/stream.hpp>
@@ -156,11 +157,11 @@ LoggerPtr SpdLogger::constructLogger(const LogSystem system) {
 }
 
 void SpdLogger::initializeSinks(spdlog::level::level_enum const& consoleLevel) {
-	auto time = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+	auto const time = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch());
 	std::string logHeader(fmt::format(
 		"{0:*^80}\n"
 		"{1:*^80}\n",
-			fmt::format(" {} {} starting, {:%Y/%m/%d @ %H:%M:%S} ", PACKAGE, VERSION, fmt::localtime(time)),
+			fmt::format(" {} {} starting, {} ", PACKAGE, VERSION, timeFormat(time, "%Y/%m/%d @ %H:%M:%S")),
 			fmt::format(" Logging any events of level {}, or higher. ", spdlog::level::to_string_view(consoleLevel))));
 	spdlog::filename_t filename = getLogFilename().u8string();
 	spdlog::filename_t profilerLogFilename = getProfilerLogFilename().u8string();

--- a/game/screen_songs.cc
+++ b/game/screen_songs.cc
@@ -365,7 +365,7 @@ std::string ScreenSongs::getHighScoreText() const {
 	};
 	auto const timeFormatter = [datetimeFormat](std::string& string, auto const& unixtime) {
 		if(unixtime.count()) {
-			fmt::format_to(std::back_inserter(string), " \t{}", format(unixtime, datetimeFormat));
+			fmt::format_to(std::back_inserter(string), " \t{}", timeFormat(unixtime, datetimeFormat));
 		}
 	};
 	std::string ret;

--- a/game/songorder/file_time_song_order.cc
+++ b/game/songorder/file_time_song_order.cc
@@ -7,7 +7,7 @@ namespace {
 	std::chrono::seconds getFileWriteTime(Song const& song) {
 		auto const time = std::filesystem::last_write_time(song.path);
 		auto const seconds = std::chrono::duration_cast<std::chrono::seconds>(time.time_since_epoch());
-		SpdLogger::debug(LogSystem::SONGS, "Song file={}, time since last write={}", seconds.count());
+		SpdLogger::debug(LogSystem::SONGS, "Song file={}, time since last write={}", song.path, seconds.count());
 
 		return seconds;
 	}

--- a/game/util.cc
+++ b/game/util.cc
@@ -27,7 +27,7 @@ unsigned stou(std::string const& str, size_t* idx, int base) {
 	return uival;
 }
 
-std::string format(std::chrono::seconds const& unixtime, std::string const& format_spec, bool utc) {
+std::string timeFormat(std::chrono::seconds const& unixtime, std::string const& format_spec, bool utc) {
 	auto const tp = std::chrono::system_clock::time_point(unixtime);
 	std::string fmt_string{"{:" + format_spec + "}"};
 	if (utc) {

--- a/game/util.hh
+++ b/game/util.hh
@@ -52,7 +52,7 @@ struct UnlockGuard {
 };
 
 std::uint32_t stou(std::string const & str, size_t * idx = nullptr, int base = 10);
-std::string format(std::chrono::seconds const& unixtime, std::string const& format, bool utc = false);
+std::string timeFormat(std::chrono::seconds const& unixtime, std::string const& format, bool utc = false);
 std::string replaceFirst(std::string const& s, std::string const& from, std::string const& toB);
 
 bool isText(std::string const& s, size_t bytesToCheck = 32);

--- a/testing/utiltest.cc
+++ b/testing/utiltest.cc
@@ -30,18 +30,18 @@ TEST(UnitTest_Utils, smoothstep_3_clamping) {
     EXPECT_EQ(1.0, smoothstep(-1., 1., 2.0));
 }
 
-TEST(UnitTest_Utils, format) {
+TEST(UnitTest_Utils, timeFormat) {
     auto const time = std::chrono::seconds(7260);
 
 #ifndef __MINGW32__
     // next two tests are not working when compiled with mingw. see https://sourceforge.net/p/mingw-w64/bugs/793/
-    EXPECT_EQ("01/01/70 02:01", format(time, "%D %R", true));
-    EXPECT_EQ("02:01:00 1970-01-01", format(time, "%T %F", true));
+    EXPECT_EQ("01/01/70 02:01", timeFormat(time, "%D %R", true));
+    EXPECT_EQ("02:01:00 1970-01-01", timeFormat(time, "%T %F", true));
 #endif
 
-    EXPECT_EQ("01/01/70 02:01", format(time, "%m/%d/%y %H:%M", true));
-    EXPECT_EQ("02:01:00 1970-01-01", format(time, "%H:%M:%S %Y-%m-%d", true));
-    EXPECT_EQ("02:01:00 1970-01-01", format(time, "%X %Y-%m-%d", true));
+    EXPECT_EQ("01/01/70 02:01", timeFormat(time, "%m/%d/%y %H:%M", true));
+    EXPECT_EQ("02:01:00 1970-01-01", timeFormat(time, "%H:%M:%S %Y-%m-%d", true));
+    EXPECT_EQ("02:01:00 1970-01-01", timeFormat(time, "%X %Y-%m-%d", true));
 }
 
     TEST(UnitTest_Utils, toLower_empty) {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/performous/performous/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

SHOULD fix the CI.

Does three things.

1) Potentially change the minimum required spdlog version. Versions older than 1.15.1 are not compatible with libfmt11.1
So, let's account for that.

2) It fixes a small oversight on a debug message from the spdlog PR.

3) Replaces fmt::localtime (which was deprecated on fmt 11.2) for the variations of C's localtime instead. I don't like this but it's the only option until we decide to upgrade to c++20.

<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

<!-- List here all the issues closed by this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
