### PR TITLE
fix boost_1.89

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -107,12 +107,6 @@ jobs:
           - os: debian
             version: 13
           - os: fedora
-            version: 36
-          - os: fedora
-            version: 37
-          - os: fedora
-            version: 38
-          - os: fedora
             version: 39
           - os: fedora
             version: 40

--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -85,14 +85,8 @@ set(SOURCES ${SOURCE_FILES} ${HEADER_FILES} ${RESOURCE_FILES})
 add_executable(performous ${SUBSYSTEM_WIN32} ${SOURCES})
 # Libraries
 
-find_package(Boost 1.55 CONFIG QUIET COMPONENTS program_options iostreams locale OPTIONAL_COMPONENTS system)
-if(NOT Boost_FOUND)
-  find_package(Boost 1.55 REQUIRED COMPONENTS program_options iostreams locale OPTIONAL_COMPONENTS system)
-endif()
-if(Boost_VERSION VERSION_LESS "1.69.0" AND NOT TARGET Boost::system)
-  message(FATAL_ERROR "Boost::system component is required but not found (Boost ${Boost_VERSION})")
-endif()
-target_link_libraries(performous PRIVATE Boost::boost Boost::program_options Boost::iostreams Boost::locale $<TARGET_NAME_IF_EXISTS:Boost::system>)
+find_package(Boost 1.70 CONFIG REQUIRED COMPONENTS program_options iostreams locale)
+target_link_libraries(performous PRIVATE Boost::boost Boost::program_options Boost::iostreams Boost::locale)
 
 find_package(ICU 65 REQUIRED uc data i18n io)
 target_link_libraries(performous PRIVATE ICU::uc ICU::data ICU::i18n ICU::io)
@@ -224,7 +218,7 @@ endif()
 if(cpprestsdk_FOUND OR CppRest_FOUND)
 	# add other required dependencies then
 	# FIXME: move this to the CppRest package includes if possible
-	find_package(Boost 1.55 REQUIRED COMPONENTS chrono thread)
+	find_package(Boost 1.70 CONFIG REQUIRED COMPONENTS chrono thread)
 	find_package(OpenSSL REQUIRED)
 	if(cpprestsdk_FOUND)
 		target_link_libraries(performous PRIVATE cpprestsdk::cpprest)

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -50,11 +50,8 @@ if(GTest_FOUND)
 	
 	add_executable(performous_test ${SOURCES})
 
-	find_package(Boost 1.55 REQUIRED COMPONENTS program_options iostreams locale OPTIONAL_COMPONENTS system)
-	if(Boost_VERSION VERSION_LESS "1.69.0" AND NOT TARGET Boost::system)
-		message(FATAL_ERROR "Boost::system component is required but not found (Boost ${Boost_VERSION})")
-	endif()
-	target_link_libraries(performous_test PRIVATE Boost::boost Boost::iostreams Boost::program_options Boost::locale $<TARGET_NAME_IF_EXISTS:Boost::system>)
+	find_package(Boost 1.70 CONFIG REQUIRED COMPONENTS program_options iostreams locale)
+	target_link_libraries(performous_test PRIVATE Boost::boost Boost::iostreams Boost::program_options Boost::locale)
 
 	find_package(fmt 8.1 REQUIRED CONFIG)
 	target_link_libraries(performous_test PRIVATE fmt::fmt)


### PR DESCRIPTION
### What does this PR do?

Fix build with boost-1.89.0
boost_system is header-only since 1.69 and the stub library is removed since boost-1.89
force CONFIG provided by >=boost-1.70

### Closes Issue(s)

Closes: #1104 