### PR TITLE
Update Fedora 42 build dependencies

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -50,7 +50,7 @@ You need [http://rpmfusion.org/Configuration RPM Fusion Free] repository for ffm
 It's best to fetch and install this first, as the package-install below depends on it.
 
 ```bash
-yum install git cmake gcc-c++ gettext cairo-devel librsvg2-devel libsigc++20-devel \
+sudo yum install git cmake gcc-c++ gettext cairo-devel librsvg2-devel libsigc++20-devel \
    glibmm24-devel libxml++-devel boost-devel SDL2-devel libepoxy-devel ffmpeg-devel \
    portaudio-devel help2man redhat-lsb opencv-devel portmidi-devel libjpeg-turbo-devel \
    pango-devel jsoncpp-devel fmt-devel
@@ -59,7 +59,7 @@ yum install git cmake gcc-c++ gettext cairo-devel librsvg2-devel libsigc++20-dev
 If you also plan to run unit tests, further packages are required.  
 (This is **not** needed just to play Performous)
 ```bash
-yum install gtest-devel gmock-devel
+sudo yum install gtest-devel gmock-devel
 ```
 
 ### MacOS


### PR DESCRIPTION
### What does this PR do?

Updated build instructions for Fedora  42. 
Most importantly fixing the list of dependencies to include `libfmt`.

### Closes Issue(s)

n/a

### Motivation

A pipeline build failed on Fedora 42 with master.
So I built a Fedora 42 VM up from scratch, and tried to follow the build instructions.

I found the `fmt` library was needed, but not included in the dependency list.
I also wanted to build the unit tests, but no information was included on this.

So I worked out what was wrong, and updated the doco.

### More

n/a

### Additional Notes

n/a
