### PR TITLE
Remember player high-score settings

### DIFF
--- a/game/database.cc
+++ b/game/database.cc
@@ -68,16 +68,17 @@ void Database::addHiscore(std::shared_ptr<Song> s) {
 		return;
 	}
 	auto playerid = maybe_playerid.value();
-	unsigned score = scores.front().score;
-	std::string track = scores.front().track;
+	ScoreItem const& hiscore = scores.front();
 	const auto songid = m_songs.lookup(s);
 	if(!songid.has_value()) {
 		SpdLogger::error(LogSystem::DATABASE, "Invalid song ID for song: artist={}, title={}", s->artist, s->title);
 		return;
 	}
 	unsigned short level = config["game/difficulty"].ui();
-	m_hiscores.addHiscore(score, playerid, songid.value(), level, track);
-	SpdLogger::info(LogSystem::DATABASE, "Added new hiscore. Score={} on track={} for song id={}, on level={}", score, track, songid.value(), level);
+	m_hiscores.addHiscore(hiscore.score, playerid, songid.value(), level, hiscore.track);
+	// Remember which player was selected for this score's source device, so it can be pre-selected next time.
+	if (!hiscore.player_id.empty()) playersByDevices[hiscore.player_id] = playerid;
+	SpdLogger::info(LogSystem::DATABASE, "Added new hiscore. Score={} on track={} for song id={}, on level={}", hiscore.score, hiscore.track, songid.value(), level);
 }
 
 bool Database::reachedHiscore(std::shared_ptr<Song> s) const {
@@ -142,4 +143,3 @@ std::vector<HiscoreItem> Database::getHiscores(SongPtr const& s) const {
 		throw;
 	}
 }
-

--- a/game/database.cc
+++ b/game/database.cc
@@ -81,6 +81,15 @@ void Database::addHiscore(std::shared_ptr<Song> s) {
 	SpdLogger::info(LogSystem::DATABASE, "Added new hiscore. Score={} on track={} for song id={}, on level={}", hiscore.score, hiscore.track, songid.value(), level);
 }
 
+std::optional<PlayerId> Database::rememberedPlayerForDevice(std::string const& deviceId) const {
+	if (deviceId.empty()) return std::nullopt;
+
+	auto const it = playersByDevices.find(deviceId);
+	if (it == playersByDevices.end()) return std::nullopt;
+
+	return it->second;
+}
+
 bool Database::reachedHiscore(std::shared_ptr<Song> s) const {
 	unsigned score = scores.front().score;
 	const auto track = scores.front().track;

--- a/game/database.cc
+++ b/game/database.cc
@@ -62,9 +62,16 @@ void Database::addSong(std::shared_ptr<Song> s) {
 }
 
 void Database::addHiscore(std::shared_ptr<Song> s) {
-	auto maybe_playerid = m_players.lookup(m_players.current().name);
+	std::string const& currentName = m_players.current().name;
+	if (currentName.empty()) {
+		// No player is actually selected (e.g. Start pressed before a name was typed/chosen).
+		// Players::addPlayer() refuses empty names, so discard the pending score
+		SpdLogger::error(LogSystem::DATABASE, "No player selected (empty name) -- discarding pending score, hiscore NOT written.");
+		return;
+	}
+	auto maybe_playerid = m_players.lookup(currentName);
 	if (!maybe_playerid.has_value()) {
-		SpdLogger::error(LogSystem::DATABASE, "Cannot find player id for player={}", m_players.current().name);
+		SpdLogger::error(LogSystem::DATABASE, "Cannot find player id for player={}", currentName);
 		return;
 	}
 	auto playerid = maybe_playerid.value();

--- a/game/database.hh
+++ b/game/database.hh
@@ -66,6 +66,8 @@ private: // will be bypassed by above friend declaration
 	//This fields are misused as additional parameters
 	cur_players_t cur;
 	cur_scores_t scores;
+
+	/// Remembers which player was last selected for a given score source device, see rememberedPlayerForDevice().
 	players_devices_t playersByDevices;
 public: // methods for database management
 
@@ -78,6 +80,11 @@ public: // methods for database management
 	 The ids will be looked up first by using the songs and current players data.
 	 */
 	void addHiscore(std::shared_ptr<Song> s);
+
+	/**Looks up which player was last selected for the given score source device (e.g. a microphone id),
+	  so that a returning player can be pre-selected instead of searched for by name each time.
+	 */
+	std::optional<PlayerId> rememberedPlayerForDevice(std::string const& deviceId) const;
 
 public: // methods for database queries
 	/**A facade for Hiscore::reachedHiscore.

--- a/game/database.hh
+++ b/game/database.hh
@@ -61,11 +61,12 @@ public:
 private: // will be bypassed by above friend declaration
 	typedef std::list<Player> cur_players_t;
 	typedef std::list<ScoreItem> cur_scores_t;
+	typedef std::map <std::string, PlayerId> players_devices_t;
 
 	//This fields are misused as additional parameters
 	cur_players_t cur;
 	cur_scores_t scores;
-
+	players_devices_t playersByDevices;
 public: // methods for database management
 
 	/**A facade for Players::addPlayer.*/

--- a/game/player.cc
+++ b/game/player.cc
@@ -21,6 +21,10 @@ void Player::prepare() {
 	m_analyzer.process();
 }
 
+std::string const& Player::getId() const {
+	return m_analyzer.getId();
+}
+
 void Player::update() {
 	if (m_pos == m_pitch.size()) return; // End of song already
 	double beginTime = Engine::TIMESTEP * static_cast<double>(m_pos);

--- a/game/player.hh
+++ b/game/player.hh
@@ -12,7 +12,6 @@
 class Song;
 class Analyzer;
 
-/// TODO: rename to Vocalist or something like that
 struct Player {
 	/// currently played vocal track
 	VocalTrack& m_vocal;

--- a/game/player.hh
+++ b/game/player.hh
@@ -12,7 +12,7 @@
 class Song;
 class Analyzer;
 
-/// player class
+/// TODO: rename to Vocalist or something like that
 struct Player {
 	/// currently played vocal track
 	VocalTrack& m_vocal;
@@ -44,6 +44,9 @@ struct Player {
 	Notes::const_iterator m_scoreIt;
 	/// constructor
 	Player(VocalTrack& vocal, Analyzer& analyzer, size_t frames);
+
+	std::string const& getId() const { return m_analyzer.getId(); }
+
 	/// prepares analyzer
 	void prepare();
 	/// updates player stats

--- a/game/player.hh
+++ b/game/player.hh
@@ -44,7 +44,7 @@ struct Player {
 	/// constructor
 	Player(VocalTrack& vocal, Analyzer& analyzer, size_t frames);
 
-	std::string const& getId() const { return m_analyzer.getId(); }
+	std::string const& getId() const;
 
 	/// prepares analyzer
 	void prepare();

--- a/game/players.cc
+++ b/game/players.cc
@@ -25,7 +25,23 @@ void Players::load(xmlpp::NodeSet const& n) {
 			auto tn = xmlpp::get_first_child_text(dynamic_cast<xmlpp::Element&>(**n2.begin()));
 			picture = tn->get_content();
 		}
-		addPlayer(a_name->get_value(), picture, id);
+
+		std::string name = a_name->get_value();
+		if (name.empty()) {
+			// assign_id_internal() used to treat a valid player id of 0 as "no players exist"
+			// (id 0 is falsy), so once a database gets its first player, every
+			// subsequently-typed name silently collided, failed to insert, and any hiscore
+			// entered right after got misattributed to a coincidentally-blank current-player
+			// selection landing on that id-0 entry instead. Existing installs may have
+			// one of these players with existing hiscores attached to it - don't drop
+			// the entry (that would orphan those scores), just give it a visible name so it's
+			// no longer a dead, unselectable, invisible list entry.
+			name = "Player " + std::to_string(id.value_or(assign_id_internal()));
+			SpdLogger::notice(LogSystem::DATABASE,
+				"Player with empty name (id={}) found while loading the database; this is a known artifact of a fixed bug. Renaming to '{}'.",
+				id.value_or(0), name);
+		}
+		addPlayer(name, picture, id);
 	}
 	filter_internal();
 }
@@ -56,13 +72,20 @@ std::optional<PlayerId> Players::lookup(std::string const& name) const {
 
 std::optional<std::string> Players::lookup(const PlayerId& id) const {
 	const auto it = m_players.find(PlayerItem(id));
-	if (it == m_players.end()) 
+	if (it == m_players.end())
 		return std::nullopt;
 
 	return it->name;
 }
 
 void Players::addPlayer (std::string const& name, std::string const& picture, std::optional<PlayerId> id) {
+	if (name.empty()) {
+		// Refuse blank names outright: a Player with an empty name is indistinguishable
+		// from "nothing selected" (see Players::current()/Database::addHiscore)
+		SpdLogger::error(LogSystem::DATABASE, "Refusing to add a player with an empty name (id={}).", id.value_or(0));
+		return;
+	}
+
 	PlayerItem pi;
 	pi.name = name;
 	pi.picture = picture;
@@ -84,7 +107,11 @@ void Players::addPlayer (std::string const& name, std::string const& picture, st
 	if (!ret.second)
 	{
 		pi.id = assign_id_internal();
-		m_players.insert(pi); // now do the insert with the fresh id
+		const auto ret2 = m_players.insert(pi); // now do the insert with the fresh id
+		if (!ret2.second) {
+			SpdLogger::error(LogSystem::DATABASE, "Player '{}' could not be added - id assignment collided twice (id={}, already owned by '{}'). "
+				"Player was not added, will not be filtered, saved, or scoreable.", pi.name, pi.id, ret2.first->name);
+		}
 	}
 }
 
@@ -96,10 +123,10 @@ void Players::setFilter(std::string const& val) {
 
 PlayerId Players::assign_id_internal() {
 	const auto it = std::max_element(m_players.begin(),m_players.end());
-	
-	if (it != m_players.end() && it->id) 
+
+	if (it != m_players.end())
 		return it->id + 1;
-	
+
 	return 0;
 }
 
@@ -172,6 +199,6 @@ void Players::advanceToId(PlayerId id) {
 
 PlayerItem Players::current() const {
 	if (math_cover.getTarget() < static_cast<ptrdiff_t>(m_filtered.size())) return m_filtered[static_cast<unsigned>(math_cover.getTarget())];
-	
+
 	return PlayerItem();
 }

--- a/game/players.cc
+++ b/game/players.cc
@@ -165,6 +165,15 @@ void Players::advance(std::ptrdiff_t diff) {
 	math_cover.setTarget(current, count());
 }
 
+void Players::advanceToId(PlayerId id) {
+	for (std::size_t i = 0; i < m_filtered.size(); ++i) {
+		if (m_filtered[i].id == id) {
+			math_cover.setTarget(static_cast<std::ptrdiff_t>(i), count());
+			return;
+		}
+	}
+}
+
 PlayerItem Players::current() const {
 	if (math_cover.getTarget() < static_cast<ptrdiff_t>(m_filtered.size())) return m_filtered[static_cast<unsigned>(math_cover.getTarget())];
 	

--- a/game/players.cc
+++ b/game/players.cc
@@ -166,12 +166,8 @@ void Players::advance(std::ptrdiff_t diff) {
 }
 
 void Players::advanceToId(PlayerId id) {
-	for (std::size_t i = 0; i < m_filtered.size(); ++i) {
-		if (m_filtered[i].id == id) {
-			math_cover.setTarget(static_cast<std::ptrdiff_t>(i), count());
-			return;
-		}
-	}
+	auto const it = std::find_if(m_filtered.begin(), m_filtered.end(), [id](PlayerItem const& p) { return p.id == id; });
+	if (it != m_filtered.end()) math_cover.setTarget(it - m_filtered.begin(), count());
 }
 
 PlayerItem Players::current() const {

--- a/game/players.hh
+++ b/game/players.hh
@@ -66,6 +66,8 @@ class Players {
 	bool isEmpty() const { return m_filtered.empty(); }
 	/// advances to next player
 	void advance(std::ptrdiff_t diff);
+	/// Advances to the player with the given id. Does nothing if the id is not present in the filtered list.
+	void advanceToId(PlayerId id);
 	/// get current id
 	std::optional<PlayerId> currentId() const { return static_cast<unsigned>(math_cover.getTarget()); }
 	/// gets current position
@@ -78,7 +80,7 @@ class Players {
 	PlayerItem current() const;
 	/// filters playerlist by regular expression
 	void setFilter(std::string const& regex);
-  
+
 private:
 	PlayerId assign_id_internal(); /// returns the next available id
 	void filter_internal();

--- a/game/scoreitem.hh
+++ b/game/scoreitem.hh
@@ -8,6 +8,7 @@ struct ScoreItem {
 	input::DevType type;
 	std::string track;  ///< includes difficulty
 	std::string track_simple; ///< no difficulty
+	std::string player_id; ///< identifies the score's source device (microphone name or similar), used to remember player selections
 	Color color;
 
 	ScoreItem() = default;

--- a/game/scorewindow.cc
+++ b/game/scorewindow.cc
@@ -20,7 +20,8 @@ ScoreWindow::ScoreWindow(Game& game, Instruments& instruments, Database& databas
 	// Singers
 	m_database.cur.remove_if([](Player const& p){ return p.getScore() < 500; }); // Dead.
 	for (Player const& p: m_database.cur) {
-		m_database.scores.emplace_back(p.getScore(), input::DevType::VOCALS, "Vocals", "vocals", Color(p.m_color.r, p.m_color.g, p.m_color.b));
+		ScoreItem& item = m_database.scores.emplace_back(p.getScore(), input::DevType::VOCALS, "Vocals", "vocals", Color(p.m_color.r, p.m_color.g, p.m_color.b));
+		item.player_id = p.getId();
 	}
 
 	// Instruments
@@ -36,7 +37,8 @@ ScoreWindow::ScoreWindow(Game& game, Instruments& instruments, Database& databas
 		else if (track_simple == TrackName::BASS)
 			color = Color(0.5f, 0.3f, 0.1f);
 
-		m_database.scores.emplace_back(i->getScore(), type, track, track_simple, color);
+		ScoreItem& item = m_database.scores.emplace_back(i->getScore(), type, track, track_simple, color);
+		item.player_id = track_simple; // probably not totally unique, but at least lets us discern some players by their favorite instrument
 	}
 
 	if (m_database.scores.empty())

--- a/game/screen_players.cc
+++ b/game/screen_players.cc
@@ -35,9 +35,8 @@ void ScreenPlayers::enter() {
 	m_players.setFilter(m_search.text);
 	m_audio.fadeout(getGame());
 	m_quitTimer.setValue(config["game/highscore_timeout"].ui());
-	if (m_database.scores.empty() || !m_database.reachedHiscore(m_song)) {
-		getGame().activateScreen("Playlist");
-	}
+
+	checkoutNewScore();
 }
 
 void ScreenPlayers::exit() {
@@ -67,18 +66,11 @@ void ScreenPlayers::manageEvent(input::NavEvent const& event) {
 			m_players.update();
 			// the current player is the new created one
 		}
+
 		m_database.addHiscore(m_song);
 		m_database.scores.pop_front();
 
-		if (m_database.scores.empty() || !m_database.reachedHiscore(m_song)) {
-			// no more highscore, we are now finished
-			getGame().activateScreen("Playlist");
-		} else {
-			m_search.text.clear();
-			m_players.setFilter("");
-			// add all players which reach highscore because if score is very near or same it might be
-			// frustrating for second one that he cannot enter, so better go for next one...
-		}
+		checkoutNewScore();
 	}
 	else if (m_players.isEmpty()) return;
 	else if (nav == input::NavButton::PAUSE) m_audio.togglePause();
@@ -101,6 +93,28 @@ void ScreenPlayers::manageEvent(SDL_Event event) {
 		if (key == SDL_SCANCODE_BACKSPACE) {
 			m_search.backspace();
 			m_players.setFilter(m_search.text);
+		}
+	}
+}
+
+void ScreenPlayers::checkoutNewScore() {
+	if (m_database.scores.empty() || !m_database.reachedHiscore(m_song)) {
+		// no more highscore, we are now finished
+		getGame().activateScreen("Playlist");
+	}
+	else {
+		m_search.text.clear();
+		m_players.setFilter("");
+		// add all players which reach highscore because if score is very near or same it might be
+		// frustrating for second one that he cannot enter, so better go for next one...
+
+		// Pre-select the player that was previously used with this score's source device, if known.
+		std::string const& deviceId = m_database.scores.front().player_id;
+		if (!deviceId.empty()) {
+			auto knownPlayerIt = m_database.playersByDevices.find(deviceId);
+			if (knownPlayerIt != m_database.playersByDevices.end()) {
+				m_players.advanceToId(knownPlayerIt->second);
+			}
 		}
 	}
 }

--- a/game/screen_players.cc
+++ b/game/screen_players.cc
@@ -109,13 +109,8 @@ void ScreenPlayers::checkoutNewScore() {
 		// frustrating for second one that he cannot enter, so better go for next one...
 
 		// Pre-select the player that was previously used with this score's source device, if known.
-		std::string const& deviceId = m_database.scores.front().player_id;
-		if (!deviceId.empty()) {
-			auto knownPlayerIt = m_database.playersByDevices.find(deviceId);
-			if (knownPlayerIt != m_database.playersByDevices.end()) {
-				m_players.advanceToId(knownPlayerIt->second);
-			}
-		}
+		auto const rememberedPlayer = m_database.rememberedPlayerForDevice(m_database.scores.front().player_id);
+		if (rememberedPlayer) m_players.advanceToId(*rememberedPlayer);
 	}
 }
 

--- a/game/screen_players.hh
+++ b/game/screen_players.hh
@@ -36,6 +36,8 @@ class ScreenPlayers : public Screen {
 
   private:
 	Texture* loadTextureFromMap(fs::path path);
+	void checkoutNewScore();
+
   	Audio& m_audio;
 	Database& m_database;
 	Players& m_players;

--- a/game/unicode.cc
+++ b/game/unicode.cc
@@ -1,7 +1,7 @@
 #include "unicode.hh"
 
 #include "configuration.hh"
-#include "game.hh"
+#include "i18n.hh"
 #include "log.hh"
 
 #include <regex>


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/performous/performous/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

This cleans up and updates https://github.com/performous/performous/pull/538 which was a great idea, just never fully merged. Devices should remember the last-used player on the high-score screen.

Along the way I found that user creation and scrolling was actually broken for new players, and perhaps all players. Bad null check.

### Closes Issue(s)

https://github.com/performous/performous/issues/61
PR https://github.com/performous/performous/pull/538

### Motivation

Fix the bug that was preventing high scores from being entered for new players
Make high-scores a bit easier to deal with
