### PR TITLE
Make point deductions configurable

### DIFF
--- a/data/config/schema.xml
+++ b/data/config/schema.xml
@@ -57,6 +57,10 @@ to save the current settings to XML.
 		<short>Difficulty</short>
 		<long>Game difficulty.</long>
 	</entry>
+	<entry name="game/instrument_miss_penalty" type="bool" value="true">
+		<short>Instrument miss penalty</short>
+		<long>Deduct points when missing notes on instrument and dance tracks.</long>
+	</entry>
 
 	<entry name="game/Textstyle" type="uint" value="0">
 		<limits>

--- a/game/dancegraph.cc
+++ b/game/dancegraph.cc
@@ -1,4 +1,5 @@
 #include "dancegraph.hh"
+#include "configuration.hh"
 #include "song.hh"
 #include "i18n.hh"
 #include "graphic/view_trans.hh"
@@ -313,7 +314,9 @@ void DanceGraph::engine() {
 		if(!it->isHit && it->note.type == Note::Type::MINE && m_pressed[static_cast<unsigned>(it->note.note)] &&
 		  it->note.begin >= time - maxTolerance && it->note.end <= time + maxTolerance) {
 			it->isHit = true;
-			m_score -= points(0);
+			if (config["game/instrument_miss_penalty"].b()) {
+				m_score -= points(0);
+			}
 		}
 	}
 
@@ -351,7 +354,9 @@ void DanceGraph::dance(double time, input::Event const& ev) {
 				m_streak++;
 				if (m_streak > m_longestStreak) m_longestStreak = m_streak;
 			} else { // Mine!
-				m_score -= points(0);
+				if (config["game/instrument_miss_penalty"].b()) {
+					m_score -= points(0);
+				}
 				m_streak = 0;
 			}
 			m_activeNotes[buttonId] = it;

--- a/game/guitargraph.cc
+++ b/game/guitargraph.cc
@@ -1,5 +1,6 @@
 #include "guitargraph.hh"
 
+#include "configuration.hh"
 #include "fs.hh"
 #include "log.hh"
 #include "song.hh"
@@ -522,7 +523,9 @@ void GuitarGraph::fail(double time, int fret) {
 		// remove equivalent of 1 perfect hit for every note
 		// kids tend to play a lot of extra notes just for the fun of it.
 		// need to make sure they don't end up with a score of zero
-		m_score -= (m_level == Difficulty::KIDS) ? points(0)/2.0f : points(0);
+		if (config["game/instrument_miss_penalty"].b()) {
+			m_score -= (m_level == Difficulty::KIDS) ? points(0)/2.0f : points(0);
+		}
 		m_correctness.setTarget(0.0, true);  // Instantly fail correctness
 	}
 	endStreak();

--- a/game/guitargraph.cc
+++ b/game/guitargraph.cc
@@ -1,5 +1,6 @@
 #include "guitargraph.hh"
 
+#include "configuration.hh"
 #include "fs.hh"
 #include "log.hh"
 #include "song.hh"
@@ -548,8 +549,10 @@ void GuitarGraph::fail(double time, int fret) {
 		// remove equivalent of 1 perfect hit for every note
 		// kids tend to play a lot of extra notes just for the fun of it.
 		// need to make sure they don't end up with a score of zero
-		m_score -= (m_level == Difficulty::KIDS) ? points(0)/2.0f : points(0);
-		m_correctness.setTarget(missVolumeTarget(), true);
+		if (config["game/instrument_miss_penalty"].b()) {
+			m_score -= (m_level == Difficulty::KIDS) ? points(0)/2.0f : points(0);
+		}
+		m_correctness.setTarget(missVolumeTarget(), true);  // Instantly fail correctness
 	}
 	endStreak();
 }


### PR DESCRIPTION
DISCLAIMER: I used Copilot to help me make these changes. They have been tested on Ubuntu 22.04 and 24.04, but that doesn't mean there weren't bugs introduced on other OS's or elsewhere.

### What does this PR do?

This creates a toggle for points deductions on instruments. The current behaviour doesn't match RB/GH, but instead of just removing it I figured I'd make it optional.


### Motivation

I was originally going to include this in https://github.com/performous/performous/pull/1108 to go with the original idea of making Kids difficulty a little more friendly, but that ended up changing completely. 
