### PR TITLE
Fix issues around a segfault logging a blank locale std::filesystem

### DIFF
--- a/game/fs.cc
+++ b/game/fs.cc
@@ -13,6 +13,8 @@
 #include <sstream>
 #include <regex>
 
+#include <fmt/std.h> // needed to format std::filesystem::path
+
 #include <boost/range.hpp>
 
 #if (BOOST_OS_WINDOWS)
@@ -286,6 +288,8 @@ std::string formatPath(const fs::path& target) {
 	// Normalize the paths by resolving symlinks and removing redundant elements.
 	// But, if just a filename, keep it as is.
 	fs::path canonicalTarget = target.has_parent_path() ? fs::weakly_canonical(target) : target;
+
+    Lock l(mutex);
 	if (canonicalTarget == cache.base) {
 	// Return the absolute path if referring to the base directory.
 		return cache.base.string();


### PR DESCRIPTION
### What does this PR do?

On Debian 12, when running performous with `--log debug` the function `PathCache::pathInit()` causes a segfault because of the fmt::format() call involving a blank locale.  According to what I have read, it's mandatory to include `<fmt/std.h>` so fmt knows how to convert a `std::filesystem::path` to text.

### Closes Issue(s)

see above

### Motivation

fix bug


### More

This issue was 100% reproducible in both `gdb` and `valgrind`.  So I don't think it was some quirk of my setup.

### Additional Notes

- There's a bunch of other ways to fix this too.  Like using `locale.string()`, `locale.c_str()`, etc.
- It's possible this issue is possibly confined to Debian 12, but I have a late-model libfmt package installed - so maybe not.
```
$ apt show libfmt-dev 
Package: libfmt-dev
Version: 9.1.0+ds1-2
```

