### PR TITLE
Added windows manifest file.

### DIFF
--- a/win32/performous.cmake.rc
+++ b/win32/performous.cmake.rc
@@ -3,6 +3,7 @@
 LANGUAGE 9, 1
 
 1 ICON "@CMAKE_SOURCE_DIR@/win32/performous.ico"
+1 RT_MANIFEST "@CMAKE_SOURCE_DIR@/win32/performous.manifest"
 
 VS_VERSION_INFO VERSIONINFO
  FILEVERSION @VERSION_MAJOR@, @VERSION_MINOR@, @VERSION_PATCH@, @VERSION_TWEAK@
@@ -20,7 +21,7 @@ BEGIN
       VALUE "FileDescription",  "@CMAKE_PROJECT_NAME@ Game"
       VALUE "FileVersion", "@PROJECT_VERSION@"
       VALUE "InternalName", "Performous.exe"
-      VALUE "LegalCopyright", "Copyright © 2009-@YEAR@ @CMAKE_PROJECT_NAME@ Team - GNU GPL v2 or later"
+      VALUE "LegalCopyright", "Copyright ï¿½ 2009-@YEAR@ @CMAKE_PROJECT_NAME@ Team - GNU GPL v2 or later"
       VALUE "OriginalFilename", "Performous.exe"
       VALUE "ProductName", "@CMAKE_PROJECT_NAME@"
       VALUE "ProductVersion", "@PROJECT_VERSION@"

--- a/win32/performous.manifest
+++ b/win32/performous.manifest
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+    <application xmlns="urn:schemas-microsoft-com:asm.v3">
+        <windowsSettings>
+            <longPathAware>true</longPathAware>
+            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+        </windowsSettings>
+    </application>
+
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+            <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/> <!-- Win7 -->
+            <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/> <!-- Win8 -->
+            <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/> <!-- Win8.1 -->
+            <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/> <!-- Win10 -->
+            <supportedOS Id="{d6a1f02d-8b3a-4b2e-85b7-69b98c31f4a7}"/> <!-- Win11 -->
+        </application>
+    </compatibility>
+</assembly>


### PR DESCRIPTION
This allows for long path awareness opt-in and better support for HighDPI monitors. Also added in the supported OS'ses (basicly everything startin from Win XP, but XP and vista didn't have these guids in place.

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

<!-- List here all the issues closed by this pull request. -->

### Motivation

I encountered some long paths on Windows and got annoyed.
So added the manifest, to make performous opt in if you have the registry key set:
```
HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem\LongPathsEnabled = 1
```

Also added in better DPI support on windows as things can get blurry when using high dpi monitors. This ties in onto the already existing game/highdpi config and the sdl setup.

### More

- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
