### PR TITLE
Update "Fedora" section after comment from @TN-1. 

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -49,18 +49,34 @@ sudo emerge boost git cmake help2man glew libsdl2 ffmpeg portaudio libxmlpp \
 
 You need [http://rpmfusion.org/Configuration RPM Fusion Free] repository for ffmpeg.
 It's best to fetch and install this first, as the package-install below depends on it.
-
 ```bash
-sudo yum install git cmake gcc-c++ gettext cairo-devel librsvg2-devel libsigc++20-devel \
+sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm
+sudo dnf install https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
+```
+
+#### Fedora 42 and earlier
+```bash
+sudo dnf install git cmake gcc-c++ gettext cairo-devel librsvg2-devel libsigc++20-devel \
    glibmm24-devel libxml++-devel boost-devel SDL2-devel libepoxy-devel ffmpeg-devel \
    portaudio-devel help2man redhat-lsb opencv-devel portmidi-devel libjpeg-turbo-devel \
    pango-devel jsoncpp-devel fmt-devel libwebp-devel
 ```
 
+#### Fedora 43 and later
+```bash
+sudo dnf install git cmake gcc-c++ gettext cairo-devel librsvg2-devel libsigc++20-devel \
+glibmm24-devel libxml++-devel boost-devel SDL2-devel libepoxy-devel ffmpeg-devel \
+portaudio-devel help2man lsb-release opencv-devel portmidi-devel libjpeg-turbo-devel \
+pango-devel jsoncpp-devel glm-devel openblas-devel fftw-devel cpprest-devel \
+libwebp-devel fmt-devel
+```
+(You may need to include `--allowerasing` for this to complete successfully)
+
+#### Unit Tests
 If you also plan to run unit tests, further packages are required.  
 (This is **not** needed just to play Performous)
 ```bash
-sudo yum install gtest-devel gmock-devel
+sudo dnf install gtest-devel gmock-devel
 ```
 
 ### MacOS


### PR DESCRIPTION
@TN-1 suggested changes for building on Fedora43, I tested the suggestion, and updated the doco.

I also changed the use of the `yum` package manager to `dnf` as this has been the default Fedora package manager since early 2015.

### What does this PR do?

Updates the build doco for Fedora43

### Closes Issue(s)

#1114

### Motivation

Veni, vidi, _fixi_.


### More

No testing required.

### Additional Notes

Be Excellent to Each Other!
