### PR TITLE
allow case-insensitive RB-file openers

### DIFF
--- a/game/songparser-ini.cc
+++ b/game/songparser-ini.cc
@@ -24,14 +24,14 @@ void SongParser::iniParseHeader() {
 	if (!m_song.vocalTracks.empty()) { m_song.vocalTracks.clear(); }
 	if (!m_song.instrumentTracks.empty()) { m_song.instrumentTracks.clear(); }
 	std::string line;
-	
+
 	while (getline(line)) {
 		if (line.empty()) continue;
 		if (trim(line)[0] == '[') { // Section header.
-			if (line.find("[song]") != std::string::npos) continue;
+			if (UnicodeUtil::toLower(line).find("[song]") != std::string::npos) continue;
 			break; // Keys should be under the correct section.
 		}
-		if ((line[0] == ';' || line[0] == '#') && line[1] == ' ') continue; // Comment. 
+		if ((line[0] == ';' || line[0] == '#') && line[1] == ' ') continue; // Comment.
 		std::string key;
 		std::string value;
 		std::smatch match;
@@ -63,4 +63,3 @@ void SongParser::iniParseHeader() {
 	}
 	if (s.title.empty() || s.artist.empty()) throw std::runtime_error("Required header fields missing");
 }
-

--- a/game/songparser.hh
+++ b/game/songparser.hh
@@ -20,6 +20,9 @@ namespace SongParserUtil {
 	const auto regex_multiline = std::regex::multiline;
 #endif
 
+	const auto regex_icase = std::regex::icase;
+
+
 	// There is some weird bug with std::regex and boost::locale on libc++ that makes regex fail if a global locale with a collation facet has been installed before instantiating patterns.
 
 	const static std::regex iniParseLine(
@@ -36,7 +39,7 @@ namespace SongParserUtil {
 		R"(^[^\S^\r\n]*)"                                       // Any number of white-space characters that are neither \n nor \r
 		R"(\[song\])"                                           // literal matching of [song]
 		R"([^\S^\r\n]*)"                                        // Any number of white-space characters that are neither \n nor \r
-		R"((?:$|[;#]))", regex_multiline                        // Non-capturing group; match end-of-line or either ';' or '#', which denote a trailing comment.
+		R"((?:$|[;#]))", regex_multiline | regex_icase           // Non-capturing group; match end-of-line or either ';' or '#', which denote a trailing comment.
 	);
 
 	const static std::regex richTags(
@@ -45,11 +48,11 @@ namespace SongParserUtil {
 		R"((=[^>]*)?)"                                          // A group of: '=' followed by any characters that are not >, appearing just 0 or 1 times as a whole.
 		R"(( [^>]*)?>)"                                         // A group of: ' ' followed by any characters that are not >, appearing just 0 or 1 times as a whole, and finishing with >
 		R"(|<color(=[^>]*)?>)"                                  // OR a <color> tag with an equal sign followed by anything that isn't '>'
-		R"(|</color>)", std::regex_constants::icase             // OR the closing </color> tag. 
+		R"(|</color>)", regex_icase                             // OR the closing </color> tag.
 	);
 
 	const static std::regex brTag(
-		R"(<br>|<br[ ]*/?>)", std::regex_constants::icase       // match <br>, <br/> or <br />, allowing for any number of spaces between br and the /.
+		R"(<br>|<br[ ]*/?>)", regex_icase                       // match <br>, <br/> or <br />, allowing for any number of spaces between br and the /.
 	);
 
 	const std::string DUET_P2 = "Duet singer";	// FIXME


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/performous/performous/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

Makes the Rockband-style INI file parser a bit more lenient by making the opening `[song]` case-insensitive. I've seen `[Song]` and `[SONG]` for otherwise valid files.

### Closes Issue(s)

<!-- List here all the issues closed by this pull request. -->

### Motivation

fix some 100-odd files in my library


### More

- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
