### PR TITLE
Fix a bug where 3-note-chords would not be counted in the combo

### DIFF
--- a/game/guitargraph.cc
+++ b/game/guitargraph.cc
@@ -403,7 +403,9 @@ void GuitarGraph::engine() {
 	// - Only after we are so much past them that they can no longer be played (maxTolerance)
 	// - For chords played or skipped by playing (i.e. play another chord that quickly follows), ++m_chordIt is done elsewhere
 	while (m_chordIt != m_chords.end() && m_chordIt->begin + maxTolerance < time) {
-		if (m_chordIt->status < m_chordIt->polyphony) endStreak();
+		// For guitar, status is 0/1/2 (not played/tapped/picked). For drums, status counts pads hit (0 to polyphony).
+		bool chordMissed = m_drums ? (m_chordIt->status < m_chordIt->polyphony) : (m_chordIt->status == 0);
+		if (chordMissed) endStreak();
 		// Calculate solo total score
 		if (m_solo) { m_soloScore += m_chordIt->score; m_soloTotal += static_cast<float>(m_chordIt->polyphony) * static_cast<float>(points(0));
 		// Solo just ended?


### PR DESCRIPTION
DISCLAIMER: I used Copilot to help me make these changes. They have been tested on Ubuntu 22.04 and 24.04, but that doesn't mean there weren't bugs introduced on other OS's or elsewhere.

### What does this PR do?
3 note chords on the guitar weren't being counted in the combo. Everything else appeared to work fine though: misses were being triggered correctly, the tracks were playing when they should, and the score would get points added, but the combo would fail every time. 

### Motivation
It was bothering the crap out of my brother. The combo is VERY important to him lol.
