### PR TITLE
Need to unblock builds while we figure out the AppImage situation

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -112,6 +112,7 @@ jobs:
 
   # Pull in the AppImage build workflow
   AppImage_Package:
+    if: false
     name: Build the AppImage package
     uses: ./.github/workflows/appimage.yml
     with:


### PR DESCRIPTION
### What does this PR do?

This PR disables AppImaghes for now. There were a few upstream changes to some of the official AppImage tools that broke the project we were using to build AppImages: 
* https://github.com/AppImageCrafters/appimage-builder/pull/376
* https://github.com/AppImageCrafters/appimage-builder/issues/378

On top of that, the maintainer of the project stated that they were looking for new maintainers since they can't work on it anymore:
* https://github.com/AppImageCrafters/appimage-builder/issues/381

### Motivation
I had forked the project https://github.com/ooshlablu/appimage-builder and @Lord-Kamina and I were whacking against it hoping that there would be some easy fixes, but it looks the changes to bring it up to speed with the new official tools will require significant effort.

Unfortunately, I think the only path forward is to look into build the AppImage with the official tools, which will also be quite a bit of work. For now, I think the correct thing to do is to disable the AppImage builds so we can continue to get PRs merged while we deal with this problem appropriately.

### Additional Notes

@Baklap4 We'll need to disable the AppImage from the required checks if this is merged.
