### PR TITLE
Start building Ubuntu 26.04 and Fedora 44 + boost:system is header only in 1.69+

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -100,6 +100,8 @@ jobs:
             version: 22.04
           - os: ubuntu
             version: 24.04
+          - os: ubuntu
+            version: 26.04
           - os: debian
             version: 12
           - os: debian
@@ -120,6 +122,8 @@ jobs:
             version: 42
           - os: fedora
             version: 43
+          - os: fedora
+            version: 44
     steps:
       - name: Container name
         run: |

--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -85,11 +85,14 @@ set(SOURCES ${SOURCE_FILES} ${HEADER_FILES} ${RESOURCE_FILES})
 add_executable(performous ${SUBSYSTEM_WIN32} ${SOURCES})
 # Libraries
 
-find_package(Boost 1.55 CONFIG QUIET COMPONENTS program_options iostreams system locale)
+find_package(Boost 1.55 CONFIG QUIET COMPONENTS program_options iostreams locale OPTIONAL_COMPONENTS system)
 if(NOT Boost_FOUND)
-  find_package(Boost 1.55 REQUIRED COMPONENTS program_options iostreams system locale)
+  find_package(Boost 1.55 REQUIRED COMPONENTS program_options iostreams locale OPTIONAL_COMPONENTS system)
 endif()
-target_link_libraries(performous PRIVATE Boost::boost Boost::program_options Boost::iostreams Boost::system Boost::locale)
+if(Boost_VERSION VERSION_LESS "1.69.0" AND NOT TARGET Boost::system)
+  message(FATAL_ERROR "Boost::system component is required but not found (Boost ${Boost_VERSION})")
+endif()
+target_link_libraries(performous PRIVATE Boost::boost Boost::program_options Boost::iostreams Boost::locale $<TARGET_NAME_IF_EXISTS:Boost::system>)
 
 find_package(ICU 65 REQUIRED uc data i18n io)
 target_link_libraries(performous PRIVATE ICU::uc ICU::data ICU::i18n ICU::io)

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -50,8 +50,11 @@ if(GTest_FOUND)
 	
 	add_executable(performous_test ${SOURCES})
 
-	find_package(Boost 1.55 REQUIRED COMPONENTS program_options iostreams system locale)
-	target_link_libraries(performous_test PRIVATE Boost::boost Boost::iostreams Boost::program_options Boost::system Boost::locale)
+	find_package(Boost 1.55 REQUIRED COMPONENTS program_options iostreams locale OPTIONAL_COMPONENTS system)
+	if(Boost_VERSION VERSION_LESS "1.69.0" AND NOT TARGET Boost::system)
+		message(FATAL_ERROR "Boost::system component is required but not found (Boost ${Boost_VERSION})")
+	endif()
+	target_link_libraries(performous_test PRIVATE Boost::boost Boost::iostreams Boost::program_options Boost::locale $<TARGET_NAME_IF_EXISTS:Boost::system>)
 
 	find_package(fmt 8.1 REQUIRED CONFIG)
 	target_link_libraries(performous_test PRIVATE fmt::fmt)


### PR DESCRIPTION
### What does this PR do?

Add packages for Ubuntu 26.04 and Fedora 44. This required some cmake changes also because `boost::system` is only available as a header in boost 1.69+

### Motivation

They were released so they should be built :-)
