### PR TITLE
Allow adjustable track volume per-difficulty on failure

### DIFF
--- a/data/config/schema.xml
+++ b/data/config/schema.xml
@@ -57,6 +57,10 @@ to save the current settings to XML.
 		<short>Difficulty</short>
 		<long>Game difficulty.</long>
 	</entry>
+	<entry name="game/kids_keep_playing" type="bool" value="false">
+		<short>Kids Mode Keep Playing</short>
+		<long>When enabled, the track keeps playing when someone misses a note in Kids difficulty mode, but still plays the failure sound.</long>
+	</entry>
 
 	<entry name="game/Textstyle" type="uint" value="0">
 		<limits>

--- a/data/config/schema.xml
+++ b/data/config/schema.xml
@@ -57,10 +57,6 @@ to save the current settings to XML.
 		<short>Difficulty</short>
 		<long>Game difficulty.</long>
 	</entry>
-	<entry name="game/kids_keep_playing" type="bool" value="false">
-		<short>Kids Mode Keep Playing</short>
-		<long>When enabled, the track keeps playing when someone misses a note in Kids difficulty mode, but still plays the failure sound.</long>
-	</entry>
 
 	<entry name="game/Textstyle" type="uint" value="0">
 		<limits>
@@ -391,6 +387,36 @@ to save the current settings to XML.
 		<limits min="0" max="100" step="5" />
 		<short>Failure volume</short>
 		<long>The ingame fail sound volume. Values above 90 are not recommended as distortion may occur. 11 is louder than 10, but these go to 100. 89 louder!</long>
+	</entry>
+	<entry name="audio/miss_volume_kids" type="uint" value="0">
+		<ui unit=" %" />
+		<limits min="0" max="100" step="5" />
+		<short>Missed note volume (Kids)</short>
+		<long>Track volume level after missing a note on Kids difficulty for instruments.</long>
+	</entry>
+	<entry name="audio/miss_volume_easy" type="uint" value="0">
+		<ui unit=" %" />
+		<limits min="0" max="100" step="5" />
+		<short>Missed note volume (Easy)</short>
+		<long>Track volume level after missing a note on Easy difficulty for instruments.</long>
+	</entry>
+	<entry name="audio/miss_volume_medium" type="uint" value="0">
+		<ui unit=" %" />
+		<limits min="0" max="100" step="5" />
+		<short>Missed note volume (Medium)</short>
+		<long>Track volume level after missing a note on Medium difficulty for instruments.</long>
+	</entry>
+	<entry name="audio/miss_volume_hard" type="uint" value="0">
+		<ui unit=" %" />
+		<limits min="0" max="100" step="5" />
+		<short>Missed note volume (Hard)</short>
+		<long>Track volume level after missing a note on Hard difficulty for instruments.</long>
+	</entry>
+	<entry name="audio/miss_volume_expert" type="uint" value="0">
+		<ui unit=" %" />
+		<limits min="0" max="100" step="5" />
+		<short>Missed note volume (Expert)</short>
+		<long>Track volume level after missing a note on Expert difficulty for instruments.</long>
 	</entry>
 	<entry name="audio/pass-through" type="bool" value="false">
 		<short>Microphone pass-through</short>

--- a/game/guitargraph.cc
+++ b/game/guitargraph.cc
@@ -178,6 +178,30 @@ void GuitarGraph::setupJoinMenuDifficulty() {
 	m_menu.back().setDynamicName(m_difficultyOpt); // Set the title to be dynamic
 }
 
+double GuitarGraph::missVolumeTarget() const {
+	auto missVolumePercent = 0u;
+	switch (m_level) {
+		case Difficulty::KIDS:
+			missVolumePercent = config["audio/miss_volume_kids"].ui();
+			break;
+		case Difficulty::SUPAEASY:
+			missVolumePercent = config["audio/miss_volume_easy"].ui();
+			break;
+		case Difficulty::EASY:
+			missVolumePercent = config["audio/miss_volume_medium"].ui();
+			break;
+		case Difficulty::MEDIUM:
+			missVolumePercent = config["audio/miss_volume_hard"].ui();
+			break;
+		case Difficulty::AMAZING:
+			missVolumePercent = config["audio/miss_volume_expert"].ui();
+			break;
+		default:
+			break;
+	}
+	return clamp(static_cast<double>(missVolumePercent) / 100.0);
+}
+
 void GuitarGraph::setupJoinMenuDrums() {
 	setupJoinMenuDifficulty();
 	m_menu.add(MenuOption(_("Lefty-mode"), "")).changer(m_leftymode);
@@ -418,11 +442,7 @@ void GuitarGraph::engine() {
 	}
 	// Start decreasing correctness instantly if the current note is being played late (don't wait until maxTolerance)
 	if (m_chordIt != m_chords.end() && m_chordIt->begin < time && m_chordIt->status == 0) {
-		// In Kids mode with "keep playing" option enabled, don't fail correctness (mute the track)
-		bool kidsKeepPlaying = (m_level == Difficulty::KIDS) && config["game/kids_keep_playing"].b();
-		if (!kidsKeepPlaying) {
-			m_correctness.setTarget(0.0);
-		}
+		m_correctness.setTarget(missVolumeTarget());
 	}
 	// Process holds
 	if (!m_drums) {
@@ -507,13 +527,7 @@ void GuitarGraph::endHold(unsigned fret, double time) {
 			if (time > chord.begin + maxTolerance && time < chord.end - maxTolerance) {
 				chord.releaseTimes[fret] = time;
 				if (time >= chord.end - maxTolerance) chord.passed = true; // Mark as past note for rewinding
-				else {
-					// In Kids mode with "keep playing" option enabled, don't fail correctness (mute the track)
-					bool kidsKeepPlaying = (m_level == Difficulty::KIDS) && config["game/kids_keep_playing"].b();
-					if (!kidsKeepPlaying) {
-						m_correctness.setValue(0.0f);  // Note: if still holding some frets, proper percentage will be set in hold handling
-					}
-				}
+				else m_correctness.setValue(static_cast<float>(missVolumeTarget()));  // Note: if still holding some frets, proper percentage will be set in hold handling
 				break;
 			}
 		}
@@ -535,11 +549,7 @@ void GuitarGraph::fail(double time, int fret) {
 		// kids tend to play a lot of extra notes just for the fun of it.
 		// need to make sure they don't end up with a score of zero
 		m_score -= (m_level == Difficulty::KIDS) ? points(0)/2.0f : points(0);
-		// In Kids mode with "keep playing" option enabled, don't fail correctness (mute the track)
-		bool kidsKeepPlaying = (m_level == Difficulty::KIDS) && config["game/kids_keep_playing"].b();
-		if (!kidsKeepPlaying) {
-			m_correctness.setTarget(0.0, true);  // Instantly fail correctness
-		}
+		m_correctness.setTarget(missVolumeTarget(), true);
 	}
 	endStreak();
 }

--- a/game/guitargraph.hh
+++ b/game/guitargraph.hh
@@ -72,6 +72,7 @@ class GuitarGraph: public InstrumentGraph {
 	bool canActivateStarpower() { return (m_starmeter > 6000); }
 	void activateStarpower();
 	void errorMeter(double error);
+	double missVolumeTarget() const;
 	void fail(double time, int fret);
 	void endHold(unsigned fret, double time = 0.0);
 	void endBRE();


### PR DESCRIPTION
DISCLAIMER: I used Copilot to help me make these changes. They have been tested on Ubuntu 22.04 and 24.04, but that doesn't mean there weren't bugs introduced on other OS's or elsewhere.

### What does this PR do?
~~When "Kids" is selected as the difficulty for the instruments, the sound track for that particular instrument continues to play no matter what happens, but the fail sound still plays for off-timed strums and wrong frets, and any wrong conditions still don't add to the score.~~

Originally with this PR, I wanted to make the track play no matter what when a failure condition was met on `Kids` difficulty. I've now re-worked it to allow adjustment of the underlying track volume during a failure condition for each difficulty level.

### Closes Issue(s)

closes https://github.com/performous/performous/issues/889

### Motivation

Want to prevent discouragement while I try to build up some more testers :-)
