### PR TITLE
Detect changes to run_tests.sh and rebuild the containers when it changes

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -59,9 +59,9 @@ jobs:
             echo "build_docker_containers=false" >> $GITHUB_OUTPUT
           fi
 
-          DIFF_UBUNTU=$((git rev-parse HEAD:docker/Dockerfile.ubuntu HEAD:docker/build_performous.sh && git diff --merge-base ${base_version} --exit-code -- docker/Dockerfile.ubuntu docker/build_performous.sh) > /dev/null 2>&1 ; echo $?)
-          DIFF_DEBIAN=$((git rev-parse HEAD:docker/Dockerfile.debian HEAD:docker/build_performous.sh && git diff --merge-base ${base_version} --exit-code -- docker/Dockerfile.debian docker/build_performous.sh) > /dev/null 2>&1 ; echo $?)
-          DIFF_FEDORA=$((git rev-parse HEAD:docker/Dockerfile.fedora HEAD:docker/build_performous.sh && git diff --merge-base ${base_version} --exit-code -- docker/Dockerfile.fedora docker/build_performous.sh) > /dev/null 2>&1 ; echo $?)
+          DIFF_UBUNTU=$((git rev-parse HEAD:docker/Dockerfile.ubuntu HEAD:docker/build_performous.sh HEAD:docker/run_tests.sh && git diff --merge-base ${base_version} --exit-code -- docker/Dockerfile.ubuntu docker/build_performous.sh docker/run_tests.sh) > /dev/null 2>&1 ; echo $?)
+          DIFF_DEBIAN=$((git rev-parse HEAD:docker/Dockerfile.debian HEAD:docker/build_performous.sh HEAD:docker/run_tests.sh && git diff --merge-base ${base_version} --exit-code -- docker/Dockerfile.debian docker/build_performous.sh docker/run_tests.sh) > /dev/null 2>&1 ; echo $?)
+          DIFF_FEDORA=$((git rev-parse HEAD:docker/Dockerfile.fedora HEAD:docker/build_performous.sh HEAD:docker/run_tests.sh && git diff --merge-base ${base_version} --exit-code -- docker/Dockerfile.fedora docker/build_performous.sh docker/run_tests.sh) > /dev/null 2>&1 ; echo $?)
 
           if [[ $DIFF_UBUNTU != 0 ]]; then
             echo "Refresh Ubuntu containers: TRUE"


### PR DESCRIPTION
### What does this PR do?

This Pr makes the docker containers rebuild when changes are made to `run_tests.sh`.

This is a run in my fork of a file that is unrelated to the docker stuff, and it skips it properly: https://github.com/ooshlablu/performous/actions/runs/16130234982/job/45516083969#step:4:49

This run picks up the change to `run_tests.sh`: https://github.com/ooshlablu/performous/actions/runs/16130241064/job/45516345364#step:4:50

### Closes Issue(s)
No open issues in github, but @twollgam mentioned in discord that he was having issues getting his changes to the test script propagated to the builds.
