### PR TITLE
add missing header

### DIFF
--- a/game/fs.hh
+++ b/game/fs.hh
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <filesystem>
+#include <fstream>
 #include <list>
 #include <mutex>
 #include <string_view>


### PR DESCRIPTION
### What does this PR do?

Include fstream for std::ifstream / std::ofstream

### Motivation

It fixes compilation w/ gcc-17 that cleaned up transitive header